### PR TITLE
Update ray-api auto label action trigger

### DIFF
--- a/.github/workflows/auto-labler.yml
+++ b/.github/workflows/auto-labler.yml
@@ -1,7 +1,7 @@
 name: Label PRs to main
 
 on:
-  pull_request:
+  pull_request_target:
     branches: [main]              # base branch filter
 
 permissions:


### PR DESCRIPTION


## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
Should fix cases like those seen in https://github.com/NVIDIA-NeMo/Curator/actions/runs/16532147074?pr=826 happening because changes are in a fork where the write perms using the upstream token leads to errors.

Thanks @sarahyurick for spotting that there's an issue with the workflow! 

## Usage
<!-- Potentially add a usage example below -->
N/A

## Checklist
<!--
Note: All commits need to be signed and signed off. This can be done via `-sS` flags while commiting
`git commit -sS -m "...."
-->
- [X] I am familiar with the [Contributing Guide](https://github.com/NVIDIA/NeMo-Curator/blob/main/CONTRIBUTING.md).
- [NA] New or Existing tests cover these changes.
- [NA] The documentation is up to date with these changes.
