### PR TITLE
Add Text Embedding Model

### DIFF
--- a/ray-curator/ray_curator/__init__.py
+++ b/ray-curator/ray_curator/__init__.py
@@ -1,5 +1,7 @@
 import os
 
+os.environ["RAPIDS_NO_INITIALIZE"] = "1"
+
 from cosmos_xenna.ray_utils.cluster import API_LIMIT
 
 # We set these incase a user ever starts a ray cluster with ray_curator, we need these for Xenna to work

--- a/ray-curator/ray_curator/stages/text/classifiers/aegis.py
+++ b/ray-curator/ray_curator/stages/text/classifiers/aegis.py
@@ -215,7 +215,9 @@ class AegisModelStage(ModelStage):
     def setup(self, _: WorkerMetadata | None = None) -> None:
         self._setup(local_files_only=True)
 
-    def process_model_output(self, outputs: torch.Tensor) -> dict[str, np.ndarray]:
+    def process_model_output(
+        self, outputs: torch.Tensor, _: dict[str, torch.Tensor] | None = None
+    ) -> dict[str, np.ndarray]:
         preds = outputs.cpu().numpy()
         return {
             self.pred_column: preds,

--- a/ray-curator/ray_curator/stages/text/classifiers/base.py
+++ b/ray-curator/ray_curator/stages/text/classifiers/base.py
@@ -130,7 +130,9 @@ class ClassifierModelStage(ModelStage):
         self.labels = list(config.label2id.keys())
         self.labels.sort(key=lambda x: config.label2id[x])
 
-    def process_model_output(self, outputs: torch.Tensor) -> dict[str, np.ndarray]:
+    def process_model_output(
+        self, outputs: torch.Tensor, _: dict[str, torch.Tensor] | None = None
+    ) -> dict[str, np.ndarray]:
         probs = outputs.cpu().numpy()
         preds = np.argmax(probs, axis=1)
 

--- a/ray-curator/ray_curator/stages/text/classifiers/prompt_task_complexity.py
+++ b/ray-curator/ray_curator/stages/text/classifiers/prompt_task_complexity.py
@@ -257,7 +257,9 @@ class PromptTaskComplexityModelStage(ModelStage):
         self.model = CustomDeberta.from_pretrained(self.model_identifier, local_files_only=True).cuda().eval()
         self.model.set_autocast(self.autocast)
 
-    def process_model_output(self, outputs: torch.Tensor) -> dict[str, np.ndarray]:
+    def process_model_output(
+        self, outputs: torch.Tensor, _: dict[str, torch.Tensor] | None = None
+    ) -> dict[str, np.ndarray]:
         return outputs
 
     def create_output_dataframe(self, df_cpu: pd.DataFrame, collected_output: dict[str, np.ndarray]) -> pd.DataFrame:

--- a/ray-curator/ray_curator/stages/text/classifiers/prompt_task_complexity.py
+++ b/ray-curator/ray_curator/stages/text/classifiers/prompt_task_complexity.py
@@ -257,9 +257,7 @@ class PromptTaskComplexityModelStage(ModelStage):
         self.model = CustomDeberta.from_pretrained(self.model_identifier, local_files_only=True).cuda().eval()
         self.model.set_autocast(self.autocast)
 
-    def process_model_output(
-        self, outputs: torch.Tensor, _: dict[str, torch.Tensor] | None = None
-    ) -> dict[str, np.ndarray]:
+    def process_model_output(self, outputs: torch.Tensor, _: dict[str, torch.Tensor] | None = None) -> torch.Tensor:
         return outputs
 
     def create_output_dataframe(self, df_cpu: pd.DataFrame, collected_output: dict[str, np.ndarray]) -> pd.DataFrame:

--- a/ray-curator/ray_curator/stages/text/embedders/__init__.py
+++ b/ray-curator/ray_curator/stages/text/embedders/__init__.py
@@ -1,0 +1,3 @@
+from .base import DistributedEmbeddingModelStage
+
+__all__ = ["DistributedEmbeddingModelStage"]

--- a/ray-curator/ray_curator/stages/text/embedders/base.py
+++ b/ray-curator/ray_curator/stages/text/embedders/base.py
@@ -1,0 +1,142 @@
+import os
+from dataclasses import dataclass
+from typing import Literal
+
+import cudf
+import cupy as cp
+import pandas as pd
+import torch
+import torch.nn.functional as F  # noqa: N812
+from crossfit.backend.cudf.series import create_list_series_from_1d_or_2d_ar
+from transformers import AutoModel
+
+from ray_curator.backends.base import WorkerMetadata
+from ray_curator.stages.text.models.model import ModelStage
+from ray_curator.stages.text.models.tokenizer import TokenizerStage
+from ray_curator.stages.text.models.utils import ATTENTION_MASK_COLUMN
+
+os.environ["RAPIDS_NO_INITIALIZE"] = "1"
+
+
+from ray_curator.stages.base import CompositeStage, ProcessingStage
+from ray_curator.tasks import DocumentBatch
+
+
+class EmbeddingModelStage(ModelStage):
+    """HuggingFace model stage that produces embeddings with pooling."""
+
+    def __init__(  # noqa: PLR0913
+        self,
+        model_identifier: str,
+        embedding_field: str = "embeddings",
+        pooling: Literal["mean_pooling", "last_token"] = "mean_pooling",
+        hf_token: str | None = None,
+        model_inference_batch_size: int = 256,
+        has_seq_order: bool = True,
+        padding_side: Literal["left", "right"] = "right",
+    ):
+        super().__init__(
+            model_identifier=model_identifier,
+            hf_token=hf_token,
+            model_inference_batch_size=model_inference_batch_size,
+            has_seq_order=has_seq_order,
+            padding_side=padding_side,
+            unpack_inference_batch=True,
+        )
+        self.embedding_field = embedding_field
+        self.pooling = pooling
+
+    def outputs(self) -> tuple[list[str], list[str]]:
+        return ["data"], [self.embedding_field]
+
+    def setup(self, _: WorkerMetadata | None = None) -> None:
+        """Load the model for inference."""
+        self.model = AutoModel.from_pretrained(self.model_identifier, local_files_only=True)
+        self.model.eval()
+        self.model.to("cuda")
+
+    def process_model_output(
+        self, outputs: torch.Tensor, model_input_batch: dict[str, torch.Tensor] | None = None
+    ) -> torch.Tensor:
+        """Process model outputs to create embeddings."""
+        if self.pooling == "mean_pooling":
+            return self._mean_pooling(outputs, model_input_batch[ATTENTION_MASK_COLUMN])
+        else:
+            return self._get_last_token(outputs, model_input_batch[ATTENTION_MASK_COLUMN])
+
+    def collect_outputs(self, processed_outputs: list[torch.Tensor]) -> cp.ndarray:
+        """Collect embeddings into a cupy array."""
+        # TODO : benchmarking this and maybe stay in cpu land
+        cupy_array_embeddings = [cp.asarray(emb_chunk) for emb_chunk in processed_outputs]
+        return cp.concatenate(cupy_array_embeddings, axis=0)
+
+    def create_output_dataframe(self, df_cpu: pd.DataFrame, collected_output: cp.ndarray) -> pd.DataFrame:
+        """Create output dataframe with embeddings."""
+        # TODO: Consider if it even makes sense to goto cudf or just concat in numpy
+        df_gpu = cudf.DataFrame(index=df_cpu.index)
+        df_gpu[self.embedding_field] = create_list_series_from_1d_or_2d_ar(collected_output, index=df_gpu.index)
+        # Add embedding_field back to cpu dataframe
+        df_cpu[self.embedding_field] = df_gpu.to_pandas()[self.embedding_field]
+        del df_gpu
+        return df_cpu
+
+    def _mean_pooling(self, model_output: torch.Tensor, attention_mask: torch.Tensor) -> torch.Tensor:
+        token_embeddings = model_output[0]
+        # Mask out irrelevant tokens directly without expanding the mask
+        masked_embeddings = token_embeddings.masked_fill(attention_mask.unsqueeze(-1) == 0, 0.0)
+        sum_embeddings = masked_embeddings.sum(dim=1)
+        sum_mask = attention_mask.sum(dim=1, keepdim=True).clamp(min=1e-9)
+        return F.normalize(sum_embeddings / sum_mask, dim=1)
+
+    def _get_last_token(self, model_output: torch.Tensor, attention_mask: torch.Tensor) -> torch.Tensor:
+        token_embeddings = model_output[0]
+        # Get indices of last non-padded tokens for each sequence in batch
+        last_token_indices = attention_mask.sum(dim=1) - 1  # -1 for 0-based indexing
+        last_token_indices = last_token_indices.to(torch.long)  # Ensure indices are of type long
+        batch_size = attention_mask.size(0)
+        batch_indices = torch.arange(batch_size, device=attention_mask.device)
+        # Get embeddings of last non-padded tokens
+        last_token_embeddings = token_embeddings[batch_indices, last_token_indices]
+        return F.normalize(last_token_embeddings, dim=1)
+
+
+@dataclass(kw_only=True)
+class DistributedEmbeddingModelStage(CompositeStage[DocumentBatch, DocumentBatch]):
+    model_identifier: str
+    text_field: str = "text"
+    embedding_field: str = "embeddings"
+    max_chars: int | None = None
+    max_seq_length: int | None = None
+    padding_side: Literal["left", "right"] = "right"
+    embedding_pooling: Literal["mean_pooling", "last_token"] = "mean_pooling"
+    model_inference_batch_size: int = 256
+    sort_by_length: bool = True
+    unk_token: bool = False
+    hf_token: str | None = None
+
+    def __post_init__(self) -> None:
+        super().__init__()
+
+        self.stages = [
+            TokenizerStage(
+                model_identifier=self.model_identifier,
+                hf_token=self.hf_token,
+                text_field=self.text_field,
+                max_chars=self.max_chars,
+                max_seq_length=self.max_seq_length,
+                padding_side=self.padding_side,
+                sort_by_length=self.sort_by_length,
+            ),
+            EmbeddingModelStage(
+                model_identifier=self.model_identifier,
+                embedding_field=self.embedding_field,
+                pooling=self.embedding_pooling,
+                hf_token=self.hf_token,
+                model_inference_batch_size=self.model_inference_batch_size,
+                has_seq_order=self.sort_by_length,
+                padding_side=self.padding_side,
+            ),
+        ]
+
+    def decompose(self) -> list[ProcessingStage]:
+        return self.stages

--- a/ray-curator/ray_curator/stages/text/embedders/base.py
+++ b/ray-curator/ray_curator/stages/text/embedders/base.py
@@ -121,7 +121,6 @@ class EmbeddingCreatorStage(CompositeStage[DocumentBatch, DocumentBatch]):
     embedding_pooling: Literal["mean_pooling", "last_token"] = "mean_pooling"
     model_inference_batch_size: int = 256
     sort_by_length: bool = True
-    unk_token: bool = False
     hf_token: str | None = None
 
     def __post_init__(self) -> None:
@@ -136,7 +135,6 @@ class EmbeddingCreatorStage(CompositeStage[DocumentBatch, DocumentBatch]):
                 max_seq_length=self.max_seq_length,
                 padding_side=self.padding_side,
                 sort_by_length=self.sort_by_length,
-                unk_token=self.unk_token,
             ),
             EmbeddingModelStage(
                 model_identifier=self.model_identifier,

--- a/ray-curator/ray_curator/stages/text/embedders/utils.py
+++ b/ray-curator/ray_curator/stages/text/embedders/utils.py
@@ -12,14 +12,22 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from typing import Any
+
 import cudf
 import cupy as cp
 import pylibcudf as plc
 
 
-def create_list_series_from_1d_or_2d_ar(ar: cp.ndarray, index: cudf.Index) -> cudf.Series:
-    """
-    Create a cudf list series  from 2d arrays
+def create_list_series_from_1d_or_2d_ar(ar: Any, index: cudf.Index) -> cudf.Series:  # noqa: ANN401
+    """Create a cudf list series from 2d arrays
+
+    Args:
+        ar (cp.ndarray): any object that can be converted to a cupy array (cupy, numpy, torch, etc.)
+        index (cudf.Index): index of the the dataframe to be returned
+
+    Returns:
+        cudf.Series: cudf series with the index respected
     """
     arr = cp.asarray(ar)
     if len(arr.shape) == 1:

--- a/ray-curator/ray_curator/stages/text/embedders/utils.py
+++ b/ray-curator/ray_curator/stages/text/embedders/utils.py
@@ -1,0 +1,32 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import cudf
+import cupy as cp
+import pylibcudf as plc
+
+
+def create_list_series_from_1d_or_2d_ar(ar: cp.ndarray, index: cudf.Index) -> cudf.Series:
+    """
+    Create a cudf list series  from 2d arrays
+    """
+    arr = cp.asarray(ar)
+    if len(arr.shape) == 1:
+        arr = arr.reshape(-1, 1)
+    if not isinstance(index, (cudf.RangeIndex, cudf.Index, cudf.MultiIndex)):
+        index = cudf.Index(index)
+    return cudf.Series.from_pylibcudf(
+        plc.Column.from_cuda_array_interface(arr),
+        metadata={"index": index},
+    )

--- a/ray-curator/ray_curator/stages/text/embedders/utils.py
+++ b/ray-curator/ray_curator/stages/text/embedders/utils.py
@@ -20,7 +20,8 @@ import pylibcudf as plc
 
 
 def create_list_series_from_1d_or_2d_ar(ar: Any, index: cudf.Index) -> cudf.Series:  # noqa: ANN401
-    """Create a cudf list series from 2d arrays
+    """Create a cudf list series from 2d arrays.
+    This code comes from https://github.com/rapidsai/crossfit/blob/76f74d0d927cf76313a3960d7dd5575d1dff2f06/crossfit/backend/cudf/series.py#L20-L32
 
     Args:
         ar (cp.ndarray): any object that can be converted to a cupy array (cupy, numpy, torch, etc.)

--- a/ray-curator/ray_curator/stages/text/models/model.py
+++ b/ray-curator/ray_curator/stages/text/models/model.py
@@ -110,7 +110,9 @@ class ModelStage(ProcessingStage[DocumentBatch, DocumentBatch]):
                 padding_side=self.padding_side,
             )
 
-    def process_model_output(self, outputs: torch.Tensor) -> dict[str, np.ndarray]:
+    def process_model_output(
+        self, outputs: torch.Tensor, model_input_batch: dict[str, torch.Tensor] | None = None
+    ) -> dict[str, np.ndarray]:
         msg = "Subclasses must implement this method"
         raise NotImplementedError(msg)
 
@@ -127,7 +129,6 @@ class ModelStage(ProcessingStage[DocumentBatch, DocumentBatch]):
     def process(self, batch: DocumentBatch) -> DocumentBatch:
         processed_outputs = []
         df_cpu = batch.to_pandas()
-
         for model_input_batch in self.yield_next_batch(df_cpu):
             # Forward pass
             with torch.no_grad():
@@ -136,9 +137,8 @@ class ModelStage(ProcessingStage[DocumentBatch, DocumentBatch]):
                 else:
                     outputs = self.model(model_input_batch)
 
+            processed_output = self.process_model_output(outputs, model_input_batch)
             del model_input_batch
-
-            processed_output = self.process_model_output(outputs)
             processed_outputs.append(processed_output)
 
         # Collect all outputs

--- a/ray-curator/ray_curator/stages/text/models/model.py
+++ b/ray-curator/ray_curator/stages/text/models/model.py
@@ -112,7 +112,7 @@ class ModelStage(ProcessingStage[DocumentBatch, DocumentBatch]):
 
     def process_model_output(
         self, outputs: torch.Tensor, model_input_batch: dict[str, torch.Tensor] | None = None
-    ) -> dict[str, np.ndarray]:
+    ) -> dict[str, np.ndarray] | torch.Tensor:
         msg = "Subclasses must implement this method"
         raise NotImplementedError(msg)
 

--- a/ray-curator/tests/stages/text/embedders/__init__.py
+++ b/ray-curator/tests/stages/text/embedders/__init__.py
@@ -11,7 +11,3 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-from .base import EmbeddingCreatorStage
-
-__all__ = ["EmbeddingCreatorStage"]

--- a/ray-curator/tests/stages/text/embedders/test_base.py
+++ b/ray-curator/tests/stages/text/embedders/test_base.py
@@ -11,17 +11,21 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import pytest
+
+# ruff: noqa: E402
+cudf = pytest.importorskip("cudf", reason="EmbeddingCreatorStage tests require cudf")
 
 from unittest.mock import Mock, patch
 
 import numpy as np
 import pandas as pd
-import pytest
 import torch
 import torch.nn.functional as F  # noqa: N812
 from transformers import AutoConfig, AutoModel, AutoTokenizer
 
 from ray_curator.stages.text.embedders.base import EmbeddingCreatorStage, EmbeddingModelStage
+from ray_curator.stages.text.models.tokenizer import TokenizerStage
 from ray_curator.stages.text.models.utils import ATTENTION_MASK_COLUMN, INPUT_ID_COLUMN
 from ray_curator.tasks import DocumentBatch
 
@@ -224,8 +228,6 @@ class TestEmbeddingCreatorStage:
         )
 
         # Test decomposition and stage types
-        from ray_curator.stages.text.models.tokenizer import TokenizerStage
-
         stages = stage.decompose()
         tokenizer_stage, embedding_stage = stages[0], stages[1]
         assert len(stages) == 2
@@ -303,6 +305,7 @@ class TestEmbeddingCreatorStage:
         # Decompose and setup stages
         stages = stage.decompose()
         for sub_stage in stages:
+            sub_stage.setup_on_node()
             sub_stage.setup()
 
         # Run stages sequentially

--- a/ray-curator/tests/stages/text/embedders/test_base.py
+++ b/ray-curator/tests/stages/text/embedders/test_base.py
@@ -220,7 +220,6 @@ class TestEmbeddingCreatorStage:
             embedding_pooling="last_token",
             model_inference_batch_size=128,
             sort_by_length=False,
-            unk_token=True,
             hf_token="test-token",  # noqa:S106
         )
 
@@ -241,7 +240,7 @@ class TestEmbeddingCreatorStage:
         assert tokenizer_stage.max_seq_length == stage.max_seq_length == 256
         assert tokenizer_stage.padding_side == stage.padding_side == "left"
         assert tokenizer_stage.sort_by_length == stage.sort_by_length is False
-        assert tokenizer_stage.unk_token == stage.unk_token is True
+        assert tokenizer_stage.unk_token is False
 
         # Verify all EmbeddingModelStage parameters
         assert embedding_stage.model_identifier == stage.model_identifier == "test-model"

--- a/ray-curator/tests/stages/text/embedders/test_base.py
+++ b/ray-curator/tests/stages/text/embedders/test_base.py
@@ -1,0 +1,379 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from unittest.mock import Mock, patch
+
+import numpy as np
+import pandas as pd
+import pytest
+import torch
+import torch.nn.functional as F  # noqa: N812
+from transformers import AutoConfig, AutoModel, AutoTokenizer
+
+from ray_curator.stages.text.embedders.base import EmbeddingCreatorStage, EmbeddingModelStage
+from ray_curator.stages.text.models.utils import ATTENTION_MASK_COLUMN, INPUT_ID_COLUMN
+from ray_curator.tasks import DocumentBatch
+
+
+class TestEmbeddingModelStage:
+    """Test EmbeddingModelStage class."""
+
+    @pytest.fixture
+    def pooling_test_data(self) -> dict[str, torch.Tensor]:
+        """Unified test data for both pooling strategies."""
+        attention_mask = torch.tensor(
+            [
+                [1, 1, 1, 0],  # First seq: 3 valid tokens
+                [1, 1, 1, 1],  # Second seq: 4 valid tokens
+            ]
+        )
+
+        token_embeddings = torch.tensor(
+            [
+                [[1.0, 1.0], [2.0, 2.0], [3.0, 3.0], [999.0, 999.0]],  # Batch 1
+                [[4.0, 4.0], [5.0, 5.0], [6.0, 6.0], [7.0, 7.0]],  # Batch 2
+            ],
+            dtype=torch.float32,
+        )
+
+        # Expected results for different pooling strategies
+        expected_results = {
+            "mean_pooling": [
+                torch.tensor([2.0, 2.0]),  # Batch 1: mean of [1,1], [2,2], [3,3] = [2,2]
+                torch.tensor([5.5, 5.5]),  # Batch 2: mean of [4,4], [5,5], [6,6], [7,7] = [5.5,5.5]
+            ],
+            "last_token": [
+                torch.tensor([3.0, 3.0]),  # Batch 1: last valid token at index 2 = [3,3]
+                torch.tensor([7.0, 7.0]),  # Batch 2: last valid token at index 3 = [7,7]
+            ],
+        }
+
+        return {
+            "attention_mask": attention_mask,
+            "token_embeddings": token_embeddings,
+            "expected_results": expected_results,
+        }
+
+    def test_embedding_model_stage_initialization(self) -> None:
+        """Test EmbeddingModelStage initialization."""
+        stage = EmbeddingModelStage(
+            model_identifier="test-model",
+            embedding_field="embeddings",
+            pooling="mean_pooling",
+        )
+
+        assert stage.model_identifier == "test-model"
+        assert stage.embedding_field == "embeddings"
+        assert stage.pooling == "mean_pooling"
+        assert stage.unpack_inference_batch is True
+
+        inputs = stage.inputs()
+        outputs = stage.outputs()
+
+        # Check that the required columns are present in inputs
+        assert inputs[0] == ["data"]
+        assert INPUT_ID_COLUMN in inputs[1]
+        assert ATTENTION_MASK_COLUMN in inputs[1]
+        assert outputs == (["data"], ["embeddings"])
+
+    @pytest.mark.parametrize("pooling_strategy", ["mean_pooling", "last_token"])
+    def test_pooling_methods(self, pooling_strategy: str, pooling_test_data: dict[str, torch.Tensor]) -> None:
+        """Test both pooling methods with unified test data."""
+        stage = EmbeddingModelStage(model_identifier="test-model", pooling=pooling_strategy)
+
+        # Extract test data
+        attention_mask = pooling_test_data["attention_mask"]
+        token_embeddings = pooling_test_data["token_embeddings"]
+        expected_results = pooling_test_data["expected_results"][pooling_strategy]
+
+        mock_output = (token_embeddings,)
+
+        # Call the appropriate pooling method
+        if pooling_strategy == "mean_pooling":
+            result = stage._mean_pooling(mock_output, attention_mask)
+        else:  # last_token
+            result = stage._get_last_token(mock_output, attention_mask)
+
+        # Check output properties
+        batch_size, hidden_size = token_embeddings.shape[0], token_embeddings.shape[2]
+        assert result.shape == (batch_size, hidden_size)
+
+        # Check that embeddings are normalized
+        norms = torch.norm(result, dim=1)
+        assert torch.allclose(norms, torch.ones(batch_size), atol=1e-5)
+
+        # Verify the actual pooling results match expected normalized values
+        for i, expected_value in enumerate(expected_results):
+            expected_normalized = torch.nn.functional.normalize(expected_value.unsqueeze(0), dim=1).squeeze(0)
+            assert torch.allclose(result[i], expected_normalized, atol=1e-5)
+
+    @pytest.mark.parametrize("pooling_strategy", ["mean_pooling", "last_token"])
+    @patch("ray_curator.stages.text.embedders.base.AutoModel")
+    def test_process_end_to_end(self, mock_auto_model: Mock, pooling_strategy: str) -> None:
+        """Test end-to-end process() with both pooling strategies."""
+        # Create a mock model that returns deterministic embeddings
+        mock_model = Mock()
+        mock_auto_model.from_pretrained.return_value = mock_model
+
+        # Create sample data with tokenized inputs
+        sample_data = DocumentBatch(
+            task_id="test_batch",
+            dataset_name="test_dataset",
+            data=pd.DataFrame(
+                {
+                    "text": ["Hello world", "Test text"],
+                    INPUT_ID_COLUMN: [[1, 2, 3, 0], [4, 5, 0, 0]],  # Second sequence shorter
+                    ATTENTION_MASK_COLUMN: [[1, 1, 1, 0], [1, 1, 0, 0]],  # Corresponding masks
+                }
+            ),
+        )
+
+        # Test the specified pooling strategy
+        stage = EmbeddingModelStage(
+            model_identifier="test-model",
+            pooling=pooling_strategy,
+            model_inference_batch_size=4,  # Process all at once
+            has_seq_order=False,  # Disable sequence ordering for simpler testing
+        )
+
+        # Mock model output - the model should return a tuple-like object where [0] is last_hidden_state
+        # The attention mask will be clipped to match the shortest sequence, so we need to match that
+        # After clipping: attention masks will be [[1,1,1], [1,1,0]] -> 3 tokens max
+        last_hidden_state = torch.tensor(
+            [
+                [[1.0, 1.0], [2.0, 2.0], [3.0, 3.0]],  # Batch 1: tokens [1,2,3]
+                [[4.0, 4.0], [5.0, 5.0], [999.0, 999.0]],  # Batch 2: tokens [4,5], last masked
+            ],
+            dtype=torch.float32,
+        )
+
+        # The model returns a tuple where first element is last_hidden_state
+        mock_model.return_value = (last_hidden_state,)
+        mock_model.device = "cpu"  # Simplify for testing
+
+        # Setup and process
+        stage.setup()
+        result = stage.process(sample_data)
+
+        # Verify result structure
+        assert isinstance(result, DocumentBatch)
+        assert result.task_id == sample_data.task_id
+        assert result.dataset_name == sample_data.dataset_name
+
+        result_df = result.to_pandas()
+        assert "embeddings" in result_df.columns
+        assert len(result_df) == 2
+
+        # Check embeddings are normalized
+        embeddings = result_df["embeddings"].tolist()
+        embeddings_array = torch.tensor(embeddings)
+        norms = torch.norm(embeddings_array, dim=1)
+        assert torch.allclose(norms, torch.ones(2), atol=1e-5)
+
+        # Define expected results based on pooling strategy
+        if pooling_strategy == "mean_pooling":
+            # Batch 1: mean of [1,1], [2,2], [3,3] = [2,2]
+            # Batch 2: mean of [4,4], [5,5] = [4.5,4.5] (last token masked)
+            expected_1 = torch.nn.functional.normalize(torch.tensor([2.0, 2.0]).unsqueeze(0), dim=1).squeeze(0)
+            expected_2 = torch.nn.functional.normalize(torch.tensor([4.5, 4.5]).unsqueeze(0), dim=1).squeeze(0)
+        else:  # last_token
+            # Batch 1: last valid token at index 2 -> [3,3]
+            # Batch 2: last valid token at index 1 -> [5,5]
+            expected_1 = torch.nn.functional.normalize(torch.tensor([3.0, 3.0]).unsqueeze(0), dim=1).squeeze(0)
+            expected_2 = torch.nn.functional.normalize(torch.tensor([5.0, 5.0]).unsqueeze(0), dim=1).squeeze(0)
+
+        assert torch.allclose(embeddings_array[0], expected_1, atol=1e-5)
+        assert torch.allclose(embeddings_array[1], expected_2, atol=1e-5)
+
+
+class TestEmbeddingCreatorStage:
+    """Test EmbeddingCreatorStage class."""
+
+    @pytest.fixture
+    def sample_data(self) -> DocumentBatch:
+        """Create sample text data for testing."""
+        texts = ["Hello world", "Test text"]
+        data = pd.DataFrame({"text": texts})
+        return DocumentBatch(task_id="test_batch", dataset_name="test_dataset", data=data)
+
+    def test_embedding_creator_stage_initialization_and_decomposition(self) -> None:
+        """Test initialization, decomposition, and parameter passing to decomposed stages."""
+        # Test with custom parameters including hf_token and unk_token
+        stage = EmbeddingCreatorStage(
+            model_identifier="test-model",
+            text_field="content",
+            embedding_field="embeddings",
+            max_chars=1000,
+            max_seq_length=256,
+            padding_side="left",
+            embedding_pooling="last_token",
+            model_inference_batch_size=128,
+            sort_by_length=False,
+            unk_token=True,
+            hf_token="test-token",  # noqa:S106
+        )
+
+        # Test decomposition and stage types
+        from ray_curator.stages.text.models.tokenizer import TokenizerStage
+
+        stages = stage.decompose()
+        tokenizer_stage, embedding_stage = stages[0], stages[1]
+        assert len(stages) == 2
+        assert isinstance(tokenizer_stage, TokenizerStage)
+        assert isinstance(embedding_stage, EmbeddingModelStage)
+
+        # Verify all TokenizerStage parameters
+        assert tokenizer_stage.model_identifier == stage.model_identifier == "test-model"
+        assert tokenizer_stage.hf_token == stage.hf_token == "test-token"  # noqa:S105
+        assert tokenizer_stage.text_field == stage.text_field == "content"
+        assert tokenizer_stage.max_chars == stage.max_chars == 1000
+        assert tokenizer_stage.max_seq_length == stage.max_seq_length == 256
+        assert tokenizer_stage.padding_side == stage.padding_side == "left"
+        assert tokenizer_stage.sort_by_length == stage.sort_by_length is False
+        assert tokenizer_stage.unk_token == stage.unk_token is True
+
+        # Verify all EmbeddingModelStage parameters
+        assert embedding_stage.model_identifier == stage.model_identifier == "test-model"
+        assert embedding_stage.hf_token == stage.hf_token == "test-token"  # noqa:S105
+        assert embedding_stage.embedding_field == stage.embedding_field == "embeddings"
+        assert embedding_stage.pooling == stage.embedding_pooling == "last_token"
+        assert embedding_stage.model_inference_batch_size == stage.model_inference_batch_size == 128
+        assert embedding_stage.has_seq_order == stage.sort_by_length is False
+        assert embedding_stage.padding_side == stage.padding_side == "left"
+        assert embedding_stage.unpack_inference_batch is True
+
+    def test_embedding_creator_stage_inputs_outputs(self) -> None:
+        """Test inputs and outputs specification."""
+        stage = EmbeddingCreatorStage(
+            model_identifier="test-model", text_field="content", embedding_field="embeddings"
+        )
+
+        inputs = stage.inputs()
+        outputs = stage.outputs()
+
+        # Should inherit from CompositeStage
+        assert inputs == (["data"], ["content"])
+        assert outputs == (["data"], ["embeddings"])
+
+    def test_embedding_creator_stage_process_integration(self) -> None:
+        """Test that decomposed stages can be run in sequence."""
+        stage = EmbeddingCreatorStage(model_identifier="test-model")
+
+        # Get the actual decomposed stages
+        stages = stage.decompose()
+
+        # Verify we have the expected number of stages
+        assert len(stages) == 2  # TokenizerStage + EmbeddingModelStage
+
+        # Verify stage types
+        from ray_curator.stages.text.models.tokenizer import TokenizerStage
+
+        assert isinstance(stages[0], TokenizerStage)
+        assert isinstance(stages[1], EmbeddingModelStage)
+
+        # Verify stage configuration is passed correctly
+        tokenizer_stage, embedding_stage = stages
+        assert tokenizer_stage.model_identifier == stage.model_identifier
+        assert embedding_stage.model_identifier == stage.model_identifier
+        assert embedding_stage.embedding_field == stage.embedding_field
+        assert embedding_stage.pooling == stage.embedding_pooling
+
+    @pytest.mark.parametrize("pooling_strategy", ["mean_pooling", "last_token"])
+    @pytest.mark.gpu
+    def test_embedding_creator_stage_with_reference_embeddings(
+        self, pooling_strategy: str, sample_data: DocumentBatch
+    ) -> None:
+        """Test embeddings match reference implementation (requires GPU and model download)."""
+        stage = EmbeddingCreatorStage(
+            model_identifier="sentence-transformers/all-MiniLM-L6-v2",
+            embedding_pooling=pooling_strategy,
+            model_inference_batch_size=32,
+        )
+
+        # Decompose and setup stages
+        stages = stage.decompose()
+        for sub_stage in stages:
+            sub_stage.setup()
+
+        # Run stages sequentially
+        result = sample_data
+        for sub_stage in stages:
+            result = sub_stage.process(result)
+        result_df = result.to_pandas()
+
+        # Get embeddings and compare with reference
+        embeddings = result_df["embeddings"].tolist()
+        embeddings_array = np.array(embeddings)
+
+        # Get reference embeddings
+        texts = sample_data.to_pandas()["text"].tolist()
+        reference_embeddings = self._get_reference_embeddings(texts, pooling_strategy=pooling_strategy)
+
+        assert np.allclose(embeddings_array, reference_embeddings, atol=1e-3), (
+            "Embeddings should match reference embeddings"
+        )
+
+    def _get_reference_embeddings(
+        self,
+        texts: list[str],
+        model_name: str = "sentence-transformers/all-MiniLM-L6-v2",
+        pooling_strategy: str = "mean_pooling",
+    ) -> np.ndarray:
+        """
+        Args:
+            texts: List of input texts
+            model_name: Name or path of the model to use
+            pooling_strategy: Either "last_token" or "mean_pooling"
+        """
+        tokenizer = AutoTokenizer.from_pretrained(model_name)
+        model = AutoModel.from_pretrained(model_name)
+        model = model.to("cuda")
+        model.eval()
+        max_len_to_use = tokenizer.model_max_length
+        if max_len_to_use > 1e5:
+            max_len_to_use = AutoConfig.from_pretrained(model_name).max_position_embeddings
+        max_seq_length: int = max_len_to_use
+
+        embs = []
+        for text in texts:
+            inputs = tokenizer(
+                text,
+                return_tensors="pt",
+                padding=True,
+                truncation=True,
+                max_length=max_seq_length,
+            )
+            inputs = {k: v.to("cuda") for k, v in inputs.items()}
+
+            with torch.no_grad(), torch.autocast(device_type="cuda"):
+                outputs = model(**inputs)
+
+            if pooling_strategy == "last_token":
+                embeddings = outputs.last_hidden_state[:, -1, :]
+            elif pooling_strategy == "mean_pooling":
+                token_embeddings = outputs.last_hidden_state
+                attention_mask = inputs["attention_mask"]
+                input_mask_expanded = attention_mask.unsqueeze(-1).expand(token_embeddings.size()).float()
+                sum_embeddings = torch.sum(token_embeddings * input_mask_expanded, dim=1)
+                sum_mask = torch.clamp(input_mask_expanded.sum(dim=1), min=1e-9)
+                embeddings = sum_embeddings / sum_mask
+            else:
+                msg = "pooling_strategy must be either 'last_token' or 'mean_pooling'"
+                raise ValueError(msg)
+
+            normed_emb = F.normalize(embeddings, dim=1).cpu()
+            normed_emb = normed_emb.squeeze(0)
+            embs.append(normed_emb)
+
+        return np.array(embs)

--- a/ray-curator/tests/stages/text/embedders/test_utils.py
+++ b/ray-curator/tests/stages/text/embedders/test_utils.py
@@ -1,0 +1,45 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import cudf
+import cupy as cp
+
+from ray_curator.stages.text.embedders.utils import create_list_series_from_1d_or_2d_ar
+
+
+class TestCreateListSeriesFrom1dOr2dAr:
+    """Test create_list_series_from_1d_or_2d_ar function."""
+
+    def test_embedding_creation_like_base_usage(self):
+        """Test the function as used in EmbeddingModelStage.create_output_dataframe."""
+        # Simulate embeddings from a model (2D array: batch_size x embedding_dim)
+        collected_output = cp.array([[0.1, 0.2, 0.3], [0.4, 0.5, 0.6], [0.7, 0.8, 0.9]])
+
+        # Create a GPU dataframe with index like in the actual usage
+        df_gpu = cudf.DataFrame(index=cudf.RangeIndex(3))
+
+        # Test the function call as it appears in base.py
+        embedding_series = create_list_series_from_1d_or_2d_ar(collected_output, index=df_gpu.index)
+
+        # Verify the result
+        assert isinstance(embedding_series, cudf.Series)
+        assert len(embedding_series) == 3
+        assert embedding_series.index.equals(df_gpu.index)
+
+        # Convert to pandas to check the actual embedding values
+        embedding_series_cpu = embedding_series.to_pandas()
+        expected_embeddings = [[0.1, 0.2, 0.3], [0.4, 0.5, 0.6], [0.7, 0.8, 0.9]]
+
+        for i, expected in enumerate(expected_embeddings):
+            assert embedding_series_cpu.iloc[i] == expected

--- a/ray-curator/tests/stages/text/embedders/test_utils.py
+++ b/ray-curator/tests/stages/text/embedders/test_utils.py
@@ -11,10 +11,12 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-import cudf
-import cupy as cp
 import pytest
+
+# ruff: noqa: E402
+cudf = pytest.importorskip("cudf", reason="utils tests require cudf")
+
+import cupy as cp
 import torch
 
 from ray_curator.stages.text.embedders.utils import create_list_series_from_1d_or_2d_ar


### PR DESCRIPTION
## Description
Extends current `models/model.py` and adds an embedding model which supports mean_pooling and last_token.

Can be used to generate embeddings that will be used in SemDedup

### TODO

- [ ] Add tests

## Usage
<!-- Potentially add a usage example below -->
```python
# Add snippet demonstrating usage
```
## Checklist
<!--
Note: All commits need to be signed and signed off. This can be done via `-sS` flags while commiting
`git commit -sS -m "...."
-->
- [ ] I am familiar with the [Contributing Guide](https://github.com/NVIDIA/NeMo-Curator/blob/main/CONTRIBUTING.md).
- [ ] New or Existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
