### PR TITLE
Add InternVideo submodule and refactor integration module

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "ray-curator/externals/InternVideo"]
+	path = ray-curator/externals/InternVideo
+	url = https://github.com/suiyoubi/InternVideo.git
+	branch = curator

--- a/ray-curator/pyproject.toml
+++ b/ray-curator/pyproject.toml
@@ -81,7 +81,6 @@ video = [
     "opencv-python",
     "torchvision",
     "einops",
-    "internvideo2-multi-modality @ git+https://github.com/suiyoubi/InternVideo.git@curator#subdirectory=InternVideo2/multi_modality",
     "easydict",
 ]
 video_cuda = [
@@ -135,6 +134,9 @@ source = ["./ray-curator/ray_curator", "/workspace/ray-curator/ray_curator", "/h
 
 [tool.ruff]
 line-length = 119
+exclude = [
+    "externals/**",
+]
 [tool.ruff.lint]
 select = ["ALL"]
 ignore = [

--- a/ray-curator/ray_curator/models/internvideo2_mm.py
+++ b/ray-curator/ray_curator/models/internvideo2_mm.py
@@ -31,9 +31,23 @@ from ray_curator.models.base import ModelInterface
 from ray_curator.modules.internvideo import InternVideo2_Stage2_visual, interpolate_pos_embed_internvideo2_new
 
 _MODEL_CONFIG_PATH = (
-    pathlib.Path(__file__).parent.parent.parent / "externals" / "InternVideo" / "InternVideo2" / "multi_modality" / "configs" / "internvideo2_mm_config_model.json"
+    pathlib.Path(__file__).parent.parent.parent
+    / "externals"
+    / "InternVideo"
+    / "InternVideo2"
+    / "multi_modality"
+    / "configs"
+    / "internvideo2_mm_config_model.json"
 )
-_BERT_CONFIG_PATH = pathlib.Path(__file__).parent.parent.parent / "externals" / "InternVideo" / "InternVideo2" / "multi_modality" / "configs" / "config_bert_large.json"
+_BERT_CONFIG_PATH = (
+    pathlib.Path(__file__).parent.parent.parent
+    / "externals"
+    / "InternVideo"
+    / "InternVideo2"
+    / "multi_modality"
+    / "configs"
+    / "config_bert_large.json"
+)
 INTERNVIDEO2_MODEL_ID: Final = "OpenGVLab/InternVideo2-Stage2_1B-224p-f4"
 INTERNVIDEO2_MODEL_FILE: Final = "InternVideo2-stage2_1b-224p-f4.pt"
 BERT_MODEL_ID: Final = "google-bert/bert-large-uncased"

--- a/ray-curator/ray_curator/models/internvideo2_mm.py
+++ b/ray-curator/ray_curator/models/internvideo2_mm.py
@@ -20,23 +20,20 @@ from pathlib import Path
 from typing import Final
 
 import cv2
-
-# Load config from the internvideo2_multi_modality package
-import internvideo2_multi_modality
 import numpy as np
 import numpy.typing as npt
 import torch
 from easydict import EasyDict
-from internvideo2_multi_modality import InternVideo2_Stage2_visual, interpolate_pos_embed_internvideo2_new
 from loguru import logger
 from transformers import AutoTokenizer, PreTrainedTokenizer
 
 from ray_curator.models.base import ModelInterface
+from ray_curator.modules.internvideo import InternVideo2_Stage2_visual, interpolate_pos_embed_internvideo2_new
 
 _MODEL_CONFIG_PATH = (
-    pathlib.Path(internvideo2_multi_modality.__file__).parent / "configs" / "internvideo2_mm_config_model.json"
+    pathlib.Path(__file__).parent.parent.parent / "externals" / "InternVideo" / "InternVideo2" / "multi_modality" / "configs" / "internvideo2_mm_config_model.json"
 )
-_BERT_CONFIG_PATH = pathlib.Path(internvideo2_multi_modality.__file__).parent / "configs" / "config_bert_large.json"
+_BERT_CONFIG_PATH = pathlib.Path(__file__).parent.parent.parent / "externals" / "InternVideo" / "InternVideo2" / "multi_modality" / "configs" / "config_bert_large.json"
 INTERNVIDEO2_MODEL_ID: Final = "OpenGVLab/InternVideo2-Stage2_1B-224p-f4"
 INTERNVIDEO2_MODEL_FILE: Final = "InternVideo2-stage2_1b-224p-f4.pt"
 BERT_MODEL_ID: Final = "google-bert/bert-large-uncased"

--- a/ray-curator/ray_curator/modules/internvideo/__init__.py
+++ b/ray-curator/ray_curator/modules/internvideo/__init__.py
@@ -1,0 +1,82 @@
+"""
+InternVideo2 Multi-Modality integration module.
+
+This module provides access to InternVideo2 multi-modality models
+through the git submodule located at externals/InternVideo.
+"""
+
+import subprocess
+import sys
+from pathlib import Path
+
+
+def _ensure_internvideo_installed() -> bool | None:
+    """Ensure the InternVideo package is installed."""
+    # Path relative to the ray_curator package
+    # The path should be: ray-curator/externals/InternVideo/InternVideo2/multi_modality
+    # From ray_curator/modules/internvideo/__init__.py, we need to go up 3 levels
+    submodule_path = Path(__file__).parent.parent.parent.parent / "externals" / "InternVideo" / "InternVideo2" / "multi_modality"
+
+    if not submodule_path.exists():
+        msg = (
+            f"InternVideo submodule not found at {submodule_path}. "
+            "Please run: git submodule update --init --recursive"
+        )
+        raise ImportError(
+            msg
+        )
+
+    # Check if the package is already installed and importable
+    try:
+        import internvideo2_multi_modality  # noqa: F401
+        return True
+    except ImportError:
+        print(f"InternVideo2 package not found, installing from {submodule_path}")
+
+    # Install the package in regular mode to avoid import context issues
+    try:
+        print(f"Installing InternVideo2 multi-modality from {submodule_path}...")
+        subprocess.run([
+            sys.executable, "-m", "pip", "install", str(submodule_path)
+        ], capture_output=True, text=True, check=True)
+
+        print("InternVideo2 multi-modality Installation completed successfully")
+
+    except subprocess.CalledProcessError as e:
+        print(f"InternVideo2 multi-modality Installation failed: {e.stderr}")
+        msg = f"Installation failed: {e.stderr}"
+        raise ImportError(msg)
+    except Exception as e:  # noqa: BLE001
+        msg = (
+            f"Failed to install InternVideo2 multi-modality from {submodule_path}. "
+            f"Error: {e}"
+        )
+        raise ImportError(
+            msg
+        )
+
+# Ensure the package is installed
+_ensure_internvideo_installed()
+
+# Now import the models from the installed package
+from internvideo2_multi_modality import (
+    InternVideo2_CLIP,
+    InternVideo2_CLIP_small,
+    InternVideo2_Stage2_audiovisual,
+    InternVideo2_Stage2_visual,
+    build_bert,
+    interpolate_pos_embed_internvideo2_new,
+    pretrain_internvideo2_1b_patch14_224,
+    pretrain_internvideo2_6b_patch14_224,
+)
+
+__all__ = [
+    "InternVideo2_CLIP",
+    "InternVideo2_CLIP_small",
+    "InternVideo2_Stage2_audiovisual",
+    "InternVideo2_Stage2_visual",
+    "build_bert",
+    "interpolate_pos_embed_internvideo2_new",
+    "pretrain_internvideo2_1b_patch14_224",
+    "pretrain_internvideo2_6b_patch14_224",
+]

--- a/ray-curator/ray_curator/modules/internvideo/__init__.py
+++ b/ray-curator/ray_curator/modules/internvideo/__init__.py
@@ -15,51 +15,56 @@ def _ensure_internvideo_installed() -> bool | None:
     # Path relative to the ray_curator package
     # The path should be: ray-curator/externals/InternVideo/InternVideo2/multi_modality
     # From ray_curator/modules/internvideo/__init__.py, we need to go up 3 levels
-    submodule_path = Path(__file__).parent.parent.parent.parent / "externals" / "InternVideo" / "InternVideo2" / "multi_modality"
+    submodule_path = (
+        Path(__file__).parent.parent.parent.parent / "externals" / "InternVideo" / "InternVideo2" / "multi_modality"
+    )
 
     if not submodule_path.exists():
         msg = (
-            f"InternVideo submodule not found at {submodule_path}. "
-            "Please run: git submodule update --init --recursive"
+            f"InternVideo submodule not found at {submodule_path}. Please run: git submodule update --init --recursive"
         )
-        raise ImportError(
-            msg
-        )
+        raise ImportError(msg)
 
     # Check if the package is already installed and importable
     try:
         import internvideo2_multi_modality  # noqa: F401
-        return True
+
+        return True  # noqa: TRY300
     except ImportError:
         print(f"InternVideo2 package not found, installing from {submodule_path}")
 
     # Install the package in regular mode to avoid import context issues
     try:
         print(f"Installing InternVideo2 multi-modality from {submodule_path}...")
-        subprocess.run([
-            sys.executable, "-m", "pip", "install", str(submodule_path)
-        ], capture_output=True, text=True, check=True)
+        subprocess.run(  # noqa: S603
+            [
+                sys.executable,
+                "-m",
+                "pip",
+                "install",
+                str(submodule_path),
+            ],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
 
         print("InternVideo2 multi-modality Installation completed successfully")
 
     except subprocess.CalledProcessError as e:
         print(f"InternVideo2 multi-modality Installation failed: {e.stderr}")
         msg = f"Installation failed: {e.stderr}"
-        raise ImportError(msg)
-    except Exception as e:  # noqa: BLE001
-        msg = (
-            f"Failed to install InternVideo2 multi-modality from {submodule_path}. "
-            f"Error: {e}"
-        )
-        raise ImportError(
-            msg
-        )
+        raise ImportError(msg) from e
+    except Exception as e:
+        msg = f"Failed to install InternVideo2 multi-modality from {submodule_path}. Error: {e}"
+        raise ImportError(msg) from e
+
 
 # Ensure the package is installed
 _ensure_internvideo_installed()
 
 # Now import the models from the installed package
-from internvideo2_multi_modality import (
+from internvideo2_multi_modality import (  # noqa: E402
     InternVideo2_CLIP,
     InternVideo2_CLIP_small,
     InternVideo2_Stage2_audiovisual,

--- a/ray-curator/tests/models/test_internvideo_integration.py
+++ b/ray-curator/tests/models/test_internvideo_integration.py
@@ -1,0 +1,164 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Unit tests for InternVideo integration module."""
+
+import pathlib
+
+import pytest
+
+from ray_curator.modules.internvideo import (
+    InternVideo2_CLIP,
+    InternVideo2_CLIP_small,
+    InternVideo2_Stage2_audiovisual,
+    InternVideo2_Stage2_visual,
+    build_bert,
+    interpolate_pos_embed_internvideo2_new,
+    pretrain_internvideo2_1b_patch14_224,
+    pretrain_internvideo2_6b_patch14_224,
+)
+
+
+class TestInternVideoIntegration:
+    """Test cases for InternVideo integration module."""
+
+    def setup_method(self) -> None:
+        """Set up test fixtures."""
+        # Get the path to the submodule for testing
+        # The test file is in tests/models/, so we need to go up to ray-curator root
+        self.submodule_path = pathlib.Path(__file__).parent.parent.parent / "externals" / "InternVideo" / "InternVideo2" / "multi_modality"
+
+    def test_submodule_path_exists(self) -> None:
+        """Test that the InternVideo submodule path exists."""
+        assert self.submodule_path.exists(), f"Submodule path does not exist: {self.submodule_path}"
+        assert (self.submodule_path / "__init__.py").exists(), "Submodule __init__.py not found"
+
+    def test_all_models_imported(self) -> None:
+        """Test that all expected InternVideo models are imported and available."""
+        # Check that all models are imported and are not None
+        assert InternVideo2_Stage2_visual is not None
+        assert InternVideo2_Stage2_audiovisual is not None
+        assert InternVideo2_CLIP is not None
+        assert InternVideo2_CLIP_small is not None
+        assert pretrain_internvideo2_1b_patch14_224 is not None
+        assert pretrain_internvideo2_6b_patch14_224 is not None
+        assert build_bert is not None
+        assert interpolate_pos_embed_internvideo2_new is not None
+
+    def test_model_types(self) -> None:
+        """Test that imported models have the expected types."""
+        # Check that models are callable (functions or classes)
+        assert callable(pretrain_internvideo2_1b_patch14_224)
+        assert callable(pretrain_internvideo2_6b_patch14_224)
+        assert callable(build_bert)
+        assert callable(interpolate_pos_embed_internvideo2_new)
+
+    def test_model_classes(self) -> None:
+        """Test that model classes are properly imported."""
+        # These should be classes, not instances
+        assert isinstance(InternVideo2_Stage2_visual, type)
+        assert isinstance(InternVideo2_Stage2_audiovisual, type)
+        assert isinstance(InternVideo2_CLIP, type)
+        assert isinstance(InternVideo2_CLIP_small, type)
+
+    def test_package_installation_fallback(self) -> None:
+        """Test that the module structure supports package installation fallback."""
+        # This test verifies that the module has the expected structure
+        # for handling package installation when needed
+        from ray_curator.modules.internvideo import _ensure_internvideo_installed
+
+        # Check that the function exists and is callable
+        assert callable(_ensure_internvideo_installed)
+
+        # Check that it has the expected docstring
+        assert "Ensure the InternVideo package is installed" in _ensure_internvideo_installed.__doc__
+
+    def test_module_structure(self) -> None:
+        """Test that the integration module has the expected structure."""
+        from ray_curator.modules.internvideo import __all__
+
+        expected_exports = [
+            "InternVideo2_Stage2_visual",
+            "InternVideo2_Stage2_audiovisual",
+            "InternVideo2_CLIP",
+            "InternVideo2_CLIP_small",
+            "pretrain_internvideo2_1b_patch14_224",
+            "pretrain_internvideo2_6b_patch14_224",
+            "build_bert",
+            "interpolate_pos_embed_internvideo2_new",
+        ]
+
+        assert set(__all__) == set(expected_exports), f"Expected {expected_exports}, got {__all__}"
+
+    def test_submodule_config_files(self) -> None:
+        """Test that important submodule configuration files exist."""
+        config_dir = self.submodule_path / "configs"
+        assert config_dir.exists(), "Configs directory not found"
+
+        # Check for key config files - make this more flexible
+        config_files = list(config_dir.glob("*.json"))
+        assert len(config_files) > 0, "No JSON config files found in configs directory"
+
+        # Check that at least one config file contains expected content
+        config_file = config_files[0]
+        assert config_file.exists(), f"Config file {config_file} not found"
+
+    def test_submodule_model_files(self) -> None:
+        """Test that submodule model files exist."""
+        models_dir = self.submodule_path / "models"
+        assert models_dir.exists(), "Models directory not found"
+
+        # Check for key model files - make this more flexible
+        model_files = list(models_dir.glob("*.py"))
+        assert len(model_files) > 0, "No Python model files found in models directory"
+
+        # Check that at least one model file exists
+        model_file = model_files[0]
+        assert model_file.exists(), f"Model file {model_file} not found"
+
+    def test_submodule_structure(self) -> None:
+        """Test that the submodule has the expected directory structure."""
+        # Check for essential directories
+        essential_dirs = ["models", "configs", "utils"]
+        for dir_name in essential_dirs:
+            dir_path = self.submodule_path / dir_name
+            assert dir_path.exists(), f"Essential directory {dir_name} not found"
+            assert dir_path.is_dir(), f"{dir_name} is not a directory"
+
+
+class TestInternVideoIntegrationErrorHandling:
+    """Test cases for error handling in InternVideo integration."""
+
+    def test_import_consistency(self) -> None:
+        """Test that imports are consistent across multiple calls."""
+        # Import the module multiple times to ensure consistency
+        from ray_curator.modules.internvideo import InternVideo2_Stage2_visual as model1
+        from ray_curator.modules.internvideo import InternVideo2_Stage2_visual as model2
+
+        # Should be the same object
+        assert model1 is model2, "Multiple imports should return the same object"
+
+    def test_module_attributes(self) -> None:
+        """Test that the module has the expected attributes and functions."""
+        from ray_curator.modules.internvideo import _ensure_internvideo_installed
+
+        # Check that the function exists
+        assert callable(_ensure_internvideo_installed)
+
+        # Check that it's a function
+        import types
+        assert isinstance(_ensure_internvideo_installed, types.FunctionType)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])

--- a/ray-curator/tests/models/test_internvideo_integration.py
+++ b/ray-curator/tests/models/test_internvideo_integration.py
@@ -36,7 +36,13 @@ class TestInternVideoIntegration:
         """Set up test fixtures."""
         # Get the path to the submodule for testing
         # The test file is in tests/models/, so we need to go up to ray-curator root
-        self.submodule_path = pathlib.Path(__file__).parent.parent.parent / "externals" / "InternVideo" / "InternVideo2" / "multi_modality"
+        self.submodule_path = (
+            pathlib.Path(__file__).parent.parent.parent
+            / "externals"
+            / "InternVideo"
+            / "InternVideo2"
+            / "multi_modality"
+        )
 
     def test_submodule_path_exists(self) -> None:
         """Test that the InternVideo submodule path exists."""
@@ -157,6 +163,7 @@ class TestInternVideoIntegrationErrorHandling:
 
         # Check that it's a function
         import types
+
         assert isinstance(_ensure_internvideo_installed, types.FunctionType)
 
 


### PR DESCRIPTION
- Introduced a new submodule for InternVideo located at `ray-curator/externals/InternVideo`.
- Updated `pyproject.toml` to remove direct dependency on `internvideo2-multi-modality` and added exclusion for externals in Ruff configuration.
- Refactored `internvideo2_mm.py` to load model configurations from the new submodule, enhancing modularity.
- Created a new integration module in `ray_curator.modules.internvideo` to manage InternVideo imports and ensure proper installation.
- Added unit tests for the integration module to verify functionality and structure.

These changes improve the organization and maintainability of the video processing pipeline, facilitating the integration of InternVideo functionalities.

## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->

## Usage
<!-- Potentially add a usage example below -->
```python
# Add snippet demonstrating usage
```
## Checklist
<!--
Note: All commits need to be signed and signed off. This can be done via `-sS` flags while commiting
`git commit -sS -m "...."
-->
- [ ] I am familiar with the [Contributing Guide](https://github.com/NVIDIA/NeMo-Curator/blob/main/CONTRIBUTING.md).
- [ ] New or Existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
