### PR TITLE
ci: Add back gpu coverage report

### DIFF
--- a/.github/actions/test-template/action.yml
+++ b/.github/actions/test-template/action.yml
@@ -227,17 +227,17 @@ runs:
 
         exit $EXIT_CODE
 
-    # - name: Test coverage
-    #   shell: bash -x -e -u -o pipefail {0}
-    #   run: |
-    #     docker exec -t nemo_container_${{ github.run_id }} coverage report -i
+    - name: Test coverage
+      shell: bash -x -e -u -o pipefail {0}
+      run: |
+        docker exec -t nemo_container_${{ github.run_id }} coverage report -i
 
-    # - name: Upload artifacts
-    #   uses: actions/upload-artifact@v4
-    #   if: ${{ steps.check.outputs.coverage_report != 'none' }}
-    #   with:
-    #     name: ${{ steps.check.outputs.coverage_report }}
-    #     path: |
-    #       coverage.xml
-    #       .coverage
-    #     include-hidden-files: true
+    - name: Upload artifacts
+      uses: actions/upload-artifact@v4
+      if: ${{ steps.check.outputs.coverage_report != 'none' }}
+      with:
+        name: ${{ steps.check.outputs.coverage_report }}
+        path: |
+          coverage.xml
+          .coverage
+        include-hidden-files: true

--- a/.github/actions/test-template/action.yml
+++ b/.github/actions/test-template/action.yml
@@ -204,13 +204,13 @@ runs:
       id: check
       shell: bash
       run: |
-        # docker exec nemo_container_${{ github.run_id }} coverage combine || true
-        # docker exec nemo_container_${{ github.run_id }} coverage xml || true
-        # docker cp nemo_container_${{ github.run_id }}:/workspace/.coverage .coverage
-        # docker cp nemo_container_${{ github.run_id }}:/workspace/coverage.xml coverage.xml
+        docker exec nemo_container_${{ github.run_id }} coverage combine || true
+        docker exec nemo_container_${{ github.run_id }} coverage xml || true
+        docker cp nemo_container_${{ github.run_id }}:/workspace/.coverage .coverage
+        docker cp nemo_container_${{ github.run_id }}:/workspace/coverage.xml coverage.xml
 
-        # coverage_report=coverage-${{ steps.create.outputs.coverage-prefix }}-${{ github.run_id }}-$(uuidgen)
-        # echo "coverage_report=$coverage_report" >> "$GITHUB_OUTPUT"
+        coverage_report=coverage-${{ steps.create.outputs.coverage-prefix }}-${{ github.run_id }}-$(uuidgen)
+        echo "coverage_report=$coverage_report" >> "$GITHUB_OUTPUT"
 
         EXIT_CODE=${{ steps.run-main-script.outputs.exit_code }}
         IS_SUCCESS=$([[ "$EXIT_CODE" -eq 0 ]] && echo "true" || echo "false")

--- a/.github/workflows/cicd-main.yml
+++ b/.github/workflows/cicd-main.yml
@@ -323,7 +323,7 @@ jobs:
       && !cancelled()
     strategy:
       matrix:
-        flag: [unit-test]
+        flag: [unit-test, e2e]
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->

## Usage
<!-- Potentially add a usage example below -->
```python
# Add snippet demonstrating usage
```
## Checklist
<!--
Note: All commits need to be signed and signed off. This can be done via `-sS` flags while commiting
`git commit -sS -m "...."
-->
- [ ] I am familiar with the [Contributing Guide](https://github.com/NVIDIA/NeMo-Curator/blob/main/CONTRIBUTING.md).
- [ ] New or Existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
