### PR TITLE
[Ray][DO NOT MERGE] Repro for Ray Data and backpressure in Common Crawl Pipeline

### DIFF
--- a/ray-curator/ray_curator/examples/common_crawl_example_do_not_commit.py
+++ b/ray-curator/ray_curator/examples/common_crawl_example_do_not_commit.py
@@ -1,0 +1,203 @@
+"""Example script for downloading and processing Common Crawl data."""
+
+import argparse
+import time
+from pathlib import Path
+from pprint import pprint
+from typing import Literal
+
+from loguru import logger
+
+from ray_curator.backends.xenna import XennaExecutor
+from ray_curator.pipeline import Pipeline
+from ray_curator.stages.download.text.common_crawl import CommonCrawlDownloadExtractStage
+from ray_curator.stages.io.writer import JsonlWriter, ParquetWriter
+from ray_curator.tasks import _EmptyTask
+
+
+def create_common_crawl_pipeline(  # noqa: PLR0913
+    download_dir: Path,
+    output_dir: Path,
+    output_format: Literal["parquet", "jsonl"],
+    crawl_type: Literal["main", "news"],
+    start_snapshot: str,
+    end_snapshot: str,
+    html_extraction_algorithm: str = "justext",
+    use_aws_to_download: bool = False,
+    verbose: bool = False,
+    url_limit: int | None = None,
+    record_limit: int | None = None,
+    add_filename_column: bool = False,
+) -> Pipeline:
+    """Create a pipeline for downloading and processing Common Crawl data.
+
+    Args:
+        download_dir: Directory to download WARC files to
+        output_dir: Directory to write output files to
+        output_format: Format of output files (parquet or jsonl)
+        crawl_type: Type of Common Crawl (main or news)
+        start_snapshot: Start snapshot string (YYYY-WW for main, YYYY-MM for news)
+        end_snapshot: End snapshot string (YYYY-WW for main, YYYY-MM for news)
+        html_extraction_algorithm: Algorithm to use for HTML extraction
+        use_aws_to_download: Whether to use AWS S3 for downloading
+        verbose: Whether to print verbose output
+        limit: Limit the number of WARC files to process
+
+    Returns:
+        Pipeline: Configured pipeline
+    """
+    # Define pipeline
+    pipeline = Pipeline(name="common_crawl_processing", description="Download and process Common Crawl data")
+
+    # Add Common Crawl pipeline stage
+    # The CommonCrawlPipeline is a CompositeStage that will be decomposed
+    # into its constituent stages during pipeline building
+    pipeline.add_stage(
+        CommonCrawlDownloadExtractStage(
+            start_snapshot=start_snapshot,
+            end_snapshot=end_snapshot,
+            download_dir=str(download_dir),
+            crawl_type=crawl_type,
+            html_extraction=html_extraction_algorithm,
+            use_aws_to_download=use_aws_to_download,
+            verbose=verbose,
+            url_limit=url_limit,
+            record_limit=record_limit,
+            add_filename_column=add_filename_column,
+        )
+    )
+
+    # Add writer stage
+    if output_format == "jsonl":
+        writer = JsonlWriter(output_dir=str(output_dir))
+    elif output_format == "parquet":
+        writer = ParquetWriter(output_dir=str(output_dir))
+    else:
+        msg = f"Invalid output format: {output_format}"
+        raise ValueError(msg)
+
+    pipeline.add_stage(writer)
+
+    return pipeline
+
+
+def main(args: argparse.Namespace) -> None:
+    """Main function to run the pipeline."""
+    # Create directories
+    download_dir = Path(args.download_path).resolve()
+    download_dir.mkdir(exist_ok=True, parents=True)
+
+    output_dir = Path(args.output_path).resolve()
+    output_dir.mkdir(exist_ok=True, parents=True)
+
+    # Create pipeline
+    pipeline = create_common_crawl_pipeline(
+        download_dir=download_dir,
+        output_dir=output_dir,
+        output_format=args.output_format,
+        crawl_type=args.crawl_type,
+        start_snapshot=args.start_snapshot,
+        end_snapshot=args.end_snapshot,
+        html_extraction_algorithm=args.html_extraction,
+        use_aws_to_download=args.aws,
+        verbose=args.verbose,
+        url_limit=args.url_limit,
+        record_limit=args.record_limit,
+        add_filename_column=args.add_filename_column,
+    )
+
+    # Print pipeline description
+    print(pipeline.describe())
+    print("\n" + "=" * 50 + "\n")
+
+    # Create executor
+    if args.executor == "xenna":
+        executor = XennaExecutor()
+    elif args.executor == "ray_data":
+        from ray_curator.backends.experimental.ray_data import RayDataExecutor
+
+        executor = RayDataExecutor()
+    elif args.executor == "ray_actors":
+        from ray_curator.backends.experimental.ray_actors import RayActorExecutor
+
+        executor = RayActorExecutor()
+    else:
+        msg = f"Invalid executor type: {args.executor}"
+        raise ValueError(msg)
+
+    # Create initial task
+    initial_task = _EmptyTask(task_id="common_crawl_task", dataset_name="common_crawl", data=None)
+
+    # Execute pipeline
+    print("Starting pipeline execution...")
+    results = pipeline.run(executor, initial_tasks=[initial_task])
+
+    # Print results summary
+    print("\nPipeline completed!")
+    print(f"Total output tasks: {len(results) if results else 0}")
+
+    total_documents = sum(task.num_items for task in results) if results else 0
+    print(f"Total documents processed: {total_documents}")
+
+    # Print sample of results
+    if results:
+        print("\nSample of processed documents:")
+        for task in results:
+            pprint(task)
+            print("\n" + "=" * 50 + "\n")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Download and process Common Crawl data")
+
+    # Pipeline configuration
+    parser.add_argument(
+        "--download_path", type=str, default="./common_crawl_downloads", help="Directory to download WARC files to"
+    )
+    parser.add_argument(
+        "--output_path", type=str, default="./common_crawl_output", help="Directory to write output files to"
+    )
+    parser.add_argument(
+        "--output_format", type=str, default="parquet", choices=["parquet", "jsonl"], help="Format of output files"
+    )
+
+    # Common Crawl configuration
+    parser.add_argument(
+        "--crawl_type", type=str, default="main", choices=["main", "news"], help="Type of Common Crawl (main or news)"
+    )
+    parser.add_argument(
+        "--start_snapshot",
+        type=str,
+        default="2023-01",
+        help="Start snapshot string (YYYY-WW for main, YYYY-MM for news)",
+    )
+    parser.add_argument(
+        "--end_snapshot", type=str, default="2023-10", help="End snapshot string (YYYY-WW for main, YYYY-MM for news)"
+    )
+    parser.add_argument(
+        "--html_extraction",
+        type=str,
+        default="justext",
+        choices=["justext", "resiliparse", "trafilatura"],
+        help="Algorithm to use for HTML extraction",
+    )
+    parser.add_argument("--aws", action="store_true", help="Use AWS S3 for downloading")
+    parser.add_argument("--verbose", action="store_true", help="Print verbose output")
+    parser.add_argument("--url_limit", type=int, default=5, help="Limit the number of WARC files to process")
+    parser.add_argument("--record_limit", type=int, default=None, help="Limit the number of records to process")
+    parser.add_argument("--add_filename_column", action="store_true", help="Add filename column to output")
+
+    # Executor configuration
+    parser.add_argument(
+        "--executor",
+        type=str,
+        default="xenna",
+        choices=["xenna", "ray_data", "ray_actors"],
+        help="Executor to use for pipeline",
+    )
+
+    args = parser.parse_args()
+    start_time = time.perf_counter()
+    main(args)
+    end_time = time.perf_counter()
+    logger.success(f"Time taken: {end_time - start_time} seconds")

--- a/ray-curator/ray_curator/stages/download/text/base/download.py
+++ b/ray-curator/ray_curator/stages/download/text/base/download.py
@@ -150,3 +150,6 @@ class DocumentDownloadStage(ProcessingStage[FileGroupTask, FileGroupTask]):
         return {
             "num_workers_per_node": self.downloader.num_workers_per_node(),
         }
+
+    def ray_stage_spec(self) -> dict[str, Any]:
+        return {"is_actor_stage": True}

--- a/ray-curator/ray_curator/stages/download/text/base/extract.py
+++ b/ray-curator/ray_curator/stages/download/text/base/extract.py
@@ -95,3 +95,6 @@ class DocumentExtractStage(ProcessingStage[DocumentBatch, DocumentBatch]):
             },
             _stage_perf=task._stage_perf,
         )
+
+    def ray_stage_spec(self) -> dict[str, Any]:
+        return {"is_actor_stage": True}

--- a/ray-curator/ray_curator/stages/download/text/base/iterator.py
+++ b/ray-curator/ray_curator/stages/download/text/base/iterator.py
@@ -96,3 +96,6 @@ class DocumentIterateStage(ProcessingStage[FileGroupTask, DocumentBatch]):
             },
             _stage_perf=task._stage_perf,
         )
+
+    def ray_stage_spec(self) -> dict[str, Any]:
+        return {"is_actor_stage": True}

--- a/ray-curator/ray_curator/stages/io/writer/dataframe.py
+++ b/ray-curator/ray_curator/stages/io/writer/dataframe.py
@@ -86,3 +86,6 @@ class BaseWriter(ProcessingStage[DocumentBatch, FileGroupTask], ABC):
             },
             _stage_perf=task._stage_perf,
         )
+
+    def ray_stage_spec(self) -> dict[str, Any]:
+        return {"is_actor_stage": True}


### PR DESCRIPTION
## Description

1. started a 64 cpu ray cluster at port 1234
2. Ran with `RAY_ADDRESS=localhost:1234 python common_crawl.py --executor ray_data --url_limit 768`

### Ray Data Logs
[common_crawl_2.48.log](https://github.com/user-attachments/files/21627812/common_crawl_2.48.log) (this is when download was still in progress)

### Observations

<img width="2915" height="275" alt="image" src="https://github.com/user-attachments/assets/9cc74d58-7671-4b54-98ef-57e2cb28aeb2" />

If you notice ideally it'll slow down `Download` since there is a big output queue anyway, and increase num workers for `Iterate` followed by increase workers for `Extract`.

Whereas we notice ~60 workers for Download even though there is a big enough pile of work to be done, while Iterate only has ~2 workers and similarly Extract has ~2 workers. The time taken per task is Extract >>> Download >> Iterate. So it should increase workers for Extract rather than keeping it minimum

One theory is Download produces a `FileGroupTask` which is lightweight (since it's just a pointer to the downloaded file on local), while `Iterate` reads and produces a `DocumentBatch` which is a pd.DataFrame i.e. much heavier and `Extract` also reads and produces a `pd.DataFrame` (think of this as a filter + transformation on output of `Iterate`).
And because the output size of `Iterate` is much larger, Ray Data doesn't increase workers so as to avoid pressure on object store. However if it were to increase workers for both Iterate and Extract, s.t. Iterate produces a DocumentBatch and it gets consumed by Extract, I'd imagine the memory consumption is constant (since pd.DataFrame is produced and immediately consumed). 


<img width="2902" height="279" alt="image" src="https://github.com/user-attachments/assets/4a820abe-2dd1-49c8-a4ac-c02ca1ee3f10" /> (this is when download has completed and we see only 13 / 64 cpus being used)



## Usage
<!-- Potentially add a usage example below -->
```python
# Add snippet demonstrating usage
```
## Checklist
<!--
Note: All commits need to be signed and signed off. This can be done via `-sS` flags while commiting
`git commit -sS -m "...."
-->
- [ ] I am familiar with the [Contributing Guide](https://github.com/NVIDIA/NeMo-Curator/blob/main/CONTRIBUTING.md).
- [ ] New or Existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
