### PR TITLE
Add option to skip data by adding a flag instead of removing them

### DIFF
--- a/nemo_curator/utils/module_utils.py
+++ b/nemo_curator/utils/module_utils.py
@@ -13,6 +13,9 @@
 # limitations under the License.
 import math
 
+SKIP_LABEL_KEY = "_skipme"
+REASON_LABEL_KEY = "reason"
+
 
 def is_batched(function):
     return hasattr(function, "batched") and function.batched

--- a/tutorials/bitext_cleaning/main.py
+++ b/tutorials/bitext_cleaning/main.py
@@ -56,6 +56,7 @@ def filter_dataset(dataset: ParallelDataset, gpu: bool = False) -> ParallelDatas
                 tgt_lang=TGT_LANG,
                 score_field="length_ratio",
                 score_type=float,
+                add_skip_label_only=True,
             ),
             ParallelScoreFilter(
                 HistogramFilter(lang=SRC_LANG),
@@ -63,6 +64,7 @@ def filter_dataset(dataset: ParallelDataset, gpu: bool = False) -> ParallelDatas
                 src_score="src_hist",
                 tgt_score="tgt_hist",
                 score_type=int,
+                add_skip_label_only=True,
             ),
         ]
     )
@@ -75,6 +77,7 @@ def filter_dataset(dataset: ParallelDataset, gpu: bool = False) -> ParallelDatas
                 gpu=gpu,
                 metadata_fields=["src_lang", "tgt_lang"],
                 score_type=float,
+                add_skip_label_only=True,
             )
         )
     else:
@@ -115,7 +118,8 @@ def run_curation_pipeline(args: Any, src_file: str, tgt_file: str) -> None:
         shutil.rmtree(out_path)
 
     os.makedirs(out_path)
-    dataset.to_bitext(out_path, write_to_filename=True)
+    # dataset.to_bitext(out_path, write_to_filename=True)
+    dataset.to_json(out_path, write_to_filename=True)
     client.close()
 
 

--- a/tutorials/bitext_cleaning/main.py
+++ b/tutorials/bitext_cleaning/main.py
@@ -119,7 +119,7 @@ def run_curation_pipeline(args: Any, src_file: str, tgt_file: str) -> None:
 
     os.makedirs(out_path)
     # dataset.to_bitext(out_path, write_to_filename=True)
-    dataset.to_json(out_path, write_to_filename=True)
+    dataset.to_json(out_path)
     client.close()
 
 


### PR DESCRIPTION
## Description

This PR implements the feature to add skip labels to filtered entries in the json/parquet outputs instead of completely removing filtered entries. When this feature is enabled, it will also log which filter discarded an entry by adding its class name to a field ("reason" by default). 

This allows easy tracking/book-keeping in some scenarios, for example:

* When there is another modality (e.g. speech) and the data files are not self-contained
* When someone is experimenting with some new filters and need to know how much entries each filter throw out
* When someone is running other pipelines outside Nemo-Curator

The feature can be applied to all filters without extra code change.

Despite all the entries being preserved in the dataset, we ensure when filters are chained in the form of `g(f(x))`, `g` will still only be ran on entries that's not filtered out by `f`.

## Usage

Simply adding an extra flag `add_skip_label_only=True` to any filter definition. For example:

```
            LengthRatioFilter(
                max_ratio=2,
                src_lang=SRC_LANG,
                tgt_lang=TGT_LANG,
                score_field="length_ratio",
                score_type=float,
                add_skip_label_only=True,
            )
```

This feature won't work with the plain bitext output format because extra flags can't be added there. Make sure json or parquet format is used.

A working example is in the updated `tutorials/bitext_cleaning`.

## Checklist

- [x] I am familiar with the [Contributing Guide](https://github.com/NVIDIA/NeMo-Curator/blob/main/CONTRIBUTING.md).
- [ ] New or Existing tests cover these changes.
- [ ] The documentation is up to date with these changes.

(Consider this as an initial draft. I'll write tests and docs if this is deemed merge-worthy.)