### PR TITLE
Fixed bug:  changed to correct model name

### DIFF
--- a/tutorials/synthetic-preference-data/synthetic_preference_data_generation_llama_3_1_405b.ipynb
+++ b/tutorials/synthetic-preference-data/synthetic_preference_data_generation_llama_3_1_405b.ipynb
@@ -213,7 +213,7 @@
     "async def generate_subtopics(client, topic, n_subtopics):\n",
     "    prompt = TOPIC_GENERATION_PROMPT_TEMPLATE.format(topic=topic, n_subtopics=n_subtopics)\n",
     "    response = await client.chat.completions.create(\n",
-    "        model=\"meta/llama3.1-405b-instruct\",\n",
+    "        model=\"meta/llama-3.1-405b-instruct\",\n",
     "        messages=[\n",
     "            {\"role\" : \"user\",\n",
     "             \"content\" : prompt}\n",
@@ -321,7 +321,7 @@
     "async def generate_questions(client, sub_topic, n_questions):\n",
     "    prompt = QUESTION_PROMPT_TEMPLATE.format(sub_topic=sub_topic, n_questions=n_questions)\n",
     "    response = await client.chat.completions.create(\n",
-    "        model=\"stg/meta/llama3.1-405b-instruct\",\n",
+    "        model=\"meta/llama-3.1-405b-instruct\",\n",
     "        messages=[\n",
     "            {\"role\" : \"user\",\n",
     "             \"content\" : prompt}\n",
@@ -469,7 +469,7 @@
     "async def generate_responses(client, question):\n",
     "    prompt = RESPONSE_PROMPT_TEMPLATE.format(question=question)\n",
     "    response = await client.chat.completions.create(\n",
-    "        model=\"stg/meta/llama3.1-405b-instruct\",\n",
+    "        model=\"meta/llama-3.1-405b-instruct\",\n",
     "        messages=[\n",
     "            {\"role\" : \"user\",\n",
     "             \"content\" : prompt}\n",
@@ -886,7 +886,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.12"
+   "version": "3.9.13"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
## Description
changed model name from meta/llama3.1-405b-instruct and stg/meta/llama3.1-405b-instruct to meta/llama-3.1-405b-instruct.
<!-- Reference any issues closed by this PR with "closes #1234". -->

## Usage
<!-- Potentially add a usage example below -->
```python
# Add snippet demonstrating usage
async def generate_subtopics(client, topic, n_subtopics):
    prompt = TOPIC_GENERATION_PROMPT_TEMPLATE.format(topic=topic, n_subtopics=n_subtopics)
    response = await client.chat.completions.create(
        model="meta/llama-3.1-405b-instruct",
        messages=[
            {"role" : "user",
             "content" : prompt}
        ],
        temperature=0.2,
        top_p=0.7,
        max_tokens=1024,
    )
    return response
```
## Checklist
<!--
Note: All commits need to be signed and signed off. This can be done via `-sS` flags while commiting
`git commit -sS -m "...."
-->
- [ ] I am familiar with the [Contributing Guide](https://github.com/NVIDIA/NeMo-Curator/blob/main/CONTRIBUTING.md).
- [ ] New or Existing tests cover these changes.
- [x] The documentation is up to date with these changes.
