### PR TITLE
Update pipeline run to use xenna executor by default

### DIFF
--- a/ray-curator/ray_curator/pipeline/pipeline.py
+++ b/ray-curator/ray_curator/pipeline/pipeline.py
@@ -166,7 +166,7 @@ class Pipeline:
 
         return "\n".join(lines)
 
-    def run(self, executor: BaseExecutor, initial_tasks: list[Task] | None = None) -> list[Task] | None:
+    def run(self, executor: BaseExecutor | None = None, initial_tasks: list[Task] | None = None) -> list[Task] | None:
         """Run the pipeline.
 
         Args:
@@ -177,4 +177,9 @@ class Pipeline:
             list[Task] | None: List of tasks
         """
         self.build()
+        if executor is None:
+            from ray_curator.backends.xenna import XennaExecutor
+
+            executor = XennaExecutor()
+
         return executor.execute(self.stages, initial_tasks)

--- a/ray-curator/tests/pipelines/test_pipelines.py
+++ b/ray-curator/tests/pipelines/test_pipelines.py
@@ -1,0 +1,31 @@
+from unittest.mock import Mock, patch
+
+import pytest
+
+from ray_curator.pipeline.pipeline import Pipeline
+from ray_curator.stages.base import ProcessingStage
+
+
+@pytest.fixture
+def some_stage() -> ProcessingStage:
+    return Mock(spec=ProcessingStage)
+
+
+def test_pipeline_uses_xenna_executor_by_default(some_stage: ProcessingStage):
+    # Create a mock executor instance
+    mock_xenna_instance = Mock()
+
+    with patch("ray_curator.backends.xenna.XennaExecutor") as mock_xenna_class:
+        mock_xenna_class.return_value = mock_xenna_instance
+
+        pipeline = Pipeline(name="test")
+        pipeline.add_stage(some_stage)
+
+        # Call run without executor
+        pipeline.run()
+
+        # Verify XennaExecutor was instantiated
+        mock_xenna_class.assert_called_once_with()
+
+        # Verify execute was called on the XennaExecutor instance
+        mock_xenna_instance.execute.assert_called_once()


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
Updates pipeline.run to use a xenna executor by default. This allows for most use cases users being able to call `pipeline.run()` without working with executors at all.

## Usage
<!-- Potentially add a usage example below -->
```python
# previously
pipleline.run(executor=XennaExecutor())

# now
pipeline.run()
```
## Checklist
<!--
Note: All commits need to be signed and signed off. This can be done via `-sS` flags while commiting
`git commit -sS -m "...."
-->
- [X] I am familiar with the [Contributing Guide](https://github.com/NVIDIA/NeMo-Curator/blob/main/CONTRIBUTING.md).
- [X] New or Existing tests cover these changes.
- [X] The documentation is up to date with these changes.
