### PR TITLE
Add video splitting pipeline with fixed stride extraction and transco…

### DIFF
--- a/ray-curator/ray_curator/examples/video/video_split_clip_example.py
+++ b/ray-curator/ray_curator/examples/video/video_split_clip_example.py
@@ -1,0 +1,264 @@
+import argparse
+
+from ray_curator.backends.xenna import XennaExecutor
+from ray_curator.pipeline import Pipeline
+from ray_curator.stages.video.clipping.clip_extraction_stages import ClipTranscodingStage, FixedStrideExtractorStage
+from ray_curator.stages.video.io.video_download import VideoDownloadStage
+
+
+def create_video_splitting_pipeline(args: argparse.Namespace) -> Pipeline:
+
+    # Define pipeline
+    pipeline = Pipeline(name="video_splitting", description="Split videos into clips")
+
+    # Add stages
+    pipeline.add_stage(VideoDownloadStage(folder_path=args.video_folder, debug=args.debug))
+
+    if args.splitting_algorithm == "fixed_stride":
+        pipeline.add_stage(
+            FixedStrideExtractorStage(
+                clip_len_s=args.fixed_stride_split_duration,
+                clip_stride_s=args.fixed_stride_split_duration,
+                min_clip_length_s=args.fixed_stride_min_clip_length_s,
+                limit_clips=args.limit_clips,
+            )
+        )
+    else:
+        msg = f"Splitting algorithm {args.splitting_algorithm} not supported"
+        raise ValueError(msg)
+
+    pipeline.add_stage(ClipTranscodingStage(
+        num_cpus_per_worker=args.transcode_cpus_per_worker,
+        encoder=args.transcode_encoder,
+        encoder_threads=args.transcode_encoder_threads,
+        encode_batch_size=args.transcode_ffmpeg_batch_size,
+        use_hwaccel=args.transcode_use_hwaccel,
+        use_input_bit_rate=args.transcode_use_input_video_bit_rate,
+        num_clips_per_chunk=args.clip_re_chunk_size,
+        verbose=args.verbose,
+        debug=args.debug,
+    ))
+
+    return pipeline
+
+
+def main(args: argparse.Namespace) -> None:
+
+    pipeline = create_video_splitting_pipeline(args)
+
+    # Print pipeline description
+    print(pipeline.describe())
+    print("\n" + "=" * 50 + "\n")
+
+    # Create executor
+    executor = XennaExecutor()
+
+    # Execute pipeline
+    print("Starting pipeline execution...")
+    pipeline.run(executor)
+
+    # Print results
+    print("\nPipeline completed!")
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    # General arguments
+    parser.add_argument("--debug", action="store_true", default=False, help="Run in debug mode")
+    parser.add_argument("--video-folder", type=str, default="/home/aot/Videos")
+    parser.add_argument("--verbose", action="store_true", default=False)
+    parser.add_argument("--output-clip-path", type=str, default="/mnt/mint/output")
+    parser.add_argument(
+        "--no-upload-clips",
+        dest="upload_clips",
+        action="store_false",
+        default=True,
+        help="Whether to upload clips to output path.",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        default=False,
+        help="If set only write minimum metadata",
+    )
+
+    # Splitting parameters
+    parser.add_argument(
+        "--splitting-algorithm",
+        type=str,
+        default="fixed_stride",
+        choices=["fixed_stride", "transnetv2"],
+        help="Splitting algorithm to use",
+    )
+    parser.add_argument(
+        "--fixed-stride-split-duration",
+        type=float,
+        default=10.0,
+        help="Duration of clips (in seconds) generated from the fixed stride splitting stage.",
+    )
+    parser.add_argument(
+        "--fixed-stride-min-clip-length-s",
+        type=float,
+        default=2.0,
+        help="Minimum length of clips (in seconds) for fixed stride splitting stage.",
+    )
+    parser.add_argument(
+        "--limit-clips",
+        type=int,
+        default=0,
+        help="limit number of clips from each input video to process. 0 means no limit.",
+    )
+    parser.add_argument(
+        "--transnetv2-frame-decoder-mode",
+        type=str,
+        default="pynvc",
+        choices=["pynvc", "ffmpeg_gpu", "ffmpeg_cpu"],
+        help="Choose between ffmpeg on CPU or GPU or PyNvVideoCodec for video decode.",
+    )
+
+    # Transcoding arguments
+    parser.add_argument(
+        "--transcode-cpus-per-worker",
+        type=float,
+        default=6.0,
+        help="Number of CPU threads per worker. The stage uses a batched ffmpeg "
+        "commandline with batch_size (-transcode-ffmpeg-batch-size) of ~64 and per-batch thread count of 1.",
+    )
+    parser.add_argument(
+        "--transcode-encoder",
+        type=str,
+        default="libopenh264",
+        choices=["libopenh264", "h264_nvenc", "libx264"],
+        help="Codec for transcoding clips; None to skip transocding.",
+    )
+    parser.add_argument(
+        "--transcode-encoder-threads",
+        type=int,
+        default=1,
+        help="Number of threads per ffmpeg encoding sub-command for transcoding clips.",
+    )
+    parser.add_argument(
+        "--transcode-ffmpeg-batch-size",
+        type=int,
+        default=16,
+        help="FFMPEG batchsize for transcoding clips. Each clip/sub-command in "
+        "the batch uses --transcode-encoder-threads number of CPU threads",
+    )
+    parser.add_argument(
+        "--transcode-use-hwaccel",
+        action="store_true",
+        default=False,
+        help="Whether to use cuda acceleration for decoding in transcoding stage.",
+    )
+    parser.add_argument(
+        "--transcode-use-input-video-bit-rate",
+        action="store_true",
+        default=False,
+        help="Whether to use input video's bit rate for encoding clips.",
+    )
+    parser.add_argument(
+        "--clip-re-chunk-size",
+        type=int,
+        default=32,
+        help="Number of clips per chunk after transcoding stage.",
+    )
+
+    # Motion vector decoding arguments
+    parser.add_argument(
+        "--motion-filter",
+        choices=["disable", "enable", "score-only"],
+        default="disable",
+        help=(
+            "Control motion filtering behavior:\n"
+            "  - disable: No filtering or scoring.\n"
+            "  - enable: Automatically filter clips based on motion thresholds.\n"
+            "      (controlled by --motion-global-mean-threshold and --motion-per-patch-min-256-threshold).\n"
+            "  - score-only: Calculate motion scores without filtering clips."
+        ),
+    )
+    parser.add_argument(
+        "--motion-global-mean-threshold",
+        type=float,
+        default=0.00098,
+        help=(
+            "Threshold for global average motion magnitude. "
+            "Clips with global motion below this value may be flagged as low-motion. "
+            "Only applies when --motion-filter is set to 'enable' or 'score-only'."
+        ),
+    )
+    parser.add_argument(
+        "--motion-per-patch-min-256-threshold",
+        type=float,
+        default=0.000001,
+        help=(
+            "Threshold for minimal average motion magnitude in any 256x256-pixel patch. "
+            "Clips containing patches below this threshold may be flagged as low-motion. "
+            "Only applies when --motion-filter is set to 'enable' or 'score-only'."
+        ),
+    )
+    parser.add_argument(
+        "--motion-decode-target-fps",
+        type=float,
+        default=2.0,
+        help="Target frames per second to sample for motion vector decoding.",
+    )
+    parser.add_argument(
+        "--motion-decode-target-duration-ratio",
+        type=float,
+        default=0.5,
+        help="Target ratio of video duration to sample for motion vector decoding (0.5 = 50%%).",
+    )
+    parser.add_argument(
+        "--motion-decode-cpus-per-worker",
+        type=float,
+        default=4.0,
+        help="Number of CPUs per worker allocated to motion vector decoding.",
+    )
+    parser.add_argument(
+        "--motion-score-batch-size",
+        type=int,
+        default=64,
+        help="Batch size for motion score computation.",
+    )
+    parser.add_argument(
+        "--motion-score-gpus-per-worker",
+        type=float,
+        default=0.5,
+        help="Number of GPUs per worker allocated to motion score computation. Set to 0 to use CPU instead of GPU.",
+    )
+    parser.add_argument(
+        "--clip-extraction-target-res",
+        type=int,
+        default=-1,
+        help="Target resolution for clip extraction as (height, width). A value of -1 implies disables resize",
+    )
+
+    # Aesthetic arguments
+    parser.add_argument(
+        "--aesthetic-threshold",
+        type=float,
+        default=None,
+        help="If specified (e.g. 3.5), filter out clips with an aesthetic score below this threshold.",
+    )
+    # Embedding arguments
+    parser.add_argument(
+        "--embedding-algorithm",
+        type=str,
+        default="internvideo2",
+        choices=["cosmos-embed1", "internvideo2"],
+        help="Embedding algorithm to use.",
+    )
+    parser.add_argument(
+        "--embedding-gpus-per-worker",
+        type=float,
+        default=1.0,
+        help="Number of GPUs per worker for InternVideo2 or Cosmos-Embed1 embedding stage.",
+    )
+    parser.add_argument(
+        "--no-generate-embeddings",
+        dest="generate_embeddings",
+        action="store_false",
+        default=True,
+        help="Whether to generate embeddings for clips.",
+    )
+    args = parser.parse_args()
+    main(args)

--- a/ray-curator/ray_curator/stages/video/clipping/clip_extraction_stages.py
+++ b/ray-curator/ray_curator/stages/video/clipping/clip_extraction_stages.py
@@ -1,0 +1,356 @@
+import copy
+import pathlib
+import subprocess
+import uuid
+from dataclasses import dataclass
+
+from loguru import logger
+
+from ray_curator.backends.base import WorkerMetadata
+from ray_curator.stages.base import ProcessingStage
+from ray_curator.stages.resources import Resources
+from ray_curator.tasks import Clip, Video, VideoTask
+from ray_curator.utils import grouping
+from ray_curator.utils.operation_utils import make_pipeline_temporary_dir
+
+
+@dataclass
+class ClipTranscodingStage(ProcessingStage[VideoTask, VideoTask]):
+    """Stage that transcodes video clips into a standardized format.
+
+    This stage handles the conversion of video clips using FFmpeg, supporting both
+    software (libx264, libopenh264) and hardware (NVENC) encoding with configurable parameters.
+    """
+    num_cpus_per_worker: float = 6.0
+    encoder: str = "libx264"
+    encoder_threads: int = 1
+    encode_batch_size: int = 16
+    nb_streams_per_gpu: int = 3
+    use_hwaccel: bool = False
+    use_input_bit_rate: bool = False
+    num_clips_per_chunk: int = 32
+    ffmpeg_verbose: bool = False
+    verbose: bool = False
+    debug: bool = False
+
+    @property
+    def name(self) -> str:
+        return "clip_transcoding"
+
+    def setup(self, worker_metadata: WorkerMetadata | None = None) -> None:  # noqa: ARG002
+        """Setup method called once before processing begins.
+        Override this method to perform any initialization that should
+        happen once per worker.
+        Args:
+            worker_metadata (WorkerMetadata, optional): Information about the worker (provided by some backends)
+        """
+        if self.encoder not in {"libopenh264", "libx264", "h264_nvenc"}:
+            error_msg = f"Expected encoder of `libopenh264`, `libx264`, or `h264_nvenc`. Got {self.encoder}"
+            raise ValueError(error_msg)
+
+    @property
+    def resources(self) -> Resources:
+        """Resource requirements for this stage."""
+        if self.encoder == "h264_nvenc" or self.use_hwaccel:
+            # TODO: support partial GPU usage
+            return Resources(entire_gpu=True)
+
+        return Resources(cpus=self.num_cpus_per_worker)
+
+    def inputs(self) -> tuple[list[str], list[str]]:
+        return ["data"], []
+
+    def outputs(self) -> tuple[list[str], list[str]]:
+        return ["data"], []
+
+    def process(self, task: VideoTask) -> VideoTask:
+        video = task.data
+        if video.source_bytes is None:
+            msg = "Video source bytes are not available"
+            raise ValueError(msg)
+
+        if not video.clips:
+            logger.warning(f"No clips to transcode for {video.input_video}. Skipping...")
+            video.source_bytes = None
+            return task
+
+        with make_pipeline_temporary_dir(sub_dir="transcode") as tmp_dir:
+            # write video to file
+            video_file = tmp_dir / "input.mp4"
+            video_file.write_bytes(video.source_bytes)
+            force_pix_fmt = video.is_10_bit_color() or False
+
+            # use input video bit-rate
+            use_bit_rate = None
+            if self.use_input_bit_rate:
+                use_bit_rate = str(video.metadata.bit_rate_k) + "K"
+
+            # extract clips in batches
+            for i in range(0, len(video.clips), self.encode_batch_size):
+                batch = video.clips[i : i + self.encode_batch_size]
+                self._extract_clips(
+                    tmp_dir,
+                    video_file.name,
+                    force_pix_fmt=force_pix_fmt,
+                    use_bit_rate=use_bit_rate,
+                    clips=batch,
+                )
+
+        # we are done with source_bytes
+        video.source_bytes = None
+
+        # TODO: log_stats
+
+        # Consider craking into smaller chunks of clips
+        output_tasks = []
+        clip_durations = [clip.duration for clip in video.clips]
+        if len(clip_durations) > 0:
+            logger.info(
+                f"video {video.input_video} has {len(video.clips)} "
+                f"clips and weight={video.weight:.2f}; "
+                f"min-clip={min(clip_durations):.2f}s, "
+                f"max-clip={max(clip_durations):.1f}s.",
+            )
+        clip_chunks = list(
+            grouping.split_by_chunk_size(
+                video.clips,
+                self.num_clips_per_chunk * 8,
+                lambda x: int(x.span[1] - x.span[0]),
+            ),
+        )
+        for idx in range(len(clip_chunks)):
+            # create subtask for each video task
+            subtask = VideoTask(
+                task_id=f"{task.task_id}_chunk_{idx}",
+                dataset_name=task.dataset_name,
+                data=Video(
+                    input_video=video.input_video,
+                    metadata=video.metadata,
+                    clips=clip_chunks[idx],
+                    num_total_clips=len(video.clips),
+                    num_clip_chunks=len(clip_chunks),
+                    clip_chunk_index=idx,
+                    errors=copy.deepcopy(video.errors),
+                ),
+            )
+
+            if self.verbose:
+                logger.info(
+                    f"Spawning subtask {idx} with {len(subtask.data.clips)} clips and weight={subtask.data.weight:.2f}",
+                )
+            output_tasks.append(subtask)
+        logger.info(f"Creating {len(clip_chunks)} tasks for downstream from {video.input_video}.")
+
+
+        return output_tasks
+
+    def _extract_clips(
+            self,
+            working_dir: pathlib.Path,
+            video_filename: str,
+            *,
+            force_pix_fmt: bool,
+            use_bit_rate: str | None,
+            clips: list[Clip],
+    ) -> None:
+        """Extract clips using ffmpeg."""
+        # construct ffmpeg command
+        command = self._build_ffmpeg_command(video_filename, clips, force_pix_fmt, use_bit_rate)
+
+        # run ffmpeg command
+        self._run_ffmpeg_command(command, working_dir, clips)
+
+        # read clips back into memory
+        self._read_clips_to_memory(working_dir, clips)
+
+    def _build_ffmpeg_command(
+            self,
+            video_filename: str,
+            clips: list[Clip],
+            force_pix_fmt: bool,
+            use_bit_rate: str | None,
+    ) -> list[str]:
+        """Build the ffmpeg command for extracting clips."""
+        command = [
+            "ffmpeg",
+            "-hide_banner",
+            "-loglevel",
+            "warning" if self.ffmpeg_verbose else "error",
+        ]
+
+        for i, clip in enumerate(clips):
+            # Add decoder threads
+            self._add_decoder_threads(command)
+
+            # Add hardware acceleration if needed
+            self._add_hwaccel_options(command)
+
+            # Add input options
+            self._add_input_options(command, clip, video_filename, i)
+
+            # Add video encoding options
+            self._add_video_encoding_options(command, use_bit_rate, force_pix_fmt)
+
+            # Add output options
+            self._add_output_options(command, clip, i)
+
+        return command
+
+    def _add_decoder_threads(self, command: list[str]) -> None:
+        """Add decoder thread options to command."""
+        thread_count = "1" if self.resources.gpus > 0 else str(self.encoder_threads)
+        command.extend(["-threads", thread_count])
+
+    def _add_hwaccel_options(self, command: list[str]) -> None:
+        """Add hardware acceleration options to command."""
+        if self.use_hwaccel:
+            if self.encoder == "h264_nvenc":
+                command.extend(["-hwaccel", "cuda", "-hwaccel_output_format", "cuda"])
+            else:
+                command.extend(["-hwaccel", "auto"])
+
+    def _add_input_options(self, command: list[str], clip: Clip, video_filename: str, index: int) -> None:
+        """Add input options to command."""
+        start_s, end_s = clip.span
+        command.extend([
+            "-ss", str(start_s),
+            "-to", str(end_s),
+            "-i", video_filename,
+            "-map", f"{index}:v:0",
+            "-c:v", self.encoder,
+        ])
+
+    def _add_video_encoding_options(self, command: list[str], use_bit_rate: str | None, force_pix_fmt: bool) -> None:
+        """Add video encoding options to command."""
+        if use_bit_rate is not None:
+            command.extend(["-b:v", use_bit_rate])
+
+        if self.encoder == "h264_nvenc":
+            self._add_nvenc_options(command, force_pix_fmt)
+
+    def _add_nvenc_options(self, command: list[str], force_pix_fmt: bool) -> None:
+        """Add NVENC-specific encoding options."""
+        command.extend([
+            "-rc:v", "vbr",
+            "-cq:v", "21",
+            "-tune", "hq",
+            "-b_ref_mode", "middle",
+            "-temporal-aq", "1",
+            "-rc-lookahead", "20",
+            "-spatial-aq", "1",
+        ])
+
+        if force_pix_fmt:
+            command.extend(["-pix_fmt", "yuv420p"])
+
+    def _add_output_options(self, command: list[str], clip: Clip, index: int) -> None:
+        """Add output options to command."""
+        # Add encoder threads again
+        thread_count = "1" if self.resources.gpus > 0 else str(self.encoder_threads)
+        command.extend(["-threads", thread_count])
+
+        # Add audio and output filename
+        command.extend([
+            "-map", f"{index}:a:0?",
+            "-c:a", "copy",
+            f"{clip.uuid}.mp4",
+        ])
+
+    def _run_ffmpeg_command(self, command: list[str], working_dir: pathlib.Path, clips: list[Clip]) -> None:
+        """Run the ffmpeg command and handle errors."""
+        try:
+            if self.verbose:
+                logger.info(f"Executing ffmpeg command: {' '.join(command)}")
+            output = subprocess.check_output(  # noqa: S603
+                command, cwd=working_dir, stderr=subprocess.STDOUT
+            )
+            if output and self.ffmpeg_verbose:
+                logger.warning(f"ffmpeg output: {output.decode('utf-8')}")
+        except subprocess.CalledProcessError as e:
+            self._handle_ffmpeg_error(e, command, clips)
+
+    def _handle_ffmpeg_error(self, error: subprocess.CalledProcessError, command: list[str], clips: list[Clip]) -> None:
+        """Handle ffmpeg command errors."""
+        logger.error(f"ffmpeg command failed with return code {error.returncode}")
+        logger.error(f"Error: {error}")
+        logger.warning(f"Command: {' '.join(command)}")
+        if error.output:
+            logger.warning(f"Error output: {error.output.decode('utf-8')}")
+
+        for clip in clips:
+            clip.errors["transcode"] = error.output.decode("utf-8") if error.output else str(error)
+
+    def _read_clips_to_memory(self, working_dir: pathlib.Path, clips: list[Clip]) -> None:
+        """Read extracted clips back into memory."""
+        for clip in clips:
+            clip.buffer = (working_dir / f"{clip.uuid}.mp4").read_bytes()
+
+
+@dataclass
+class FixedStrideExtractorStage(ProcessingStage[VideoTask, VideoTask]):
+    """Stage that extracts video clips using fixed-length intervals.
+
+    This stage splits videos into clips of specified length and stride, ensuring
+    each clip meets minimum length requirements and optionally limiting total clips.
+    """
+    clip_len_s: float
+    clip_stride_s: float
+    min_clip_length_s: float
+    limit_clips: int
+
+    @property
+    def name(self) -> str:
+        return "fixed_stride_extractor"
+
+    def inputs(self) -> tuple[list[str], list[str]]:
+        return ["data"], []
+
+    def outputs(self) -> tuple[list[str], list[str]]:
+        return ["data"], []
+
+    def process(self, task: VideoTask) -> VideoTask:
+        video = task.data
+        if video.source_bytes is None:
+            msg = "Video source bytes are not available"
+            raise ValueError(msg)
+
+        if not video.has_metadata():
+            logger.warning(f"Incomplete metadata for {video.input_video}. Skipping...")
+            video.errors["metadata"] = "incomplete"
+            return task
+
+        if self.limit_clips > 0 and len(video.clips) >= self.limit_clips:
+            logger.warning(f"Skipping {video.input_video} because it has already been clipped")
+            return task
+
+        file = video.input_video
+        if video.metadata.num_frames is None or video.metadata.framerate is None:
+            msg = f"Incomplete metadata for {video.input_video}: Either metadata.num_frames or metadata.framerate is None."
+            raise ValueError(msg)
+
+        duration = video.metadata.num_frames / video.metadata.framerate if video.metadata.framerate > 0 else -1
+
+        # create clip bounds based on clip_len_s and clip_stride_s
+        clip_start = 0.0
+        clip_bounds: list[tuple[float, float]] = []
+        while clip_start < duration:
+            clip_end = min(clip_start + self.clip_len_s, duration)
+            if (clip_end - clip_start) >= self.min_clip_length_s:
+                clip_bounds.append((clip_start, clip_end))
+            clip_start += self.clip_stride_s
+
+        for span in clip_bounds:
+            start_event = int(span[0] * video.metadata.framerate)
+            end_event = int(span[1] * video.metadata.framerate)
+            clip = Clip(
+                uuid=uuid.uuid5(
+                    uuid.NAMESPACE_URL,
+                    f"{file}_{start_event}_{end_event}",
+                ),
+                source_video=str(file),
+                span=span,
+            )
+            video.clips.append(clip)
+
+        logger.info(f"Extracted {len(task.data.clips)} clips from {task.data.input_video}")
+        return task

--- a/ray-curator/ray_curator/utils/grouping.py
+++ b/ray-curator/ray_curator/utils/grouping.py
@@ -1,0 +1,88 @@
+"""Utility Functions for grouping iterables.
+
+This module provides a collection of utility functions designed to assist with common tasks related to manipulating
+and transforming iterables in Python.
+
+These utilities are generic and work with any iterable types. They're particularly useful for data processing tasks,
+batching operations, and other scenarios where dividing data into specific groupings is necessary.
+
+Note:
+    While these utilities are designed for flexibility and ease-of-use,
+    they may not be optimized for extremely large datasets or performance-critical applications.
+
+"""
+
+import itertools
+import typing
+from collections.abc import Generator, Iterable
+
+T = typing.TypeVar("T")
+
+
+def split_by_chunk_size(
+    iterable: Iterable[T],
+    chunk_size: int,
+    custom_size_func: typing.Callable[[T], int] = lambda x: 1,  # noqa: ARG005
+    *,
+    drop_incomplete_chunk: bool = False,
+) -> Generator[list[T], None, None]:
+    """Split an iterable into chunks of the specified size.
+
+    Args:
+        iterable (Iterable[T]): The input iterable to be split.
+        chunk_size (int): Size of each chunk.
+        custom_size_func (typing.Callable): function
+        drop_incomplete_chunk (bool, optional): If True, drops the last chunk if its size is less than the
+                                                specified chunk size. Defaults to False.
+
+    Yields:
+    - Generator[list[T], None, None]: Chunks of the input iterable.
+
+    """
+    out = []
+    cur_count = 0
+    for value in iterable:
+        out.append(value)
+        cur_count += custom_size_func(value)
+        if cur_count >= chunk_size:
+            yield out
+            out = []
+            cur_count = 0
+    if out and not drop_incomplete_chunk:
+        yield out
+
+
+def split_into_n_chunks(iterable: Iterable[T], num_chunks: int) -> Generator[list[T], None, None]:
+    """Split an iterable into a specified number of chunks.
+
+    Args:
+        iterable (Iterable[T]): The input iterable to be split.
+        num_chunks (int): The desired number of chunks.
+
+    Yields:
+    - Generator[list[T], None, None]: Chunks of the input iterable.
+
+    """
+    it = list(iterable)
+    if len(it) <= num_chunks:
+        yield from [[x] for x in it]
+        return
+    d, r = divmod(len(it), num_chunks)
+    for i in range(num_chunks):
+        si = (d + 1) * (min(r, i)) + d * (0 if i < r else i - r)
+        yield it[si : si + (d + 1 if i < r else d)]
+
+
+def pairwise(iterable: Iterable[T]) -> Iterable[tuple[T, T]]:
+    """Return pairs of consecutive items from the input iterable.
+
+    Args:
+        iterable (Iterable[T]): The input iterable.
+
+    Returns:
+        Iterable[tuple[T, T]]: Pairs of consecutive items.
+
+    """
+    a, b = itertools.tee(iterable)
+    next(b, None)
+    return zip(a, b, strict=False)

--- a/ray-curator/tests/stages/video/clipping/__init__.py
+++ b/ray-curator/tests/stages/video/clipping/__init__.py
@@ -1,0 +1,1 @@
+"""Unit tests for video clipping stages."""

--- a/ray-curator/tests/stages/video/clipping/test_clip_transcoding_stage.py
+++ b/ray-curator/tests/stages/video/clipping/test_clip_transcoding_stage.py
@@ -1,0 +1,674 @@
+"""Unit tests for ClipTranscodingStage."""
+
+import copy
+import pathlib
+import subprocess
+import tempfile
+import uuid
+from unittest.mock import MagicMock, Mock, patch
+
+import pytest
+
+from ray_curator.backends.base import WorkerMetadata
+from ray_curator.stages.resources import Resources
+from ray_curator.stages.video.clipping.clip_extraction_stages import ClipTranscodingStage
+from ray_curator.tasks import Clip, Video, VideoTask
+from ray_curator.tasks.video import VideoMetadata
+
+
+class TestClipTranscodingStage:
+    """Test cases for ClipTranscodingStage."""
+
+    @classmethod
+    def setup_class(cls) -> None:
+        """Set up class-level fixtures."""
+        cls.temp_dir = pathlib.Path(tempfile.gettempdir()) / "test_clip_transcoding"
+
+    def setup_method(self) -> None:
+        """Set up test fixtures."""
+        self.stage = ClipTranscodingStage(
+            num_cpus_per_worker=4.0,
+            encoder="libx264",
+            encoder_threads=2,
+            encode_batch_size=8,
+            use_hwaccel=False,
+            use_input_bit_rate=False,
+            num_clips_per_chunk=16,
+            ffmpeg_verbose=False,
+            verbose=False,
+            debug=False
+        )
+
+        # Create mock clips
+        self.mock_clips = [
+            Clip(
+                uuid=uuid.uuid4(),
+                source_video="test_video.mp4",
+                span=(0.0, 5.0)
+            ),
+            Clip(
+                uuid=uuid.uuid4(),
+                source_video="test_video.mp4",
+                span=(5.0, 10.0)
+            )
+        ]
+
+        # Create a mock video with clips
+        self.mock_video = Video(
+            input_video=pathlib.Path("test_video.mp4"),
+            source_bytes=b"mock_video_data",
+            metadata=VideoMetadata(
+                height=1080,
+                width=1920,
+                framerate=30.0,
+                num_frames=300,
+                duration=10.0,
+                video_codec="h264",
+                pixel_format="yuv420p",
+                audio_codec="aac",
+                bit_rate_k=5000
+            ),
+            clips=copy.deepcopy(self.mock_clips)
+        )
+
+        self.mock_task = VideoTask(
+            task_id="test_task",
+            dataset_name="test_dataset",
+            data=self.mock_video
+        )
+
+    def test_name_property(self) -> None:
+        """Test that the name property returns the correct value."""
+        assert self.stage.name == "clip_transcoding"
+
+    def test_inputs_outputs(self) -> None:
+        """Test that inputs and outputs return the correct values."""
+        inputs, _ = self.stage.inputs()
+        outputs, _ = self.stage.outputs()
+
+        assert inputs == ["data"]
+        assert outputs == ["data"]
+
+    def test_setup_valid_encoders(self) -> None:
+        """Test setup with valid encoders."""
+        valid_encoders = ["libopenh264", "libx264", "h264_nvenc"]
+
+        for encoder in valid_encoders:
+            stage = ClipTranscodingStage(encoder=encoder)
+            # Should not raise any exception
+            stage.setup()
+
+    def test_setup_invalid_encoder(self) -> None:
+        """Test setup with invalid encoder raises ValueError."""
+        stage = ClipTranscodingStage(encoder="invalid_encoder")
+
+        with pytest.raises(ValueError, match="Expected encoder of"):
+            stage.setup()
+
+    def test_resources_cpu_encoder(self) -> None:
+        """Test resource requirements for CPU encoders."""
+        stage = ClipTranscodingStage(
+            encoder="libx264",
+            use_hwaccel=False,
+            num_cpus_per_worker=6.0
+        )
+
+        resources = stage.resources
+        assert isinstance(resources, Resources)
+        assert resources.cpus == 6.0
+        assert not resources.entire_gpu
+
+    def test_resources_gpu_encoder(self) -> None:
+        """Test resource requirements for GPU encoders."""
+        stage = ClipTranscodingStage(
+            encoder="h264_nvenc",
+            use_hwaccel=False,
+            num_cpus_per_worker=6.0
+        )
+
+        resources = stage.resources
+        assert isinstance(resources, Resources)
+        assert resources.entire_gpu
+
+    def test_resources_hwaccel_enabled(self) -> None:
+        """Test resource requirements when hardware acceleration is enabled."""
+        stage = ClipTranscodingStage(
+            encoder="libx264",
+            use_hwaccel=True,
+            num_cpus_per_worker=6.0
+        )
+
+        resources = stage.resources
+        assert isinstance(resources, Resources)
+        assert resources.entire_gpu
+
+    def test_process_no_source_bytes(self) -> None:
+        """Test processing when source_bytes is None."""
+        self.mock_video.source_bytes = None
+
+        with pytest.raises(ValueError, match="Video source bytes are not available"):
+            self.stage.process(self.mock_task)
+
+    def test_process_no_clips(self) -> None:
+        """Test processing when video has no clips."""
+        self.mock_video.clips = []
+
+        with patch("ray_curator.stages.video.clipping.clip_extraction_stages.logger") as mock_logger:
+            result = self.stage.process(self.mock_task)
+
+            # Should return early and log warning
+            mock_logger.warning.assert_called_once()
+            assert "No clips to transcode" in mock_logger.warning.call_args[0][0]
+            assert result.data.source_bytes is None
+
+    def test_process_debug_mode(self) -> None:
+        """Test processing in debug mode."""
+        stage = ClipTranscodingStage(debug=True, encode_batch_size=1)
+
+        # Add more clips than batch size
+        for i in range(5):
+            self.mock_video.clips.append(
+                Clip(
+                    uuid=uuid.uuid4(),
+                    source_video="test_video.mp4",
+                    span=(i * 5.0, (i + 1) * 5.0)
+                )
+            )
+
+        with patch("ray_curator.stages.video.clipping.clip_extraction_stages.logger") as mock_logger, \
+             patch.object(stage, "_extract_clips"), \
+             patch("ray_curator.stages.video.clipping.clip_extraction_stages.make_pipeline_temporary_dir") as mock_temp_dir, \
+             patch("ray_curator.stages.video.clipping.clip_extraction_stages.grouping.split_by_chunk_size") as mock_split, \
+             patch("pathlib.Path.write_bytes"):
+
+            # Setup mocks
+            mock_temp_dir.return_value.__enter__.return_value = self.temp_dir
+            mock_split.return_value = [self.mock_video.clips[:1]]  # Return one chunk
+
+            stage.process(self.mock_task)
+
+            # Should log debug message and limit clips
+            mock_logger.info.assert_called()
+            debug_call = [call for call in mock_logger.info.call_args_list if "DEBUG Mode" in str(call)]
+            assert len(debug_call) > 0
+
+    @patch("ray_curator.stages.video.clipping.clip_extraction_stages.make_pipeline_temporary_dir")
+    @patch("ray_curator.stages.video.clipping.clip_extraction_stages.grouping.split_by_chunk_size")
+    def test_process_successful_transcoding(self, mock_split: MagicMock, mock_temp_dir: MagicMock) -> None:
+        """Test successful transcoding process."""
+        # Setup mocks
+        mock_temp_dir.return_value.__enter__.return_value = self.temp_dir
+        mock_split.return_value = [self.mock_video.clips]  # Return one chunk
+
+        with patch.object(self.stage, "_extract_clips") as mock_extract, \
+             patch("ray_curator.stages.video.clipping.clip_extraction_stages.logger"), \
+             patch("pathlib.Path.write_bytes") as mock_write:
+
+            result = self.stage.process(self.mock_task)
+
+            # Should extract clips and create output tasks
+            mock_extract.assert_called_once()
+            mock_write.assert_called_once()
+            assert isinstance(result, list)
+            assert len(result) == 1
+            assert isinstance(result[0], VideoTask)
+            assert result[0].data.source_bytes is None  # Should be cleared
+
+    @patch("ray_curator.stages.video.clipping.clip_extraction_stages.make_pipeline_temporary_dir")
+    @patch("ray_curator.stages.video.clipping.clip_extraction_stages.grouping.split_by_chunk_size")
+    def test_process_multiple_chunks(self, mock_split: MagicMock, mock_temp_dir: MagicMock) -> None:
+        """Test processing with multiple clip chunks."""
+        # Setup mocks to return multiple chunks
+        chunk1 = [self.mock_clips[0]]
+        chunk2 = [self.mock_clips[1]]
+        mock_split.return_value = [chunk1, chunk2]
+        mock_temp_dir.return_value.__enter__.return_value = self.temp_dir
+
+        with patch.object(self.stage, "_extract_clips"), \
+             patch("ray_curator.stages.video.clipping.clip_extraction_stages.logger"), \
+             patch("pathlib.Path.write_bytes") as mock_write:
+
+            result = self.stage.process(self.mock_task)
+
+            # Should create multiple output tasks
+            mock_write.assert_called_once()
+            assert isinstance(result, list)
+            assert len(result) == 2
+
+            # Verify task properties
+            for i, task in enumerate(result):
+                assert isinstance(task, VideoTask)
+                assert task.task_id == f"test_task_chunk_{i}"
+                assert task.data.num_total_clips == len(self.mock_clips)
+                assert task.data.num_clip_chunks == 2
+                assert task.data.clip_chunk_index == i
+
+    def test_process_with_input_bit_rate(self) -> None:
+        """Test processing with input bit rate enabled."""
+        stage = ClipTranscodingStage(use_input_bit_rate=True)
+
+        with patch("ray_curator.stages.video.clipping.clip_extraction_stages.make_pipeline_temporary_dir") as mock_temp_dir, \
+             patch("ray_curator.stages.video.clipping.clip_extraction_stages.grouping.split_by_chunk_size") as mock_split, \
+             patch.object(stage, "_extract_clips") as mock_extract, \
+             patch("pathlib.Path.write_bytes"):
+
+            mock_temp_dir.return_value.__enter__.return_value = self.temp_dir
+            mock_split.return_value = [self.mock_video.clips]
+
+            stage.process(self.mock_task)
+
+            # Verify that use_bit_rate is passed correctly
+            mock_extract.assert_called_once()
+            call_args = mock_extract.call_args
+            assert call_args[1]["use_bit_rate"] == "5000K"
+
+    def test_extract_clips(self) -> None:
+        """Test the _extract_clips method."""
+        working_dir = self.temp_dir / "extract_test"
+        video_filename = "input.mp4"
+
+        with patch.object(self.stage, "_build_ffmpeg_command") as mock_build, \
+             patch.object(self.stage, "_run_ffmpeg_command") as mock_run, \
+             patch.object(self.stage, "_read_clips_to_memory") as mock_read:
+
+            mock_build.return_value = ["ffmpeg", "command"]
+
+            self.stage._extract_clips(
+                working_dir,
+                video_filename,
+                force_pix_fmt=False,
+                use_bit_rate=None,
+                clips=self.mock_clips
+            )
+
+            # Verify all steps are called
+            mock_build.assert_called_once_with(video_filename, self.mock_clips, False, None)
+            mock_run.assert_called_once_with(["ffmpeg", "command"], working_dir, self.mock_clips)
+            mock_read.assert_called_once_with(working_dir, self.mock_clips)
+
+    def test_build_ffmpeg_command_basic(self) -> None:
+        """Test building basic FFmpeg command."""
+        video_filename = "input.mp4"
+        clips = [self.mock_clips[0]]
+
+        command = self.stage._build_ffmpeg_command(video_filename, clips, False, None)
+
+        # Verify basic command structure
+        assert command[0] == "ffmpeg"
+        assert "-hide_banner" in command
+        assert "-loglevel" in command
+        assert "error" in command  # Since ffmpeg_verbose is False
+
+    def test_build_ffmpeg_command_verbose(self) -> None:
+        """Test building FFmpeg command with verbose logging."""
+        stage = ClipTranscodingStage(ffmpeg_verbose=True)
+        command = stage._build_ffmpeg_command("input.mp4", [self.mock_clips[0]], False, None)
+
+        # Should use warning level instead of error
+        loglevel_idx = command.index("-loglevel")
+        assert command[loglevel_idx + 1] == "warning"
+
+    def test_add_decoder_threads_cpu(self) -> None:
+        """Test adding decoder threads for CPU encoding."""
+        command = []
+        stage = ClipTranscodingStage(encoder_threads=4)
+
+        stage._add_decoder_threads(command)
+
+        assert "-threads" in command
+        assert "4" in command
+
+    def test_add_decoder_threads_gpu(self) -> None:
+        """Test adding decoder threads for GPU encoding."""
+        command = []
+        stage = ClipTranscodingStage(encoder="h264_nvenc", encoder_threads=4)
+
+        stage._add_decoder_threads(command)
+
+        assert "-threads" in command
+        assert "4" in command  # Should use configured threads for GPU
+
+    def test_add_hwaccel_options_disabled(self) -> None:
+        """Test hardware acceleration options when disabled."""
+        command = []
+        stage = ClipTranscodingStage(use_hwaccel=False)
+
+        stage._add_hwaccel_options(command)
+
+        # Should not add any hwaccel options
+        assert "-hwaccel" not in command
+
+    def test_add_hwaccel_options_nvenc(self) -> None:
+        """Test hardware acceleration options for NVENC."""
+        command = []
+        stage = ClipTranscodingStage(encoder="h264_nvenc", use_hwaccel=True)
+
+        stage._add_hwaccel_options(command)
+
+        assert "-hwaccel" in command
+        assert "cuda" in command
+        assert "-hwaccel_output_format" in command
+
+    def test_add_hwaccel_options_auto(self) -> None:
+        """Test hardware acceleration options for auto detection."""
+        command = []
+        stage = ClipTranscodingStage(encoder="libx264", use_hwaccel=True)
+
+        stage._add_hwaccel_options(command)
+
+        assert "-hwaccel" in command
+        assert "auto" in command
+
+    def test_add_input_options(self) -> None:
+        """Test adding input options to FFmpeg command."""
+        command = []
+        clip = self.mock_clips[0]
+
+        self.stage._add_input_options(command, clip, "input.mp4", 0)
+
+        # Verify input options
+        assert "-ss" in command
+        assert "0.0" in command  # Start time
+        assert "-to" in command
+        assert "5.0" in command  # End time
+        assert "-i" in command
+        assert "input.mp4" in command
+        assert "-map" in command
+        assert "0:v:0" in command
+        assert "-c:v" in command
+        assert "libx264" in command
+
+    def test_add_video_encoding_options_no_bitrate(self) -> None:
+        """Test adding video encoding options without bit rate."""
+        command = []
+
+        self.stage._add_video_encoding_options(command, None, False)
+
+        # Should not add bit rate options
+        assert "-b:v" not in command
+
+    def test_add_video_encoding_options_with_bitrate(self) -> None:
+        """Test adding video encoding options with bit rate."""
+        command = []
+
+        self.stage._add_video_encoding_options(command, "5000K", False)
+
+        # Should add bit rate options
+        assert "-b:v" in command
+        assert "5000K" in command
+
+    def test_add_video_encoding_options_nvenc(self) -> None:
+        """Test adding video encoding options for NVENC."""
+        command = []
+        stage = ClipTranscodingStage(encoder="h264_nvenc")
+
+        with patch.object(stage, "_add_nvenc_options") as mock_nvenc:
+            stage._add_video_encoding_options(command, None, False)
+            mock_nvenc.assert_called_once_with(command, False)
+
+    def test_add_nvenc_options(self) -> None:
+        """Test adding NVENC-specific options."""
+        command = []
+        stage = ClipTranscodingStage(encoder="h264_nvenc")
+
+        stage._add_nvenc_options(command, False)
+
+        # Verify NVENC options
+        nvenc_options = ["-rc:v", "vbr", "-cq:v", "21", "-tune", "hq"]
+        for option in nvenc_options:
+            assert option in command
+
+    def test_add_nvenc_options_with_pix_fmt(self) -> None:
+        """Test adding NVENC options with pixel format."""
+        command = []
+        stage = ClipTranscodingStage(encoder="h264_nvenc")
+
+        stage._add_nvenc_options(command, True)
+
+        # Should include pixel format
+        assert "-pix_fmt" in command
+        assert "yuv420p" in command
+
+    def test_add_output_options(self) -> None:
+        """Test adding output options to FFmpeg command."""
+        command = []
+        clip = self.mock_clips[0]
+
+        self.stage._add_output_options(command, clip, 0)
+
+        # Verify output options
+        assert "-threads" in command
+        assert "-map" in command
+        assert "0:a:0?" in command
+        assert "-c:a" in command
+        assert "copy" in command
+        assert f"{clip.uuid}.mp4" in command
+
+    @patch("ray_curator.stages.video.clipping.clip_extraction_stages.subprocess.check_output")
+    def test_run_ffmpeg_command_success(self, mock_subprocess: MagicMock) -> None:
+        """Test successful FFmpeg command execution."""
+        command = ["ffmpeg", "-version"]
+        working_dir = self.temp_dir / "ffmpeg_test"
+        clips = self.mock_clips
+
+        mock_subprocess.return_value = b"ffmpeg output"
+
+        # Should not raise any exception
+        self.stage._run_ffmpeg_command(command, working_dir, clips)
+
+        mock_subprocess.assert_called_once_with(
+            command, cwd=working_dir, stderr=subprocess.STDOUT
+        )
+
+    @patch("ray_curator.stages.video.clipping.clip_extraction_stages.subprocess.check_output")
+    def test_run_ffmpeg_command_verbose(self, mock_subprocess: MagicMock) -> None:
+        """Test FFmpeg command execution with verbose logging."""
+        stage = ClipTranscodingStage(verbose=True, ffmpeg_verbose=True)
+        command = ["ffmpeg", "-version"]
+        working_dir = self.temp_dir / "ffmpeg_verbose_test"
+        clips = self.mock_clips
+
+        mock_subprocess.return_value = b"ffmpeg output"
+
+        with patch("ray_curator.stages.video.clipping.clip_extraction_stages.logger") as mock_logger:
+            stage._run_ffmpeg_command(command, working_dir, clips)
+
+            # Should log the command
+            mock_logger.info.assert_called()
+            mock_logger.warning.assert_called()  # For ffmpeg output
+
+    @patch("ray_curator.stages.video.clipping.clip_extraction_stages.subprocess.check_output")
+    def test_run_ffmpeg_command_error(self, mock_subprocess: MagicMock) -> None:
+        """Test FFmpeg command execution with error."""
+        command = ["ffmpeg", "-invalid"]
+        working_dir = self.temp_dir / "ffmpeg_error_test"
+        clips = self.mock_clips
+
+        error = subprocess.CalledProcessError(1, command, b"error output")
+        mock_subprocess.side_effect = error
+
+        with patch.object(self.stage, "_handle_ffmpeg_error") as mock_handle:
+            self.stage._run_ffmpeg_command(command, working_dir, clips)
+
+            mock_handle.assert_called_once_with(error, command, clips)
+
+    def test_handle_ffmpeg_error(self) -> None:
+        """Test FFmpeg error handling."""
+        command = ["ffmpeg", "-invalid"]
+        clips = self.mock_clips
+        error = subprocess.CalledProcessError(1, command, b"error output")
+
+        with patch("ray_curator.stages.video.clipping.clip_extraction_stages.logger") as mock_logger:
+            self.stage._handle_ffmpeg_error(error, command, clips)
+
+            # Should log errors
+            assert mock_logger.error.call_count >= 2
+            mock_logger.warning.assert_called()
+
+            # Should add errors to clips
+            for clip in clips:
+                assert "transcode" in clip.errors
+                assert clip.errors["transcode"] == "error output"
+
+    def test_handle_ffmpeg_error_no_output(self) -> None:
+        """Test FFmpeg error handling when there's no error output."""
+        command = ["ffmpeg", "-invalid"]
+        clips = self.mock_clips
+        error = subprocess.CalledProcessError(1, command, None)
+
+        with patch("ray_curator.stages.video.clipping.clip_extraction_stages.logger"):
+            self.stage._handle_ffmpeg_error(error, command, clips)
+
+            # Should add string representation of error
+            for clip in clips:
+                assert "transcode" in clip.errors
+                assert str(error) in clip.errors["transcode"]
+
+    def test_read_clips_to_memory(self) -> None:
+        """Test reading clips back into memory."""
+        working_dir = self.temp_dir / "read_test"
+        clips = self.mock_clips
+
+        # Mock file reading
+        mock_file_data = b"mock_clip_data"
+
+        with patch("pathlib.Path.read_bytes") as mock_read:
+            mock_read.return_value = mock_file_data
+
+            self.stage._read_clips_to_memory(working_dir, clips)
+
+            # Should read each clip file
+            assert mock_read.call_count == len(clips)
+
+            # Should set buffer for each clip
+            for clip in clips:
+                assert clip.buffer == mock_file_data
+
+    def test_process_10_bit_color(self) -> None:
+        """Test processing with 10-bit color video."""
+        # Mock 10-bit color detection
+        with patch.object(self.mock_video, "is_10_bit_color", return_value=True), \
+             patch("ray_curator.stages.video.clipping.clip_extraction_stages.make_pipeline_temporary_dir") as mock_temp_dir, \
+             patch("ray_curator.stages.video.clipping.clip_extraction_stages.grouping.split_by_chunk_size") as mock_split, \
+             patch.object(self.stage, "_extract_clips") as mock_extract, \
+             patch("pathlib.Path.write_bytes"):
+
+            mock_temp_dir.return_value.__enter__.return_value = self.temp_dir
+            mock_split.return_value = [self.mock_video.clips]
+
+            self.stage.process(self.mock_task)
+
+            # Should pass force_pix_fmt=True
+            mock_extract.assert_called_once()
+            assert mock_extract.call_args[1]["force_pix_fmt"] is True
+
+    def test_process_logging_clip_stats(self) -> None:
+        """Test that clip statistics are logged during processing."""
+        with patch("ray_curator.stages.video.clipping.clip_extraction_stages.make_pipeline_temporary_dir") as mock_temp_dir, \
+             patch("ray_curator.stages.video.clipping.clip_extraction_stages.grouping.split_by_chunk_size") as mock_split, \
+             patch.object(self.stage, "_extract_clips"), \
+             patch("ray_curator.stages.video.clipping.clip_extraction_stages.logger") as mock_logger, \
+             patch("pathlib.Path.write_bytes"):
+
+            mock_temp_dir.return_value.__enter__.return_value = self.temp_dir
+            mock_split.return_value = [self.mock_video.clips]
+
+            self.stage.process(self.mock_task)
+
+            # Should log clip statistics
+            info_calls = [str(call) for call in mock_logger.info.call_args_list]
+            stats_calls = [call for call in info_calls if "clips and weight" in call]
+            assert len(stats_calls) > 0
+
+    def test_process_verbose_logging(self) -> None:
+        """Test verbose logging during processing."""
+        stage = ClipTranscodingStage(verbose=True)
+
+        with patch("ray_curator.stages.video.clipping.clip_extraction_stages.make_pipeline_temporary_dir") as mock_temp_dir, \
+             patch("ray_curator.stages.video.clipping.clip_extraction_stages.grouping.split_by_chunk_size") as mock_split, \
+             patch.object(stage, "_extract_clips"), \
+             patch("ray_curator.stages.video.clipping.clip_extraction_stages.logger") as mock_logger, \
+             patch("pathlib.Path.write_bytes"):
+
+            mock_temp_dir.return_value.__enter__.return_value = self.temp_dir
+            mock_split.return_value = [self.mock_video.clips[:1], self.mock_video.clips[1:]]  # Two chunks
+
+            stage.process(self.mock_task)
+
+            # Should log subtask spawning
+            info_calls = [str(call) for call in mock_logger.info.call_args_list]
+            spawn_calls = [call for call in info_calls if "Spawning subtask" in call]
+            assert len(spawn_calls) == 2  # One for each chunk
+
+    def test_different_encoder_configurations(self) -> None:
+        """Test various encoder configurations."""
+        test_configs = [
+            {"encoder": "libopenh264", "use_hwaccel": False},
+            {"encoder": "libx264", "use_hwaccel": False},
+            {"encoder": "h264_nvenc", "use_hwaccel": False},
+            {"encoder": "libx264", "use_hwaccel": True},
+        ]
+
+        for config in test_configs:
+            stage = ClipTranscodingStage(**config)
+
+            # Should not raise during setup
+            stage.setup()
+
+            # Should have appropriate resource requirements
+            resources = stage.resources
+            if config["encoder"] == "h264_nvenc" or config["use_hwaccel"]:
+                assert resources.entire_gpu
+            else:
+                assert resources.cpus > 0
+                assert not resources.entire_gpu
+
+    def test_batch_processing(self) -> None:
+        """Test processing clips in batches."""
+        stage = ClipTranscodingStage(encode_batch_size=1)  # Process one clip at a time
+
+        with patch("ray_curator.stages.video.clipping.clip_extraction_stages.make_pipeline_temporary_dir") as mock_temp_dir, \
+             patch("ray_curator.stages.video.clipping.clip_extraction_stages.grouping.split_by_chunk_size") as mock_split, \
+             patch.object(stage, "_extract_clips") as mock_extract, \
+             patch("pathlib.Path.write_bytes"):
+
+            mock_temp_dir.return_value.__enter__.return_value = self.temp_dir
+            mock_split.return_value = [self.mock_video.clips]
+
+            stage.process(self.mock_task)
+
+            # Should call _extract_clips twice (once per clip)
+            assert mock_extract.call_count == 2
+
+    def test_worker_metadata_setup(self) -> None:
+        """Test setup with worker metadata."""
+        worker_metadata = Mock(spec=WorkerMetadata)
+
+        # Should not raise any exception
+        self.stage.setup(worker_metadata)
+
+    def test_edge_case_empty_clips_after_debug_limit(self) -> None:
+        """Test edge case where debug mode results in empty clips."""
+        stage = ClipTranscodingStage(debug=True, encode_batch_size=1)
+
+        # Create a video with no clips
+        empty_video = Video(
+            input_video=pathlib.Path("test_video.mp4"),
+            source_bytes=b"mock_video_data",
+            metadata=self.mock_video.metadata,
+            clips=[]
+        )
+
+        empty_task = VideoTask(
+            task_id="test_task",
+            dataset_name="test_dataset",
+            data=empty_video
+        )
+
+        with patch("ray_curator.stages.video.clipping.clip_extraction_stages.logger") as mock_logger:
+            result = stage.process(empty_task)
+
+            # Should handle empty clips gracefully
+            assert result.data.source_bytes is None
+            mock_logger.warning.assert_called_once()
+            assert "No clips to transcode" in mock_logger.warning.call_args[0][0]

--- a/ray-curator/tests/stages/video/clipping/test_fixed_stride_extractor_stage.py
+++ b/ray-curator/tests/stages/video/clipping/test_fixed_stride_extractor_stage.py
@@ -1,0 +1,528 @@
+"""Unit tests for FixedStrideExtractorStage."""
+
+import pathlib
+import uuid
+from unittest.mock import patch
+
+import pytest
+
+from ray_curator.stages.video.clipping.clip_extraction_stages import FixedStrideExtractorStage
+from ray_curator.tasks import Clip, Video, VideoTask
+from ray_curator.tasks.video import VideoMetadata
+
+
+class TestFixedStrideExtractorStage:
+    """Test cases for FixedStrideExtractorStage."""
+
+    def setup_method(self):
+        """Set up test fixtures."""
+        self.stage = FixedStrideExtractorStage(
+            clip_len_s=5.0,
+            clip_stride_s=2.5,
+            min_clip_length_s=1.0,
+            limit_clips=10
+        )
+
+        # Create a mock video with complete metadata
+        self.mock_video = Video(
+            input_video=pathlib.Path("test_video.mp4"),
+            source_bytes=b"mock_video_data",
+            metadata=VideoMetadata(
+                height=1080,
+                width=1920,
+                framerate=30.0,
+                num_frames=900,  # 30 seconds at 30fps
+                duration=30.0,
+                video_codec="h264",
+                pixel_format="yuv420p",
+                audio_codec="aac",
+                bit_rate_k=5000
+            ),
+            clips=[]
+        )
+
+        self.mock_task = VideoTask(
+            task_id="test_task",
+            dataset_name="test_dataset",
+            data=self.mock_video
+        )
+
+    def test_name_property(self):
+        """Test that the name property returns the correct value."""
+        assert self.stage.name == "fixed_stride_extractor"
+
+    def test_inputs_outputs(self):
+        """Test that inputs and outputs return the correct values."""
+        inputs, _ = self.stage.inputs()
+        outputs, _ = self.stage.outputs()
+
+        assert inputs == ["data"]
+        assert outputs == ["data"]
+
+    def test_process_successful_extraction(self):
+        """Test successful clip extraction with valid video data."""
+        result = self.stage.process(self.mock_task)
+
+        assert isinstance(result, VideoTask)
+        assert result.task_id == "test_task"
+        assert result.dataset_name == "test_dataset"
+        assert len(result.data.clips) > 0
+
+        # Verify clip properties
+        for clip in result.data.clips:
+            assert isinstance(clip, Clip)
+            assert isinstance(clip.uuid, uuid.UUID)
+            assert clip.source_video == "test_video.mp4"
+            assert len(clip.span) == 2
+            assert clip.span[0] < clip.span[1]
+            assert (clip.span[1] - clip.span[0]) >= self.stage.min_clip_length_s
+
+    def test_process_no_source_bytes(self):
+        """Test processing when source_bytes is None."""
+        self.mock_video.source_bytes = None
+
+        with pytest.raises(ValueError, match="Video source bytes are not available"):
+            self.stage.process(self.mock_task)
+
+    def test_process_incomplete_metadata(self):
+        """Test processing when video has incomplete metadata."""
+        self.mock_video.metadata.framerate = None
+
+        result = self.stage.process(self.mock_task)
+
+        assert isinstance(result, VideoTask)
+        assert "metadata" in result.data.errors
+        assert result.data.errors["metadata"] == "incomplete"
+
+    def test_process_already_clipped(self):
+        """Test processing when video already has clips and limit is reached."""
+        # Add existing clips to reach the limit
+        for i in range(self.stage.limit_clips):
+            clip = Clip(
+                uuid=uuid.uuid4(),
+                source_video="test_video.mp4",
+                span=(i * 5.0, (i + 1) * 5.0)
+            )
+            self.mock_video.clips.append(clip)
+
+        result = self.stage.process(self.mock_task)
+
+        assert isinstance(result, VideoTask)
+        # Should return the same task without adding new clips
+        assert len(result.data.clips) == self.stage.limit_clips
+
+    def test_process_missing_framerate(self):
+        """Test processing when framerate is None."""
+        self.mock_video.metadata.framerate = None
+
+        result = self.stage.process(self.mock_task)
+
+        # Should return early with error logged due to incomplete metadata
+        assert isinstance(result, VideoTask)
+        assert "metadata" in result.data.errors
+        assert result.data.errors["metadata"] == "incomplete"
+
+    def test_process_missing_num_frames(self):
+        """Test processing when num_frames is None."""
+        self.mock_video.metadata.num_frames = None
+
+        result = self.stage.process(self.mock_task)
+
+        # Should return early with error logged due to incomplete metadata
+        assert isinstance(result, VideoTask)
+        assert "metadata" in result.data.errors
+        assert result.data.errors["metadata"] == "incomplete"
+
+    def test_process_zero_framerate(self):
+        """Test processing when framerate is zero."""
+        self.mock_video.metadata.framerate = 0.0
+
+        result = self.stage.process(self.mock_task)
+
+        # Should return early with error logged due to incomplete metadata
+        assert isinstance(result, VideoTask)
+        assert "metadata" in result.data.errors
+        assert result.data.errors["metadata"] == "incomplete"
+
+    def test_clip_generation_logic(self):
+        """Test that clips are generated with correct timing."""
+        # Create a video with specific duration
+        video = Video(
+            input_video=pathlib.Path("test_video.mp4"),
+            source_bytes=b"mock_video_data",
+            metadata=VideoMetadata(
+                height=1080,
+                width=1920,
+                framerate=30.0,
+                num_frames=600,  # 20 seconds at 30fps
+                duration=20.0,
+                video_codec="h264"
+            ),
+            clips=[]
+        )
+
+        task = VideoTask(
+            task_id="test_task",
+            dataset_name="test_dataset",
+            data=video
+        )
+
+        result = self.stage.process(task)
+
+        # Calculate expected clips
+        # clip_len_s=5.0, clip_stride_s=2.5, duration=20.0
+        # Expected clips: (0,5), (2.5,7.5), (5,10), (7.5,12.5), (10,15), (12.5,17.5), (15,20), (17.5,20)
+        expected_clips = [
+            (0.0, 5.0),
+            (2.5, 7.5),
+            (5.0, 10.0),
+            (7.5, 12.5),
+            (10.0, 15.0),
+            (12.5, 17.5),
+            (15.0, 20.0),
+            (17.5, 20.0)
+        ]
+
+        assert len(result.data.clips) == len(expected_clips)
+
+        for _i, (clip, expected_span) in enumerate(zip(result.data.clips, expected_clips, strict=False)):
+            assert clip.span == expected_span
+            assert clip.source_video == "test_video.mp4"
+
+            # Verify UUID generation
+            expected_start_event = int(expected_span[0] * video.metadata.framerate)
+            expected_end_event = int(expected_span[1] * video.metadata.framerate)
+            expected_uuid = uuid.uuid5(
+                uuid.NAMESPACE_URL,
+                f"test_video.mp4_{expected_start_event}_{expected_end_event}"
+            )
+            assert clip.uuid == expected_uuid
+
+    def test_min_clip_length_filtering(self):
+        """Test that clips shorter than min_clip_length_s are filtered out."""
+        # Create a stage with longer minimum clip length
+        stage = FixedStrideExtractorStage(
+            clip_len_s=2.0,
+            clip_stride_s=1.0,
+            min_clip_length_s=3.0,  # Longer than clip_len_s
+            limit_clips=10
+        )
+
+        video = Video(
+            input_video=pathlib.Path("test_video.mp4"),
+            source_bytes=b"mock_video_data",
+            metadata=VideoMetadata(
+                height=1080,
+                width=1920,
+                framerate=30.0,
+                num_frames=600,  # 20 seconds
+                duration=20.0,
+                video_codec="h264"
+            ),
+            clips=[]
+        )
+
+        task = VideoTask(
+            task_id="test_task",
+            dataset_name="test_dataset",
+            data=video
+        )
+
+        result = stage.process(task)
+
+        # All clips should be filtered out because they're shorter than min_clip_length_s
+        assert len(result.data.clips) == 0
+
+    def test_limit_clips_enforcement(self):
+        """Test that the limit_clips parameter is respected when clips already exist."""
+        stage = FixedStrideExtractorStage(
+            clip_len_s=1.0,
+            clip_stride_s=0.5,
+            min_clip_length_s=0.5,
+            limit_clips=3  # Limit to 3 clips
+        )
+
+        video = Video(
+            input_video=pathlib.Path("test_video.mp4"),
+            source_bytes=b"mock_video_data",
+            metadata=VideoMetadata(
+                height=1080,
+                width=1920,
+                framerate=30.0,
+                num_frames=900,  # 30 seconds
+                duration=30.0,
+                video_codec="h264"
+            ),
+            clips=[]
+        )
+
+        # Add existing clips to reach the limit
+        for i in range(stage.limit_clips):
+            clip = Clip(
+                uuid=uuid.uuid4(),
+                source_video="test_video.mp4",
+                span=(i * 1.0, (i + 1) * 1.0)
+            )
+            video.clips.append(clip)
+
+        task = VideoTask(
+            task_id="test_task",
+            dataset_name="test_dataset",
+            data=video
+        )
+
+        result = stage.process(task)
+
+        # Should return the same task without adding new clips
+        assert len(result.data.clips) == stage.limit_clips
+
+    def test_no_limit_clips(self):
+        """Test behavior when limit_clips is 0 (no limit)."""
+        stage = FixedStrideExtractorStage(
+            clip_len_s=5.0,
+            clip_stride_s=2.5,
+            min_clip_length_s=1.0,
+            limit_clips=0  # No limit
+        )
+
+        result = stage.process(self.mock_task)
+
+        # Should generate all possible clips without limit
+        assert len(result.data.clips) > 0
+        # With 30 second video, 5s clips, 2.5s stride: should have 12 clips
+        assert len(result.data.clips) == 12
+
+    def test_edge_case_very_short_video(self):
+        """Test behavior with very short video."""
+        video = Video(
+            input_video=pathlib.Path("test_video.mp4"),
+            source_bytes=b"mock_video_data",
+            metadata=VideoMetadata(
+                height=1080,
+                width=1920,
+                framerate=30.0,
+                num_frames=30,  # 1 second
+                duration=1.0,
+                video_codec="h264"
+            ),
+            clips=[]
+        )
+
+        task = VideoTask(
+            task_id="test_task",
+            dataset_name="test_dataset",
+            data=video
+        )
+
+        result = self.stage.process(task)
+
+        # Should have one clip from 0.0 to 1.0 (min(clip_len_s, duration))
+        assert len(result.data.clips) == 1
+        assert result.data.clips[0].span == (0.0, 1.0)
+
+    def test_edge_case_exact_clip_length(self):
+        """Test behavior when video duration exactly matches clip length."""
+        video = Video(
+            input_video=pathlib.Path("test_video.mp4"),
+            source_bytes=b"mock_video_data",
+            metadata=VideoMetadata(
+                height=1080,
+                width=1920,
+                framerate=30.0,
+                num_frames=150,  # 5 seconds (exactly clip_len_s)
+                duration=5.0,
+                video_codec="h264"
+            ),
+            clips=[]
+        )
+
+        task = VideoTask(
+            task_id="test_task",
+            dataset_name="test_dataset",
+            data=video
+        )
+
+        result = self.stage.process(task)
+
+        # Should have two clips: (0.0, 5.0) and (2.5, 5.0)
+        assert len(result.data.clips) == 2
+        assert result.data.clips[0].span == (0.0, 5.0)
+        assert result.data.clips[1].span == (2.5, 5.0)
+
+    def test_logging_behavior(self):
+        """Test that appropriate logging occurs during processing."""
+        with patch("ray_curator.stages.video.clipping.clip_extraction_stages.logger") as mock_logger:
+            self.stage.process(self.mock_task)
+
+            # Verify that info logging occurred
+            mock_logger.info.assert_called_once()
+            call_args = mock_logger.info.call_args[0][0]
+            assert "Extracted" in call_args
+            assert "clips from" in call_args
+            assert "test_video.mp4" in call_args
+
+    def test_clip_uuid_uniqueness(self):
+        """Test that generated clip UUIDs are unique."""
+        result = self.stage.process(self.mock_task)
+
+        uuids = [clip.uuid for clip in result.data.clips]
+        assert len(uuids) == len(set(uuids))  # All UUIDs should be unique
+
+    def test_clip_span_ordering(self):
+        """Test that clips are generated in chronological order."""
+        result = self.stage.process(self.mock_task)
+
+        for i in range(len(result.data.clips) - 1):
+            current_clip = result.data.clips[i]
+            next_clip = result.data.clips[i + 1]
+
+            # Each clip should start after or at the same time as the previous one
+            assert current_clip.span[0] <= next_clip.span[0]
+            # Clips can overlap based on stride settings
+
+    def test_different_parameter_combinations(self):
+        """Test various parameter combinations."""
+        test_cases = [
+            # format as: (clip_len_s, clip_stride_s, min_clip_length_s, limit_clips)
+            (1.0, 0.5, 0.5, 5),
+            (5.0, 10.0, 2.0, 0),  # Non-overlapping clips with reasonable min length
+            (2.0, 1.0, 1.5, 3),
+            (3.0, 3.0, 1.0, 10),  # No overlap between clips
+        ]
+
+        for clip_len_s, clip_stride_s, min_clip_length_s, limit_clips in test_cases:
+            stage = FixedStrideExtractorStage(
+                clip_len_s=clip_len_s,
+                clip_stride_s=clip_stride_s,
+                min_clip_length_s=min_clip_length_s,
+                limit_clips=limit_clips
+            )
+
+            # Create a fresh video for each test case
+            video = Video(
+                input_video=pathlib.Path("test_video.mp4"),
+                source_bytes=b"mock_video_data",
+                metadata=VideoMetadata(
+                    height=1080,
+                    width=1920,
+                    framerate=30.0,
+                    num_frames=900,  # 30 seconds at 30fps
+                    duration=30.0,
+                    video_codec="h264",
+                    pixel_format="yuv420p",
+                    audio_codec="aac",
+                    bit_rate_k=5000
+                ),
+                clips=[]
+            )
+
+            task = VideoTask(
+                task_id="test_task",
+                dataset_name="test_dataset",
+                data=video
+            )
+
+            result = stage.process(task)
+
+            # Basic validation
+            assert isinstance(result, VideoTask)
+            assert len(result.data.clips) >= 0
+
+            # Validate clip properties
+            for clip in result.data.clips:
+                assert clip.span[1] - clip.span[0] >= min_clip_length_s
+                assert clip.source_video == "test_video.mp4"
+
+    def test_limit_clips_generation(self):
+        """Test that limit_clips doesn't limit generation of new clips (current behavior)."""
+        stage = FixedStrideExtractorStage(
+            clip_len_s=1.0,
+            clip_stride_s=0.5,
+            min_clip_length_s=0.5,
+            limit_clips=3  # This currently only applies to existing clips
+        )
+
+        video = Video(
+            input_video=pathlib.Path("test_video.mp4"),
+            source_bytes=b"mock_video_data",
+            metadata=VideoMetadata(
+                height=1080,
+                width=1920,
+                framerate=30.0,
+                num_frames=150,  # 5 seconds
+                duration=5.0,
+                video_codec="h264"
+            ),
+            clips=[]
+        )
+
+        task = VideoTask(
+            task_id="test_task",
+            dataset_name="test_dataset",
+            data=video
+        )
+
+        result = stage.process(task)
+
+        # Currently, limit_clips doesn't limit generation, only prevents processing if clips exist
+        # For a 5s video with 1s clips and 0.5s stride, we expect 10 clips
+        assert len(result.data.clips) == 10  # Not limited to 3
+
+    def test_metadata_validation_edge_cases(self):
+        """Test various metadata validation scenarios."""
+        # Test with missing video_codec (should still work)
+        video = Video(
+            input_video=pathlib.Path("test_video.mp4"),
+            source_bytes=b"mock_video_data",
+            metadata=VideoMetadata(
+                height=1080,
+                width=1920,
+                framerate=30.0,
+                num_frames=150,
+                duration=5.0,
+                video_codec=None  # Missing codec
+            ),
+            clips=[]
+        )
+
+        task = VideoTask(
+            task_id="test_task",
+            dataset_name="test_dataset",
+            data=video
+        )
+
+        result = self.stage.process(task)
+
+        # Should return early with incomplete metadata error
+        assert isinstance(result, VideoTask)
+        assert "metadata" in result.data.errors
+        assert result.data.errors["metadata"] == "incomplete"
+
+    def test_negative_duration_calculation(self):
+        """Test the edge case where duration calculation might be negative."""
+        # Create a video with very small num_frames compared to framerate
+        video = Video(
+            input_video=pathlib.Path("test_video.mp4"),
+            source_bytes=b"mock_video_data",
+            metadata=VideoMetadata(
+                height=1080,
+                width=1920,
+                framerate=30.0,
+                num_frames=1,  # Very small number of frames
+                duration=0.033,  # About 1/30 second
+                video_codec="h264"
+            ),
+            clips=[]
+        )
+
+        task = VideoTask(
+            task_id="test_task",
+            dataset_name="test_dataset",
+            data=video
+        )
+
+        result = self.stage.process(task)
+
+        # Should process successfully but likely generate no clips due to min_clip_length_s
+        assert isinstance(result, VideoTask)
+        assert len(result.data.clips) == 0  # No clips meet minimum length requirement


### PR DESCRIPTION
…ding stages

Note this requires https://github.com/NVIDIA-NeMo/Curator/pull/775 to be merged first (currently the base is set to `aot/;ray-video-reader` instead of `ray-api`)
- Introduced `video_split_clip_example.py` to demonstrate video splitting functionality.
- Added `ClipTranscodingStage` and `FixedStrideExtractorStage` for processing video clips.
- Implemented command-line arguments for configuring video processing parameters.
- Created utility functions for grouping iterables in `grouping.py`.
- Added unit tests for the new stages in `test_clip_transcoding_stage.py` and `test_fixed_stride_extractor_stage.py`.

## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->

## Usage
<!-- Potentially add a usage example below -->
```python

python Curator/ray-curator/ray_curator/examples/video/video_split_clip_example.py --debug --verbose
```
## Checklist
<!--
Note: All commits need to be signed and signed off. This can be done via `-sS` flags while commiting
`git commit -sS -m "...."
-->
- [ ] I am familiar with the [Contributing Guide](https://github.com/NVIDIA/NeMo-Curator/blob/main/CONTRIBUTING.md).
- [ ] New or Existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
