### PR TITLE
Fix exception when blocksize is set

### DIFF
--- a/nemo_curator/utils/distributed_utils.py
+++ b/nemo_curator/utils/distributed_utils.py
@@ -513,7 +513,7 @@ def read_data_files_per_partition(  # noqa: PLR0913
     else:
         read_func_single_partition_kwargs = kwargs
 
-    if files_per_partition > 1:
+    if files_per_partition is not None and files_per_partition > 1:
         input_files = [
             input_files[i : i + files_per_partition] for i in range(0, len(input_files), files_per_partition)
         ]


### PR DESCRIPTION
## Description
If blocksize is set instead of files_per_partition, this line raised an exception.

## Usage
<!-- Potentially add a usage example below -->
```python
# Add snippet demonstrating usage
```
## Checklist
<!--
Note: All commits need to be signed and signed off. This can be done via `-sS` flags while commiting
`git commit -sS -m "...."
-->
- [x] I am familiar with the [Contributing Guide](https://github.com/NVIDIA/NeMo-Curator/blob/main/CONTRIBUTING.md).
- [ ] New or Existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
