### PR TITLE
Raise informative error when on unsupported system

### DIFF
--- a/nemo_curator/__init__.py
+++ b/nemo_curator/__init__.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import os
+import sys
 
 from .package_info import (
     __contact_emails__,
@@ -35,3 +36,13 @@ from cosmos_xenna.ray_utils.cluster import API_LIMIT
 # We set these incase a user ever starts a ray cluster with nemo_curator, we need these for Xenna to work
 os.environ["RAY_MAX_LIMIT_FROM_API_SERVER"] = str(API_LIMIT)
 os.environ["RAY_MAX_LIMIT_FROM_DATA_SOURCE"] = str(API_LIMIT)
+
+# Raise an informative error early to users on unsupported systems
+if sys.platform != "linux":
+    _msg = (
+        "NeMo-Curator currently only supports Linux systems, "
+        f"while the current machine has a {sys.platform} system. \n"
+        "For more information on installation and system requirements, see "
+        "https://docs.nvidia.com/nemo/curator/latest/admin/installation.html"
+    )
+    raise ValueError(_msg)

--- a/tests/test___init__.py
+++ b/tests/test___init__.py
@@ -1,0 +1,28 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import sys
+
+import pytest
+
+
+def test_raises_system_error(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(sys, "modules", {})
+    dummy_platform = "asdfasdf"
+    monkeypatch.setattr(sys, "platform", dummy_platform)
+
+    with pytest.raises(ValueError, match="only supports Linux systems") as excinfo:
+        import nemo_curator  # noqa
+
+    assert dummy_platform in str(excinfo.value)


### PR DESCRIPTION
## Description

I ran into errors while running the tinystories tutorial locally on my macbook. After talking with @arhamm1 and @ayushdg, it turns out that's because only linux systems are currently supported. This PR adds a system check and raises an informative error to users if they're on a non-linux system. Better to raise early than let users do things that end up breaking. 

One question I have is if there are any existing users on non-linux systems running things that happens to work by chance today.

## Usage
<!-- Potentially add a usage example below -->

This is what I see now when I attempt to import `nemo_curator` on a macbook

```
In [1]: import nemo_curator
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
Cell In[1], line 1
----> 1 import nemo_curator

File ~/work/NVIDIA-NeMo/Curator/nemo_curator/__init__.py:48
     41 if sys.platform != "linux":
     42     _msg = (
     43         "NeMo-Curator currently only supports Linux systems, "
     44         f"while the current machine has a {sys.platform} system. \n"
     45         "For more information on installation and system requirements, see "
     46         "https://docs.nvidia.com/nemo/curator/latest/admin/installation.html"
     47     )
---> 48     raise ValueError(_msg)

ValueError: NeMo-Curator currently only supports Linux systems, while the current machine has a darwin system.
For more information on installation and system requirements, see https://docs.nvidia.com/nemo/curator/latest/admin/installation.html
```

## Checklist
<!--
Note: All commits need to be signed and signed off. This can be done via `-sS` flags while commiting
`git commit -sS -m "...."
-->
- [ ] I am familiar with the [Contributing Guide](https://github.com/NVIDIA/NeMo-Curator/blob/main/CONTRIBUTING.md).
- [ ] New or Existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
