### PR TITLE
Make Ray Datas log less verbose

### DIFF
--- a/nemo_curator/backends/experimental/ray_data/executor.py
+++ b/nemo_curator/backends/experimental/ray_data/executor.py
@@ -16,7 +16,7 @@ from typing import TYPE_CHECKING, Any
 
 import ray
 from loguru import logger
-from ray.data import Dataset
+from ray.data import DataContext, Dataset
 
 from nemo_curator.backends.base import BaseExecutor
 from nemo_curator.backends.experimental.utils import execute_setup_on_node
@@ -57,6 +57,8 @@ class RayDataExecutor(BaseExecutor):
             return []
 
         register_loguru_serializer()
+        # This prevents verbose logging from Ray Data about serialization of the dataclass
+        DataContext.get_current().enable_fallback_to_arrow_object_ext_type = True
         # Initialize with initial tasks if provided, otherwise start with EmptyTask
         tasks: list[Task] = initial_tasks if initial_tasks else [EmptyTask]
         output_tasks: list[Task] = []


### PR DESCRIPTION
## Description
Sets `DataContext.get_current().enable_fallback_to_arrow_object_ext_type = True` inside RayDataExecutor
This setting should have no performance impact (since by default the value is None, so its treated as True), but only logging impact.
See this code path
https://github.com/ray-project/ray/blob/d13aa963f94df3d1e0424009d638e3aa46441be5/python/ray/air/util/tensor_extensions/arrow.py#L155-L198

## Usage
<!-- Potentially add a usage example below -->
```python
# Add snippet demonstrating usage
```
## Checklist
<!--
Note: All commits need to be signed and signed off. This can be done via `-sS` flags while commiting
`git commit -sS -m "...."
-->
- [ ] I am familiar with the [Contributing Guide](https://github.com/NVIDIA/NeMo-Curator/blob/main/CONTRIBUTING.md).
- [ ] New or Existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
