### PR TITLE
Auto label PRs with the ray-api label

### DIFF
--- a/.github/workflows/auto-labler.yml
+++ b/.github/workflows/auto-labler.yml
@@ -1,0 +1,18 @@
+name: Label PRs to main
+
+on:
+  pull_request:
+    branches: [main]              # base branch filter
+
+permissions:
+  pull-requests: write            # needed to add labels
+
+jobs:
+  add-ray-api-label:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Add ray-api label
+        uses: actions-ecosystem/action-add-labels@v1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          labels: ray-api


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
To ensure than any changes to main are synced with the ray-api branch, this is a simple workflow adding the `ray-api` label to PR's targeting main. This will ensure that the cherry-pick workflow also opens an equivalent PR to the ray-api branch

## Usage
<!-- Potentially add a usage example below -->
N/A

## Checklist
<!--
Note: All commits need to be signed and signed off. This can be done via `-sS` flags while commiting
`git commit -sS -m "...."
-->
- [X] I am familiar with the [Contributing Guide](https://github.com/NVIDIA/NeMo-Curator/blob/main/CONTRIBUTING.md).
- [NA] New or Existing tests cover these changes.
- [NA] The documentation is up to date with these changes.
