### PR TITLE
Catch runtime error for PyNvcFrameExtractor

### DIFF
--- a/ray-curator/ray_curator/stages/video/clipping/transnetv2_extraction.py
+++ b/ray-curator/ray_curator/stages/video/clipping/transnetv2_extraction.py
@@ -89,7 +89,7 @@ class TransNetV2ClipExtractionStage(ProcessingStage[VideoTask, VideoTask]):
     def __post_init__(self) -> None:
         self._resources = Resources(gpu_memory_gb=self.gpu_memory_gb)
 
-    def process(self, task: VideoTask) -> VideoTask:
+    def process(self, task: VideoTask) -> VideoTask:  # noqa: C901
         video: Video = task.data
         video_name = video.input_video
         if not video.has_metadata():
@@ -105,7 +105,7 @@ class TransNetV2ClipExtractionStage(ProcessingStage[VideoTask, VideoTask]):
             error_msg = "Run `FrameExtractionStage` stage prior to `TransNetV2ClipExtractionStage`!"
             raise ValueError(error_msg)
         if tuple(frames.shape[1:4]) == (48, 27, 3):
-            frames = frames.transpose(0, 2, 1, 3) # transpose weight and height
+            frames = frames.transpose(0, 2, 1, 3)  # transpose weight and height
         if tuple(frames.shape[1:4]) != (27, 48, 3):
             error_msg = f"Expected frames of shape 27x48x3, got {frames.shape[1:4]}."
             raise ValueError(error_msg)

--- a/ray-curator/ray_curator/stages/video/clipping/transnetv2_extraction.py
+++ b/ray-curator/ray_curator/stages/video/clipping/transnetv2_extraction.py
@@ -104,6 +104,8 @@ class TransNetV2ClipExtractionStage(ProcessingStage[VideoTask, VideoTask]):
         if frames is None:
             error_msg = "Run `FrameExtractionStage` stage prior to `TransNetV2ClipExtractionStage`!"
             raise ValueError(error_msg)
+        if tuple(frames.shape[1:4]) == (48, 27, 3):
+            frames = frames.transpose(0, 2, 1, 3) # transpose weight and height
         if tuple(frames.shape[1:4]) != (27, 48, 3):
             error_msg = f"Expected frames of shape 27x48x3, got {frames.shape[1:4]}."
             raise ValueError(error_msg)

--- a/ray-curator/ray_curator/stages/video/clipping/video_frame_extraction.py
+++ b/ray-curator/ray_curator/stages/video/clipping/video_frame_extraction.py
@@ -29,7 +29,7 @@ try:
     from ray_curator.utils.nvcodec_utils import PyNvcFrameExtractor
 
     _PYNVC_AVAILABLE = True
-except ImportError:
+except (ImportError, RuntimeError):
     logger.warning("PyNvcFrameExtractor not available, PyNvCodec mode will fall back to FFmpeg")
     PyNvcFrameExtractor = None
     _PYNVC_AVAILABLE = False

--- a/ray-curator/ray_curator/utils/nvcodec_utils.py
+++ b/ray-curator/ray_curator/utils/nvcodec_utils.py
@@ -35,7 +35,7 @@ try:
         Nvc.Pixel_Format.YUV444: cvcuda.ColorConversion.YUV2RGB,  # type: ignore[import-untyped]
         Nvc.Pixel_Format.NV12: cvcuda.ColorConversion.YUV2RGB_NV12,  # type: ignore[import-untyped]
     }
-except ImportError:
+except (ImportError, RuntimeError):
     logger.warning("PyNvVideoCodec is not installed, some features will be disabled.")
     Nvc = None
     cvcuda = None


### PR DESCRIPTION
## Description
Catch the Runtime Error when import  PyNvcFrameExtractor failed due to unsupported hardware.


## Usage
<!-- Potentially add a usage example below -->
```python
# Add snippet demonstrating usage
```
## Checklist
<!--
Note: All commits need to be signed and signed off. This can be done via `-sS` flags while commiting
`git commit -sS -m "...."
-->
- [ ] I am familiar with the [Contributing Guide](https://github.com/NVIDIA/NeMo-Curator/blob/main/CONTRIBUTING.md).
- [ ] New or Existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
