### PR TITLE
Allow RayActorPool (RAFT) to run after Xenna

### DIFF
--- a/tests/backends/experimental/ray_actor_pool/executor.py
+++ b/tests/backends/experimental/ray_actor_pool/executor.py
@@ -1,0 +1,19 @@
+from unittest import mock
+
+from nemo_curator.backends.experimental.ray_actor_pool.executor import _parse_runtime_env
+
+
+class TestRayActorPoolExecutor:
+    def test_parse_runtime_env(self):
+        # With noset defined we should override it to be empty
+        with_noset_defined = {"env_vars": {"RAY_EXPERIMENTAL_NOSET_CUDA_VISIBLE_DEVICES": mock.ANY}}
+        assert _parse_runtime_env(with_noset_defined) == {
+            "env_vars": {"RAY_EXPERIMENTAL_NOSET_CUDA_VISIBLE_DEVICES": ""}
+        }
+
+        # we overwrite when config env_var is not provided
+        without_env_var = {"some_other_key": "some_other_value"}
+        assert _parse_runtime_env(without_env_var) == {
+            "env_vars": {"RAY_EXPERIMENTAL_NOSET_CUDA_VISIBLE_DEVICES": ""},
+            "some_other_key": "some_other_value",
+        }

--- a/tests/backends/experimental/ray_actor_pool/test_executor.py
+++ b/tests/backends/experimental/ray_actor_pool/test_executor.py
@@ -1,3 +1,17 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from unittest import mock
 
 from nemo_curator.backends.experimental.ray_actor_pool.executor import _parse_runtime_env

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -171,6 +171,7 @@ def shared_ray_cluster(tmp_path_factory: pytest.TempPathFactory, pytestconfig: p
     logger.info(f"Running Ray command: {' '.join(cmd_to_run)}")
 
     # Use explicit path to ray command for security
+    os.environ["RAY_EXPERIMENTAL_NOSET_CUDA_VISIBLE_DEVICES"] = "0"
     ray_process = subprocess.Popen(cmd_to_run, shell=False)  # noqa: S603
     logger.info(f"Started Ray process: {ray_process.pid}")
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -171,7 +171,6 @@ def shared_ray_cluster(tmp_path_factory: pytest.TempPathFactory, pytestconfig: p
     logger.info(f"Running Ray command: {' '.join(cmd_to_run)}")
 
     # Use explicit path to ray command for security
-    os.environ["RAY_EXPERIMENTAL_NOSET_CUDA_VISIBLE_DEVICES"] = "0"
     ray_process = subprocess.Popen(cmd_to_run, shell=False)  # noqa: S603
     logger.info(f"Started Ray process: {ray_process.pid}")
 

--- a/tests/stages/deduplication/semantic/test_kmeans.py
+++ b/tests/stages/deduplication/semantic/test_kmeans.py
@@ -107,46 +107,6 @@ def create_clustered_dataset(  # noqa: PLR0913
     return input_dir, y_true
 
 
-def create_kmeans_pipeline(
-    input_dir: Path,
-    output_dir: Path,
-    n_clusters: int = N_CLUSTERS,
-    embedding_dim: int = EMBEDDING_DIM,
-    file_format: str = "parquet",
-) -> Pipeline:
-    """Create a KMeans pipeline for testing.
-
-    Args:
-        input_dir: Input directory containing test data
-        output_dir: Output directory for results
-        n_clusters: Number of clusters
-        embedding_dim: Embedding dimensionality
-        file_format: Input file format
-
-    Returns:
-        Configured pipeline
-    """
-    pipeline = Pipeline(name="kmeans_integration_test")
-
-    kmeans_stage = KMeansStage(
-        id_field="id",
-        embedding_field="embeddings",
-        n_clusters=n_clusters,
-        input_path=str(input_dir),
-        output_path=str(output_dir),
-        metadata_fields=["random_col", "true_cluster"],
-        embedding_dim=embedding_dim,
-        input_filetype=file_format,
-        verbose=True,
-        random_state=RANDOM_STATE,
-        max_iter=300,
-        tol=1e-4,
-    )
-
-    pipeline.add_stage(kmeans_stage)
-    return pipeline
-
-
 def run_single_gpu_baseline(
     input_dir: Path,
     n_clusters: int = N_CLUSTERS,


### PR DESCRIPTION
## Description
Xenna implicitly sets `os.environ["RAY_EXPERIMENTAL_NOSET_CUDA_VISIBLE_DEVICES"]` on client. This means RayActorPool when starting after Xenna won't be able to allocate `CUDA_VISIBLE_DEVICE` on its own. This could result in RAFT Actor Pool failing 

## Root cause
<!-- Potentially add a usage example below -->
```python
client.start() # noset hasn't been defined
run_xenna() # noset HAS been defined on client but not on workers
run_kmeans()  # same as above, but since its not on workers this works fine
client.stop() # all workers die; noset is still present on client

client.start() # noset is now propogated to workers too
run_kmeans() # fails
```
## Checklist
<!--
Note: All commits need to be signed and signed off. This can be done via `-sS` flags while commiting
`git commit -sS -m "...."
-->
- [ ] I am familiar with the [Contributing Guide](https://github.com/NVIDIA/NeMo-Curator/blob/main/CONTRIBUTING.md).
- [ ] New or Existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
