### PR TITLE
tutorial readmess crosslink to docs site

### DIFF
--- a/tutorials/README.md
+++ b/tutorials/README.md
@@ -1,7 +1,35 @@
 # NeMo Curator Tutorials
 
-The following is a set of tutorials that demonstrate various functionalities and features of NeMo Curator. These tutorials are meant to provide the coding foundation for building applications that consume the data that NeMo Curator curates.
+Hands-on tutorials for curating data across all modalities with NeMo Curator. Complete working examples with detailed explanations.
 
-Tutorials are split by modality: audio, image, text, or video. Please refer to each subdirectory for more information.
+## Quick Start
 
-Within this directory, we include a `quickstart.py` which does not reference a specific modality but instead provides a high-level example of how to define and use `Task`, `ProcessingStage`, and `Pipeline` objects, which are the core data structures in NeMo Curator. It is meant to serve as a lightweight example for how these objects interact with each other and help expose the skeleton which all Curator modalities are built upon.
+**New to NeMo Curator?** Start with the [Getting Started Guide](https://docs.nvidia.com/nemo/curator/latest/get-started/index.html) or try the [`quickstart.py`](quickstart.py) example to understand core concepts.
+
+## Tutorials by Modality
+
+| Modality | Description | Key Tutorials |
+|----------|-------------|---------------|
+| **[Text](text/)** | Natural language processing and curation | Deduplication, Classification, Quality Assessment |
+| **[Image](image/)** | Computer vision and image processing | Aesthetic Classification, NSFW Detection, Deduplication |
+| **[Video](video/)** | Video processing and analysis | Clipping, Frame Extraction, Filtering |
+| **[Audio](audio/)** | Speech and audio data curation | FLEURS Dataset Processing |
+
+## Core Concepts Example
+
+The [`quickstart.py`](quickstart.py) demonstrates NeMo Curator's foundational architecture:
+- **Task**: Define data processing objectives
+- **ProcessingStage**: Individual processing steps
+- **Pipeline**: Orchestrate multiple stages
+
+## Documentation Links
+
+| Category | Links |
+|----------|-------|
+| **Getting Started** | [Installation](https://docs.nvidia.com/nemo/curator/latest/get-started/installation.html) • [Configuration](https://docs.nvidia.com/nemo/curator/latest/get-started/configuration.html) • [Core Concepts](https://docs.nvidia.com/nemo/curator/latest/about/concepts/index.html) |
+| **Modality Guides** | [Text Curation](https://docs.nvidia.com/nemo/curator/latest/curate-text/index.html) • [Image Curation](https://docs.nvidia.com/nemo/curator/latest/curate-images/index.html) • [Video Curation](https://docs.nvidia.com/nemo/curator/latest/curate-video/index.html) |
+| **Advanced** | [Custom Pipelines](https://docs.nvidia.com/nemo/curator/latest/reference/index.html) • [Execution Backends](https://docs.nvidia.com/nemo/curator/latest/reference/infrastructure/execution-backends.html) • [API Reference](https://docs.nvidia.com/nemo/curator/latest/apidocs/index.html) |
+
+## Support
+
+**Documentation**: [Main Docs](https://docs.nvidia.com/nemo/curator/latest/) • [GitHub Discussions](https://github.com/NVIDIA/NeMo-Curator/discussions)

--- a/tutorials/audio/README.md
+++ b/tutorials/audio/README.md
@@ -1,2 +1,25 @@
 # Audio Curation Tutorials
-The following is a set of tutorials that demonstrate various functionalities and features for curating audio data with NeMo Curator. These tutorials are meant to provide the coding foundation for building applications that consume the data that NeMo Curator curates.
+
+Hands-on tutorials for curating audio data with NeMo Curator. Complete working examples with detailed explanations.
+
+## Quick Start
+
+**New to audio curation?** Start with the [Audio Getting Started Guide](https://docs.nvidia.com/nemo/curator/latest/get-started/audio.html) for setup and basic concepts.
+
+## Available Tutorials
+
+| Tutorial | Description | Files |
+|----------|-------------|-------|
+| **[FLEURS Dataset](fleurs/)** | Complete pipeline for multilingual speech data | `pipeline.py`, `run.py`, `pipeline.yaml` |
+
+## Documentation Links
+
+| Category | Links |
+|----------|-------|
+| **Setup** | [Installation](https://docs.nvidia.com/nemo/curator/latest/get-started/installation.html) • [Configuration](https://docs.nvidia.com/nemo/curator/latest/get-started/configuration.html) |
+| **Concepts** | [Architecture](https://docs.nvidia.com/nemo/curator/latest/about/concepts/index.html) • [Data Loading](https://docs.nvidia.com/nemo/curator/latest/about/concepts/text/data-loading-concepts.html) |
+| **Advanced** | [Custom Pipelines](https://docs.nvidia.com/nemo/curator/latest/reference/index.html) • [Execution Backends](https://docs.nvidia.com/nemo/curator/latest/reference/infrastructure/execution-backends.html) • [NeMo ASR Integration](https://docs.nvidia.com/nemo/curator/latest/about/key-features.html) |
+
+## Support
+
+**Documentation**: [Main Docs](https://docs.nvidia.com/nemo/curator/latest/) • [API Reference](https://docs.nvidia.com/nemo/curator/latest/apidocs/index.html) • [GitHub Discussions](https://github.com/NVIDIA/NeMo-Curator/discussions)

--- a/tutorials/image/README.md
+++ b/tutorials/image/README.md
@@ -1,2 +1,26 @@
 # Image Curation Tutorials
-The following is a set of tutorials that demonstrate various functionalities and features for curating image data with NeMo Curator. These tutorials are meant to provide the coding foundation for building applications that consume the data that NeMo Curator curates.
+
+Hands-on tutorials for curating image data with NeMo Curator. Complete working examples with detailed explanations.
+
+## Quick Start
+
+**New to image curation?** Start with the [Image Getting Started Guide](https://docs.nvidia.com/nemo/curator/latest/get-started/image.html) for setup and basic concepts.
+
+## Available Tutorials
+
+| Tutorial | Description | Files |
+|----------|-------------|-------|
+| **[Getting Started](getting-started/)** | Image curation fundamentals | `image_curation_example.py`, `image_dedup_example.py`, `helper.py` |
+
+## Documentation Links
+
+| Category | Links |
+|----------|-------|
+| **Concepts** | [Processing](https://docs.nvidia.com/nemo/curator/latest/about/concepts/image/data-processing-concepts.html) • [Loading](https://docs.nvidia.com/nemo/curator/latest/about/concepts/image/data-loading-concepts.html) • [Export](https://docs.nvidia.com/nemo/curator/latest/about/concepts/image/data-export-concepts.html) |
+| **Data & Processing** | [WebDataset](https://docs.nvidia.com/nemo/curator/latest/curate-images/load-data/webdataset.html) • [Aesthetic Classification](https://docs.nvidia.com/nemo/curator/latest/curate-images/process-data/classifiers/aesthetic.html) • [NSFW Classification](https://docs.nvidia.com/nemo/curator/latest/curate-images/process-data/classifiers/nsfw.html) • [Export Data](https://docs.nvidia.com/nemo/curator/latest/curate-images/save-export.html) |
+| **Embeddings** | [TIMM Embeddings](https://docs.nvidia.com/nemo/curator/latest/curate-images/process-data/embeddings/timm.html) • [Custom Embeddings](https://docs.nvidia.com/nemo/curator/latest/curate-images/process-data/embeddings/custom.html) |
+| **Advanced** | [Image Tutorials](https://docs.nvidia.com/nemo/curator/latest/curate-images/tutorials/index.html) • [Custom Pipelines](https://docs.nvidia.com/nemo/curator/latest/curate-images/process-data/index.html) • [Production](https://docs.nvidia.com/nemo/curator/latest/reference/infrastructure/execution-backends.html) |
+
+## Support
+
+**Documentation**: [Main Docs](https://docs.nvidia.com/nemo/curator/latest/) • [API Reference](https://docs.nvidia.com/nemo/curator/latest/apidocs/index.html) • [GitHub Discussions](https://github.com/NVIDIA/NeMo-Curator/discussions)

--- a/tutorials/text/README.md
+++ b/tutorials/text/README.md
@@ -1,2 +1,30 @@
 # Text Curation Tutorials
-The following is a set of tutorials that demonstrate various functionalities and features for curating text data with NeMo Curator. These tutorials are meant to provide the coding foundation for building applications that consume the data that NeMo Curator curates.
+
+Hands-on tutorials for curating text data with NeMo Curator. Complete working examples with detailed explanations.
+
+## Quick Start
+
+**New to text curation?** Start with the [Text Getting Started Guide](https://docs.nvidia.com/nemo/curator/latest/get-started/text.html) for setup and basic concepts.
+
+## Available Tutorials
+
+| Tutorial | Description | Files |
+|----------|-------------|-------|
+| **[Download & Extract](download-and-extract/)** | Data acquisition workflows | `download_extract_tutorial.ipynb` |
+| **[Deduplication](deduplication/)** | Remove duplicate content | `semantic_e2e.ipynb`, `semantic_step_by_step.ipynb` |
+| **[Classification](distributed-data-classification/)** | Quality assessment and categorization | `quality-classification.ipynb`, `domain-classification.ipynb`, `aegis-classification.ipynb`, `fineweb-edu-classification.ipynb` |
+| **[PEFT Curation](peft-curation/)** | Instruction-tuning data preparation | `main.py`, `stages.py` |
+| **[TinyStories](tinystories/)** | End-to-end processing pipeline | `main.py`, `stages.py` |
+
+## Documentation Links
+
+| Category | Links |
+|----------|-------|
+| **Concepts** | [Processing](https://docs.nvidia.com/nemo/curator/latest/about/concepts/text/data-processing-concepts.html) • [Pipeline](https://docs.nvidia.com/nemo/curator/latest/about/concepts/text/data-curation-pipeline.html) • [Loading](https://docs.nvidia.com/nemo/curator/latest/about/concepts/text/data-loading-concepts.html) • [Generation](https://docs.nvidia.com/nemo/curator/latest/about/concepts/text/data-generation-concepts.html) |
+| **Data Sources** | [Common Crawl](https://docs.nvidia.com/nemo/curator/latest/curate-text/load-data/common-crawl.html) • [Wikipedia](https://docs.nvidia.com/nemo/curator/latest/curate-text/load-data/wikipedia.html) • [ArXiv](https://docs.nvidia.com/nemo/curator/latest/curate-text/load-data/arxiv.html) • [Custom](https://docs.nvidia.com/nemo/curator/latest/curate-text/load-data/custom.html) |
+| **Processing** | [Quality Assessment](https://docs.nvidia.com/nemo/curator/latest/curate-text/process-data/quality-assessment/index.html) • [Deduplication](https://docs.nvidia.com/nemo/curator/latest/curate-text/process-data/deduplication/index.html) • [Content Processing](https://docs.nvidia.com/nemo/curator/latest/curate-text/process-data/content-processing/index.html) • [PII Removal](https://docs.nvidia.com/nemo/curator/latest/curate-text/process-data/content-processing/pii.html) |
+| **Advanced** | [Distributed Classification](https://docs.nvidia.com/nemo/curator/latest/curate-text/process-data/quality-assessment/distributed-classifier.html) • [Semantic Dedup](https://docs.nvidia.com/nemo/curator/latest/curate-text/process-data/deduplication/semdedup.html) • [GPU Dedup](https://docs.nvidia.com/nemo/curator/latest/curate-text/process-data/deduplication/gpudedup.html) • [Synthetic Data](https://docs.nvidia.com/nemo/curator/latest/curate-text/generate-data/pipelines/index.html) |
+
+## Support
+
+**Documentation**: [Main Docs](https://docs.nvidia.com/nemo/curator/latest/) • [API Reference](https://docs.nvidia.com/nemo/curator/latest/apidocs/index.html) • [GitHub Discussions](https://github.com/NVIDIA/NeMo-Curator/discussions)

--- a/tutorials/video/README.md
+++ b/tutorials/video/README.md
@@ -1,2 +1,26 @@
 # Video Curation Tutorials
-The following is a set of tutorials that demonstrate various functionalities and features for curating video data with NeMo Curator. These tutorials are meant to provide the coding foundation for building applications that consume the data that NeMo Curator curates.
+
+Hands-on tutorials for curating video data with NeMo Curator. Complete working examples with detailed explanations.
+
+## Quick Start
+
+**New to video curation?** Start with the [Video Getting Started Guide](https://docs.nvidia.com/nemo/curator/latest/get-started/video.html) for setup and basic concepts.
+
+## Available Tutorials
+
+| Tutorial | Description | Files |
+|----------|-------------|-------|
+| **[Getting Started](getting-started/)** | Basic video loading and operations | `video_read_example.py`, `video_split_clip_example.py` |
+
+## Documentation Links
+
+| Category | Links |
+|----------|-------|
+| **Concepts** | [Architecture](https://docs.nvidia.com/nemo/curator/latest/about/concepts/video/architecture.html) • [Data Flow](https://docs.nvidia.com/nemo/curator/latest/about/concepts/video/data-flow.html) • [Abstractions](https://docs.nvidia.com/nemo/curator/latest/about/concepts/video/abstractions.html) |
+| **Processing** | [Filtering](https://docs.nvidia.com/nemo/curator/latest/curate-video/process-data/filtering.html) • [Clipping](https://docs.nvidia.com/nemo/curator/latest/curate-video/process-data/clipping.html) • [Frame Extraction](https://docs.nvidia.com/nemo/curator/latest/curate-video/process-data/frame-extraction.html) • [Deduplication](https://docs.nvidia.com/nemo/curator/latest/curate-video/process-data/dedup.html) |
+| **Data Flow** | [Load Data](https://docs.nvidia.com/nemo/curator/latest/curate-video/load-data/index.html) • [Process Data](https://docs.nvidia.com/nemo/curator/latest/curate-video/process-data/index.html) • [Export Data](https://docs.nvidia.com/nemo/curator/latest/curate-video/save-export.html) |
+| **Advanced** | [Pipeline Customization](https://docs.nvidia.com/nemo/curator/latest/curate-video/tutorials/pipeline-customization/index.html) • [Video Embeddings](https://docs.nvidia.com/nemo/curator/latest/curate-video/process-data/embeddings.html) • [Production](https://docs.nvidia.com/nemo/curator/latest/reference/infrastructure/execution-backends.html) |
+
+## Support
+
+**Documentation**: [Main Docs](https://docs.nvidia.com/nemo/curator/latest/) • [API Reference](https://docs.nvidia.com/nemo/curator/latest/apidocs/index.html) • [GitHub Discussions](https://github.com/NVIDIA/NeMo-Curator/discussions)


### PR DESCRIPTION
Added compact templates for READMEs within the tutorial sections to act as overviews/routing docs that also point to the docs site. This should address the VDR point about crosslinking and navigability