### PR TITLE
Fail loudly for NeMo Curator Dask-Cuda cluster creation CUDA context issues

### DIFF
--- a/nemo_curator/modifiers/pii_modifier.py
+++ b/nemo_curator/modifiers/pii_modifier.py
@@ -16,7 +16,6 @@
 import pandas as pd
 
 from nemo_curator.modifiers import DocumentModifier
-from nemo_curator.pii.algorithm import PiiDeidentifier
 from nemo_curator.pii.constants import DEFAULT_LANGUAGE, DEFAULT_MAX_DOC_SIZE
 from nemo_curator.utils.decorators import batched
 from nemo_curator.utils.distributed_utils import load_object_on_worker
@@ -86,7 +85,7 @@ class PiiModifier(DocumentModifier):
         output: pd.Series = pd.Series(output, text.index)
         return output
 
-    def load_deidentifier(self) -> PiiDeidentifier:
+    def load_deidentifier(self) -> "PiiDeidentifier":  # noqa: F821
         """
         Helper function to load the de-identifier
         """

--- a/nemo_curator/modules/__init__.py
+++ b/nemo_curator/modules/__init__.py
@@ -43,6 +43,10 @@ ConnectedComponents = gpu_only_import_from(
 )
 FuzzyDuplicates = gpu_only_import_from("nemo_curator.modules.fuzzy_dedup.fuzzyduplicates", "FuzzyDuplicates")
 
+# PyTorch-related imports must come after all imports that require cuGraph
+# because of context cleanup issues between PyTorch and cuGraph
+# See this issue: https://github.com/rapidsai/cugraph/issues/2718
+
 EmbeddingCreator = gpu_only_import_from("nemo_curator.modules.semantic_dedup.embeddings", "EmbeddingCreator")
 ClusteringModel = gpu_only_import_from("nemo_curator.modules.semantic_dedup.clusteringmodel", "ClusteringModel")
 SemanticClusterLevelDedup = gpu_only_import_from(
@@ -50,10 +54,6 @@ SemanticClusterLevelDedup = gpu_only_import_from(
     "SemanticClusterLevelDedup",
 )
 SemDedup = gpu_only_import_from("nemo_curator.modules.semantic_dedup.semdedup", "SemDedup")
-
-# PyTorch-related imports must come after all imports that require cuGraph
-# because of context cleanup issues between PyTorch and cuGraph
-# See this issue: https://github.com/rapidsai/cugraph/issues/2718
 from .filter import Filter, ParallelScoreFilter, Score, ScoreFilter
 
 __all__ = [

--- a/nemo_curator/utils/distributed_utils.py
+++ b/nemo_curator/utils/distributed_utils.py
@@ -99,7 +99,8 @@ def _worker_gpu_tuple() -> tuple[str, int]:
     try:
         handle = nvmlDeviceGetHandleByPciBusId(pci_bus_id)
         index = nvmlDeviceGetIndex(handle)
-    except NVMLError:
+    except NVMLError as e:
+        warnings.warn(f"NVML error occurred: {e} while verifying GPU index", stacklevel=2)
         index = -1  # fallback - shouldn't happen
 
     return socket.gethostname(), index

--- a/nemo_curator/utils/distributed_utils.py
+++ b/nemo_curator/utils/distributed_utils.py
@@ -90,11 +90,18 @@ def _worker_gpu_tuple() -> tuple[str, int]:
     # Touch the GPU so a context is created (idempotent if one already exists)
     cp.cuda.runtime.getDevice()
     ctx = has_cuda_context()
+    hostname = socket.gethostname()
     if ctx.has_context and ctx.device_info is not None:
-        return socket.gethostname(), ctx.device_info.device_index
+        device_index = ctx.device_info.device_index
     else:
         # Fallback - context not yet created or NVML unavailable
-        return socket.gethostname(), -1
+        warnings.warn(
+            f"Unable to retrieve valid GPU index for host '{hostname}'. "
+            "GPU context may not be initialized or NVML may be unavailable. Returning -1.",
+            stacklevel=2,
+        )
+        device_index = -1
+    return hostname, device_index
 
 
 def _assert_unique_gpu_per_host(client: Client) -> None:

--- a/nemo_curator/utils/distributed_utils.py
+++ b/nemo_curator/utils/distributed_utils.py
@@ -32,7 +32,6 @@ from datetime import datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal
 
-import cupy as cp
 import dask.dataframe as dd
 import numpy as np
 import pandas as pd
@@ -44,6 +43,7 @@ from nemo_curator.utils.gpu_utils import is_cudf_type
 from nemo_curator.utils.import_utils import gpu_only_import, gpu_only_import_from
 
 cudf = gpu_only_import("cudf")
+cp = gpu_only_import("cupy")
 LocalCUDACluster = gpu_only_import_from("dask_cuda", "LocalCUDACluster")
 get_device_total_memory = gpu_only_import_from("dask_cuda.utils", "get_device_total_memory")
 if TYPE_CHECKING:


### PR DESCRIPTION
## Description
This PR fixes : https://github.com/NVIDIA/NeMo-Curator/pull/61/files by ensuring we always have cuda context spread across multiple GPUs. 

#### Local Test to verify this:


```python3
#!/usr/bin/env python3
"""
Test to ensure that we fail if over subscribed on GPUs and deviate from 1 GPU per worker model
"""
import time
from nemo_curator.pii.algorithm import PiiDeidentifier
from nemo_curator import get_client, __version__ as curator_version

def main() -> None:
    print(f"NeMo Curator version: {curator_version}")
    client = get_client(cluster_type="gpu", rmm_pool_size="1GB")
    time.sleep(3)  # give workers time to register

if __name__ == "__main__":
    main()

```

With PR:
```python3
NeMo Curator version: 0.9.0rc0.dev0
cuDF Spilling is enabled
Traceback (most recent call last):
  File "/home/nfs/vjawa/NeMo-Curator/tests/test_cluster_cuda.py", line 15, in <module>
    main()
  File "/home/nfs/vjawa/NeMo-Curator/tests/test_cluster_cuda.py", line 11, in main
    client = get_client(cluster_type="gpu", rmm_pool_size="1GB")
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/nfs/vjawa/NeMo-Curator/nemo_curator/utils/distributed_utils.py", line 344, in get_client
    _assert_unique_gpu_per_host(client)
  File "/home/nfs/vjawa/NeMo-Curator/nemo_curator/utils/distributed_utils.py", line 147, in _assert_unique_gpu_per_host
    raise RuntimeError(report)
RuntimeError: Duplicate GPU assignment detected!

Host: dgx11  (total workers: 8)
  GPU 0 → 8 workers
Each worker on a host must own a distinct GPU.
```


Without PR (No error/warnings are raised):
```python3

NeMo Curator version: 0.9.0rc0.dev0
cuDF Spilling is enabled
```

But `nvidia-smi`, looks like below:
```bash
vjawa@dgx11:~/NeMo-Curator$ nvidia-smi
Fri Apr 25 10:55:19 2025       
+---------------------------------------------------------------------------------------+
| NVIDIA-SMI 535.161.08             Driver Version: 535.161.08   CUDA Version: 12.2     |
|-----------------------------------------+----------------------+----------------------+
| GPU  Name                 Persistence-M | Bus-Id        Disp.A | Volatile Uncorr. ECC |
| Fan  Temp   Perf          Pwr:Usage/Cap |         Memory-Usage | GPU-Util  Compute M. |
|                                         |                      |               MIG M. |
|=========================================+======================+======================|
|   0  Tesla V100-SXM2-32GB           On  | 00000000:06:00.0 Off |                    0 |
| N/A   32C    P0              57W / 300W |  10133MiB / 32768MiB |      0%      Default |
|                                         |                      |                  N/A |
+-----------------------------------------+----------------------+----------------------+
|   1  Tesla V100-SXM2-32GB           On  | 00000000:07:00.0 Off |                    0 |
| N/A   33C    P0              43W / 300W |      3MiB / 32768MiB |      0%      Default |
|                                         |                      |                  N/A |
+-----------------------------------------+----------------------+----------------------+
|   2  Tesla V100-SXM2-32GB           On  | 00000000:0A:00.0 Off |                    0 |
| N/A   31C    P0              42W / 300W |      3MiB / 32768MiB |      0%      Default |
|                                         |                      |                  N/A |
+-----------------------------------------+----------------------+----------------------+
|   3  Tesla V100-SXM2-32GB           On  | 00000000:0B:00.0 Off |                    0 |
| N/A   29C    P0              41W / 300W |      3MiB / 32768MiB |      0%      Default |
|                                         |                      |                  N/A |
+-----------------------------------------+----------------------+----------------------+
|   4  Tesla V100-SXM2-32GB           On  | 00000000:85:00.0 Off |                    0 |
| N/A   31C    P0              42W / 300W |      3MiB / 32768MiB |      0%      Default |
|                                         |                      |                  N/A |
+-----------------------------------------+----------------------+----------------------+
|   5  Tesla V100-SXM2-32GB           On  | 00000000:86:00.0 Off |                    0 |
| N/A   31C    P0              42W / 300W |      3MiB / 32768MiB |      0%      Default |
|                                         |                      |                  N/A |
+-----------------------------------------+----------------------+----------------------+
|   6  Tesla V100-SXM2-32GB           On  | 00000000:89:00.0 Off |                    0 |
| N/A   34C    P0              43W / 300W |      3MiB / 32768MiB |      0%      Default |
|                                         |                      |                  N/A |
+-----------------------------------------+----------------------+----------------------+
|   7  Tesla V100-SXM2-32GB           On  | 00000000:8A:00.0 Off |                    0 |
| N/A   30C    P0              43W / 300W |      3MiB / 32768MiB |      0%      Default |
|                                         |                      |                  N/A |
+-----------------------------------------+----------------------+----------------------+
                                                                                         
+---------------------------------------------------------------------------------------+
| Processes:                                                                            |
|  GPU   GI   CI        PID   Type   Process name                            GPU Memory |
|        ID   ID                                                             Usage      |
|=======================================================================================|
|    0   N/A  N/A   2093974      C   ...o_curator_nightly_25_04/bin/python3     1266MiB |
|    0   N/A  N/A   2093976      C   ...o_curator_nightly_25_04/bin/python3     1266MiB |
|    0   N/A  N/A   2093982      C   ...o_curator_nightly_25_04/bin/python3     1266MiB |
|    0   N/A  N/A   2093984      C   ...o_curator_nightly_25_04/bin/python3     1266MiB |
|    0   N/A  N/A   2093989      C   ...o_curator_nightly_25_04/bin/python3     1266MiB |
|    0   N/A  N/A   2093995      C   ...o_curator_nightly_25_04/bin/python3     1266MiB |
|    0   N/A  N/A   2093997      C   ...o_curator_nightly_25_04/bin/python3     1266MiB |
|    0   N/A  N/A   2094001      C   ...o_curator_nightly_25_04/bin/python3     1266MiB |
```