### PR TITLE
Create .gitattributes to classify lang as Python

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.ipynb linguist-language=Python


### PR DESCRIPTION
## Description
This PR introduces a `.gitattributes` file to correctly classify the repository's primary language as **Python** instead of "Jupyter Notebook.
