### PR TITLE
chore: Version bump to 0.10.0rc0.dev0

### DIFF
--- a/nemo_curator/package_info.py
+++ b/nemo_curator/package_info.py
@@ -16,8 +16,8 @@
 MAJOR = 0
 MINOR = 10
 PATCH = 0
-PRE_RELEASE = 'rc0'
-DEV = 'dev0'
+PRE_RELEASE = "rc0"
+DEV = "dev0"
 
 # Use the following formatting: (major, minor, patch, pre-release)
 VERSION = (MAJOR, MINOR, PATCH, PRE_RELEASE, DEV)

--- a/nemo_curator/package_info.py
+++ b/nemo_curator/package_info.py
@@ -14,10 +14,10 @@
 
 
 MAJOR = 0
-MINOR = 9
+MINOR = 10
 PATCH = 0
-PRE_RELEASE = "rc0"
-DEV = "dev0"
+PRE_RELEASE = 'rc0'
+DEV = 'dev0'
 
 # Use the following formatting: (major, minor, patch, pre-release)
 VERSION = (MAJOR, MINOR, PATCH, PRE_RELEASE, DEV)


### PR DESCRIPTION
## Description
[🤖]: Howdy folks, let's bump NeMo Curator to `0.10.0rc0.dev0` !

## Usage
<!-- Potentially add a usage example below -->
```python
# Add snippet demonstrating usage
```
## Checklist
<!--
Note: All commits need to be signed and signed off. This can be done via `-sS` flags while commiting
`git commit -sS -m "...."
-->
- [ ] I am familiar with the [Contributing Guide](https://github.com/NVIDIA/NeMo-Curator/blob/main/CONTRIBUTING.md).
- [ ] New or Existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
