### PR TITLE
Ray Data should set num_blocks=len(tasks)

### DIFF
--- a/nemo_curator/backends/experimental/ray_data/executor.py
+++ b/nemo_curator/backends/experimental/ray_data/executor.py
@@ -108,7 +108,7 @@ class RayDataExecutor(BaseExecutor):
             Ray Data dataset containing Task objects directly
         """
         # Create Ray Data dataset directly from Task objects
-        return ray.data.from_items(tasks)
+        return ray.data.from_items(tasks, override_num_blocks=len(tasks))
 
     def _dataset_to_tasks(self, dataset: Dataset) -> list[Task]:
         """Convert Ray Data dataset back to list of tasks.


### PR DESCRIPTION
## Description
This shouldn't be an issue in current pipeline at all because we start with EmptyTask always i.e. num_blocks==1.
However when we give ray data N tasks as initial tasks (e.g. in removal workflow) then we want it to consider all of them as separate blocks, i.e. increasing parallelism.

## Usage
<!-- Potentially add a usage example below -->
```python
# Add snippet demonstrating usage
```
## Checklist
<!--
Note: All commits need to be signed and signed off. This can be done via `-sS` flags while commiting
`git commit -sS -m "...."
-->
- [ ] I am familiar with the [Contributing Guide](https://github.com/NVIDIA/NeMo-Curator/blob/main/CONTRIBUTING.md).
- [ ] New or Existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
