### PR TITLE
ci: Add placeholder codecov check for when tests do not run

### DIFF
--- a/.github/workflows/gpuci.yml
+++ b/.github/workflows/gpuci.yml
@@ -217,7 +217,7 @@ jobs:
           if [ "${{ needs.pre-flight.outputs.allowed_to_run }}" == "false" ]; then
             echo "No tests were required to run, marking as success"
             exit 0
-          elif [ "${{ needs.run-gpu-tests.conclusion }}" == "success" ]; then
+          elif [ "${{ needs.run-gpu-tests.result }}" == "success" ]; then
             echo "GPU tests passed successfully"
             exit 0
           else

--- a/.github/workflows/gpuci.yml
+++ b/.github/workflows/gpuci.yml
@@ -56,7 +56,7 @@ jobs:
       - name: Allowed to run
         id: allowed-to-run
         run: |
-          echo "allowed_to_run=false" >> $GITHUB_OUTPUT
+          echo "allowed_to_run=${{ steps.changed-files.outputs.any_changed == 'true' || steps.changed-files.outputs.is_main_branch == 'true' }}" >> $GITHUB_OUTPUT
 
   # First, we build and push a NeMo Curator container
   build-container:

--- a/.github/workflows/gpuci.yml
+++ b/.github/workflows/gpuci.yml
@@ -206,3 +206,13 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           verbose: true
           flags: gpu
+
+  codecov-placeholder:
+    name: codecov/patch
+    needs: [pre-flight]
+    if: ${{ needs.pre-flight.outputs.allowed_to_run != 'true' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: codecov_placeholder
+        run: |
+          echo "This is a placeholder status check for when no tests are ran but the codecov status is expected"

--- a/.github/workflows/gpuci.yml
+++ b/.github/workflows/gpuci.yml
@@ -56,7 +56,7 @@ jobs:
       - name: Allowed to run
         id: allowed-to-run
         run: |
-          echo "allowed_to_run=${{ steps.changed-files.outputs.any_changed == 'true' || steps.changed-files.outputs.is_main_branch == 'true' }}" >> $GITHUB_OUTPUT
+          echo "allowed_to_run=false" >> $GITHUB_OUTPUT
 
   # First, we build and push a NeMo Curator container
   build-container:

--- a/.github/workflows/gpuci.yml
+++ b/.github/workflows/gpuci.yml
@@ -207,6 +207,24 @@ jobs:
           verbose: true
           flags: gpu
 
+  gpu-ci-result:
+    runs-on: ubuntu-latest
+    needs: [pre-flight, run-gpu-tests]
+    if: always()
+    steps:
+      - name: Check GPU CI results
+        run: |
+          if [ "${{ needs.pre-flight.outputs.allowed_to_run }}" == "false" ]; then
+            echo "No tests were required to run, marking as success"
+            exit 0
+          elif [ "${{ needs.run-gpu-tests.conclusion }}" == "success" ]; then
+            echo "GPU tests passed successfully"
+            exit 0
+          else
+            echo "GPU tests failed"
+            exit 1
+          fi
+
   codecov-placeholder:
     name: codecov/patch
     needs: [pre-flight]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,8 @@ on:
     branches:
       - main
   pull_request:
-    types: [labeled, synchronize]
+    branches:
+      - main
   workflow_dispatch:
 
 # When this workflow is queued, automatically cancel any previous running

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -550,6 +550,7 @@ class TestExtractor:
 
         assert result == expected
 
+    @pytest.mark.skip(reason="This test failure needs to be investigated.")
     @pytest.mark.parametrize("extraction_algorithm", ["justext", "resiliparse", "trafilatura"])
     def test_extract_chinese_text(
         self, extraction_algorithm: Literal["justext", "resiliparse", "trafilatura"]
@@ -597,6 +598,7 @@ class TestExtractor:
 
         assert result == expected
 
+    @pytest.mark.skip(reason="This test failure needs to be investigated.")
     @pytest.mark.parametrize("extraction_algorithm", ["justext", "resiliparse", "trafilatura"])
     def test_extract_japanese_text(
         self, extraction_algorithm: Literal["justext", "resiliparse", "trafilatura"]

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -550,7 +550,6 @@ class TestExtractor:
 
         assert result == expected
 
-    @pytest.mark.skip(reason="This test failure needs to be investigated.")
     @pytest.mark.parametrize("extraction_algorithm", ["justext", "resiliparse", "trafilatura"])
     def test_extract_chinese_text(
         self, extraction_algorithm: Literal["justext", "resiliparse", "trafilatura"]
@@ -598,7 +597,6 @@ class TestExtractor:
 
         assert result == expected
 
-    @pytest.mark.skip(reason="This test failure needs to be investigated.")
     @pytest.mark.parametrize("extraction_algorithm", ["justext", "resiliparse", "trafilatura"])
     def test_extract_japanese_text(
         self, extraction_algorithm: Literal["justext", "resiliparse", "trafilatura"]


### PR DESCRIPTION
## Description
Add placeholder codecov check for when tests do not run

If no test coverage is uploaded, then the `codecov/patch` status will never exist. So we add a placeholder status check using the same name for when tests do not run.

Here is an example when I forced the tests to be skipped:
<img width="951" alt="Screenshot 2025-06-26 at 8 21 39 PM" src="https://github.com/user-attachments/assets/7407f50d-1e86-483d-8418-f942b2ca0b9f" />

* Lastly, added a `gpu-ci-result` job so that it always runs even if gpu job is skipped if it's a docs only case. This would be good to have to enable a status check on it.
* Updated cpu tests to run all PR events not just labeld and synchronized

## Usage
<!-- Potentially add a usage example below -->
```python
# Add snippet demonstrating usage
```
## Checklist
<!--
Note: All commits need to be signed and signed off. This can be done via `-sS` flags while commiting
`git commit -sS -m "...."
-->
- [ ] I am familiar with the [Contributing Guide](https://github.com/NVIDIA/NeMo-Curator/blob/main/CONTRIBUTING.md).
- [ ] New or Existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
