### PR TITLE
Pin Ray to 2.48

### DIFF
--- a/ray-curator/pyproject.toml
+++ b/ray-curator/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
     "mecab-python3",
     "pandas>=2.1.0",
     "pyarrow",
-    "ray[default,data]>=2.48",
+    "ray[default,data]==2.48",
     "torch",
     "transformers>=4.48.0",
 ]


### PR DESCRIPTION
## Description
This PR pins ray to 2.48 to unblock CI issues like here: https://github.com/NVIDIA-NeMo/Curator/actions/runs/17249750279/job/48948748035

```
E               ray.exceptions.RayTaskError(UserCodeException): ray::MapBatches(JsonlReaderStageTask)() (pid=38384, ip=10.1.0.211)
E                 File "/home/runner/work/Curator/Curator/ray-curator/ray_curator/backends/experimental/ray_data/adapter.py", line 145, in stage_map_fn
E                   return adapter._process_batch_internal(batch)
E                 File "/home/runner/work/Curator/Curator/ray-curator/ray_curator/backends/experimental/ray_data/adapter.py", line 56, in _process_batch_internal
E                   results = self.process_batch(tasks)
E                 File "/home/runner/work/Curator/Curator/ray-curator/ray_curator/backends/base.py", line 69, in process_batch
E                   results = self.stage.process_batch(tasks)
E                 File "/home/runner/work/Curator/Curator/ray-curator/ray_curator/stages/base.py", line 169, in process_batch
E                   result = self.process(task)
E                 File "/home/runner/work/Curator/Curator/ray-curator/ray_curator/stages/text/io/reader/base.py", line 92, in process
E                   result = self._generate_ids_func(task.data, result)
E                 File "/home/runner/work/Curator/Curator/ray-curator/ray_curator/stages/text/io/reader/base.py", line 128, in _generate_ids_func
E                   min_id = ray.get(self.id_generator.register_batch.remote(filepath, num_rows))
E               AttributeError: 'JsonlReaderStage' object has no attribute 'id_generator'
E               
E               The above exception was the direct cause of the following exception:
```