### PR TITLE
Minor changes for Dedup / IO consistency

### DIFF
--- a/nemo_curator/stages/deduplication/fuzzy/workflow.py
+++ b/nemo_curator/stages/deduplication/fuzzy/workflow.py
@@ -290,14 +290,14 @@ class FuzzyDeduplicationWorkflow:
             start_time = time.time()
             minhash_pipeline.run(executor=executor, initial_tasks=initial_tasks)
             minhash_end_time = time.time()
-            logger.info(f"Minhash pipeline completed in {minhash_end_time - start_time} seconds")
+            logger.info(f"Minhash pipeline completed in {(minhash_end_time - start_time):.2f} seconds")
 
             lsh_pipeline = self._create_lsh_pipeline()
             lsh_start_time = time.time()
             # LSH stage generates it's own input tasks from the minhash directory
             lsh_tasks = lsh_pipeline.run(executor=executor, initial_tasks=None)
             lsh_end_time = time.time()
-            logger.info(f"LSH pipeline completed in {lsh_end_time - lsh_start_time} seconds")
+            logger.info(f"LSH pipeline completed in {(lsh_end_time - lsh_start_time):.2f} seconds")
 
             valid_lsh_tasks = [task for task in lsh_tasks if task._metadata.get("num_docs", 0) > 0]
             if len(valid_lsh_tasks) == 0:
@@ -310,7 +310,7 @@ class FuzzyDeduplicationWorkflow:
                 )
                 connected_components_end_time = time.time()
                 logger.info(
-                    f"Connected components pipeline completed in {connected_components_end_time - connected_components_start_time} seconds"
+                    f"Connected components pipeline completed in {(connected_components_end_time - connected_components_start_time):.2f} seconds"
                 )
                 num_removed_documents = sum(
                     task._metadata.get("num_removal_ids", 0) for task in connected_components_tasks
@@ -329,6 +329,6 @@ class FuzzyDeduplicationWorkflow:
                 )
                 logger.info(f"Id generator written to {id_generator_path}")
             end_time = time.time()
-            logger.info(f"Fuzzy deduplication pipeline completed in {end_time - start_time} seconds")
+            logger.info(f"Fuzzy deduplication pipeline completed in {(end_time - start_time):.2f} seconds")
         finally:
             kill_id_generator_actor()

--- a/nemo_curator/stages/deduplication/semantic/workflow.py
+++ b/nemo_curator/stages/deduplication/semantic/workflow.py
@@ -44,16 +44,26 @@ from nemo_curator.utils.file_utils import create_or_overwrite_dir
 class SemanticDeduplicationWorkflow:
     """
     End-to-End Semantic Deduplication Workflow.
-
-    K-means stage always runs on RayActorPoolExecutor.
-    Pairwise + duplicate identification runs on configurable executor.
+    It consists of the following stages:
+    - KMeansStage
+        Takes the input path (embeddings) and clusters the embeddings into n_clusters.
+    - PairwiseStage
+        Computes pairwise similarity between all embeddings in each cluster.
+        Takes the output of KMeansStage and computes pairwise similarity between all embeddings in each cluster.
+        This is written to cache_path.
+    - IdentifyDuplicatesStage (optional)
+        Identifies duplicates based on the pairwise similarity scores.
+        Runs only if eps is provided.
+        This is written to output_path.
     """
 
     def __init__(  # noqa: PLR0913
         self,
+        # required args
         input_path: str | list[str],
         output_path: str,
         n_clusters: int,
+        cache_path: str | None = None,
         # Core data configuration
         id_field: str = "id",
         embedding_field: str = "embeddings",
@@ -79,6 +89,7 @@ class SemanticDeduplicationWorkflow:
         _duplicates_num_row_groups_hint: int | None = None,
         # I/O and storage parameters
         read_kwargs: dict[str, Any] | None = None,
+        cache_kwargs: dict[str, Any] | None = None,
         write_kwargs: dict[str, Any] | None = None,
         # Execution parameters
         verbose: bool = True,
@@ -88,8 +99,10 @@ class SemanticDeduplicationWorkflow:
 
         Args:
             input_path: Directory or list of directories containing input files with embeddings
-            output_path: Directory to write output files
+            output_path: Directory to write output files (i.e. ids to remove)
             n_clusters: Number of clusters for K-means
+            cache_path: Directory to write cache files (i.e. kmeans and pairwise results)
+                If None, will be set to output_path
 
             # Core data configuration
             id_field: Name of the ID field in the data
@@ -127,11 +140,11 @@ class SemanticDeduplicationWorkflow:
         """
         # Core paths and configuration
         self.input_path = input_path
-
         self.output_path = output_path
+        self.cache_path = cache_path or output_path
 
-        self.kmeans_output_path = os.path.join(output_path, "kmeans_results")
-        self.pairwise_output_path = os.path.join(output_path, "pairwise_results")
+        self.kmeans_output_path = os.path.join(cache_path, "kmeans_results")
+        self.pairwise_output_path = os.path.join(cache_path, "pairwise_results")
         self.duplicates_output_path = os.path.join(output_path, "duplicates")
 
         self.n_clusters = n_clusters
@@ -166,6 +179,7 @@ class SemanticDeduplicationWorkflow:
         # I/O parameters
         self.read_kwargs = read_kwargs.copy() if read_kwargs else {}
         self.write_kwargs = write_kwargs.copy() if write_kwargs else {}
+        self.cache_kwargs = cache_kwargs.copy() if cache_kwargs else self.write_kwargs.copy()
 
         # Execution parameters
         self.verbose = verbose
@@ -190,6 +204,12 @@ class SemanticDeduplicationWorkflow:
         elif self.distance_metric or self.which_to_keep:
             msg = "distance_metric and which_to_keep are not used when ranking_strategy is provided"
             logger.warning(msg)
+        else:
+            cols_needed_for_ranking = self.ranking_strategy.metadata_cols
+            missing_cols = set(cols_needed_for_ranking) - set(self.metadata_fields)
+            if missing_cols:
+                msg = f"Metadata fields {missing_cols} are required for ranking"
+                raise ValueError(msg)
 
     def _setup_directories(self) -> None:
         """Setup output directories with fsspec compliance."""
@@ -232,7 +252,7 @@ class SemanticDeduplicationWorkflow:
             oversampling_factor=self.oversampling_factor,
             max_samples_per_batch=self.max_samples_per_batch,
             read_kwargs=self.read_kwargs,
-            write_kwargs=self.write_kwargs,
+            write_kwargs=self.cache_kwargs,
         )
         pipeline.add_stage(kmeans_stage)
 
@@ -262,11 +282,8 @@ class SemanticDeduplicationWorkflow:
             which_to_keep=self.which_to_keep,
             sim_metric=self.distance_metric,
             random_seed=self.random_state,
-            # Since we use the output of KMeans we don't need to pass any read_kwargs which were
-            # passed to the KMeans stage.
-            # We do need to pass the storage_options to the Pairwise stage.
-            read_kwargs={"storage_options": self.write_kwargs.get("storage_options")},
-            write_kwargs={"storage_options": self.write_kwargs.get("storage_options")},
+            read_kwargs=self.cache_kwargs,
+            write_kwargs=self.cache_kwargs,
         )
         pipeline.add_stage(pairwise_stage)
 
@@ -277,7 +294,7 @@ class SemanticDeduplicationWorkflow:
                 eps=self.eps,
                 _num_row_groups_hint=self._duplicates_num_row_groups_hint,
                 verbose=self.verbose,
-                read_kwargs=self.write_kwargs,
+                read_kwargs=self.cache_kwargs,
                 write_kwargs=self.write_kwargs,
             )
             pipeline.add_stage(identify_duplicates_stage)
@@ -358,7 +375,7 @@ class SemanticDeduplicationWorkflow:
             logger.success("=" * 60)
             logger.success("SEMANTIC DEDUPLICATION COMPLETED")
             logger.success("=" * 60)
-            logger.success(f"Total execution time: {total_time:.2f} seconds ({total_time / 60:.2f} minutes)")
+            logger.success(f"Total execution time: {total_time:.2f} seconds")
             logger.info(f"K-means time: {kmeans_time:.2f} seconds")
             logger.info(f"Pairwise time: {pairwise_time:.2f} seconds")
             if total_duplicates > 0:

--- a/nemo_curator/stages/text/deduplication/removal.py
+++ b/nemo_curator/stages/text/deduplication/removal.py
@@ -23,7 +23,7 @@ This stage implements the removal phase of the distributed deduplication approac
 """
 
 import time
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any
 
 import pandas as pd
@@ -50,13 +50,13 @@ class TextDuplicatesRemovalStage(ProcessingStage[DocumentBatch, DocumentBatch]):
     duplicate_id_field: str = "id"
 
     # Optional parameters
-    read_kwargs: dict[str, Any] | None = None
+    read_kwargs: dict[str, Any] = field(default_factory=dict)
 
     def __post_init__(self):
         """Initialize parent class after dataclass initialization."""
         super().__init__()
         self._name = "DuplicatesRemovalStage"
-        self.read_kwargs = self.read_kwargs.copy() if self.read_kwargs is not None else {}
+        self.read_kwargs = self.read_kwargs.copy()
 
     def process(self, task: DocumentBatch) -> DocumentBatch:
         """

--- a/nemo_curator/stages/text/deduplication/removal_workflow.py
+++ b/nemo_curator/stages/text/deduplication/removal_workflow.py
@@ -135,7 +135,7 @@ class TextDuplicatesRemovalWorkflow:
             write_stage(
                 path=self.output_path,
                 **({"file_extension": self.output_file_extension} if self.output_file_extension else {}),
-                write_kwargs=self.output_kwargs,
+                write_kwargs=self.output_kwargs or {},
                 fields=self.output_fields,
                 **({"mode": self.output_mode} if self.output_mode else {}),
             )

--- a/nemo_curator/stages/text/io/reader/base.py
+++ b/nemo_curator/stages/text/io/reader/base.py
@@ -39,7 +39,6 @@ class BaseReader(ProcessingStage[FileGroupTask, DocumentBatch]):
 
     fields: list[str] | None = None
     read_kwargs: dict[str, Any] = field(default_factory=dict)
-    file_extensions: list[str] = field(default_factory=list)
     _name: str = ""
     _generate_ids: bool = False
     _assign_ids: bool = False


### PR DESCRIPTION
## Description
Adds cache_path / cache_kwargs in SemDedup.
Removes file_extensions from base_reader
## Usage
<!-- Potentially add a usage example below -->
```python
# Add snippet demonstrating usage
```
## Checklist
<!--
Note: All commits need to be signed and signed off. This can be done via `-sS` flags while commiting
`git commit -sS -m "...."
-->
- [ ] I am familiar with the [Contributing Guide](https://github.com/NVIDIA/NeMo-Curator/blob/main/CONTRIBUTING.md).
- [ ] New or Existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
