### PR TITLE
Add Nemotron VLM support in video captioning

### DIFF
--- a/nemo_curator/models/nemotron_h_vl.py
+++ b/nemo_curator/models/nemotron_h_vl.py
@@ -1,0 +1,225 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+import os
+from pathlib import Path
+from typing import Any
+
+from loguru import logger
+
+from nemo_curator.models.base import ModelInterface
+from nemo_curator.utils import grouping
+from nemo_curator.utils.hf_download_utils import download_model_from_hf
+
+# Constants for prompt processing
+VIDEO_TAG_SPLIT_MAX = 1
+EXPECTED_VIDEO_TAG_PARTS = 2
+
+try:
+    from vllm import LLM, SamplingParams
+
+    VLLM_AVAILABLE = True
+except ImportError:
+    VLLM_AVAILABLE = False
+
+    class LLM:
+        pass
+
+    class SamplingParams:
+        pass
+
+
+# HuggingFace model IDs (will be updated when models are published)
+_NEMOTRON_H_NANO_MODEL_ID = None
+_NEMOTRON_H_NANO_MODEL_REVISION = None
+
+
+class NemotronHVL(ModelInterface):
+    """NemotronH hybrid Mamba-Attention VLM for video captioning."""
+
+    def __init__(  # noqa: PLR0913
+        self,
+        model_dir: str,
+        model_variant: str = "nemotron",
+        caption_batch_size: int = 8,
+        max_output_tokens: int = 512,
+        stage2_prompt_text: str | None = None,
+        verbose: bool = False,
+    ):
+        self.model_dir = model_dir
+        self.model_variant = model_variant
+        self.caption_batch_size = caption_batch_size
+        self.max_output_tokens = max_output_tokens
+        self.stage2_prompt = stage2_prompt_text if stage2_prompt_text else "Please refine this caption: "
+        self.verbose = verbose
+
+        if _NEMOTRON_H_NANO_MODEL_ID is not None:
+            self.weight_file = str(Path(model_dir) / _NEMOTRON_H_NANO_MODEL_ID)
+        else:
+            # Local checkpoint: model_dir is the checkpoint path itself
+            self.weight_file = str(Path(model_dir))
+
+    @property
+    def model_id_names(self) -> list[str]:
+        """Return model ID from config.json or HuggingFace ID."""
+        if _NEMOTRON_H_NANO_MODEL_ID is not None:
+            return [_NEMOTRON_H_NANO_MODEL_ID]
+
+        # Read from config.json if available
+        try:
+            config_path = Path(self.weight_file) / "config.json"
+            with open(config_path) as f:
+                config = json.load(f)
+            return [config.get("_name_or_path", Path(self.weight_file).name)]
+        except (FileNotFoundError, json.JSONDecodeError, KeyError):
+            return [Path(self.weight_file).name]
+
+    def setup(self) -> None:
+        if not VLLM_AVAILABLE:
+            msg = "vllm is required for NemotronHVL but is not installed. Please install vllm: pip install vllm"
+            raise ImportError(msg)
+
+        # Use V0 engine to avoid flashinfer issues for now
+        os.environ["VLLM_USE_V1"] = "0"
+        logger.info("Using vLLM V0 engine.")
+
+        os.environ["PYTORCH_CUDA_ALLOC_CONF"] = "expandable_segments:True"
+
+        self.model = LLM(
+            model=self.weight_file,
+            trust_remote_code=True,
+            tensor_parallel_size=1,
+            gpu_memory_utilization=0.9,
+            max_model_len=32768,
+            limit_mm_per_prompt={"video": 1},
+        )
+
+        self.sampling_params = SamplingParams(
+            temperature=0.6,
+            max_tokens=self.max_output_tokens,
+            top_p=0.95,
+            stop=["</s>", "<|endoftext|>", "<SPECIAL_12>", "</think>"],
+        )
+
+        logger.info(
+            f"NemotronHVL initialized: variant={self.model_variant}, "
+            f"TP=1, GPU_util=0.9, max_len=32768"
+        )
+
+    def _refine_caption_prompt(self, original_prompt: str, refinement_text: str) -> str:
+        """Create a refined prompt for stage 2 captioning."""
+        if "<video>" not in original_prompt:
+            return refinement_text
+
+        parts = original_prompt.split("<video>", VIDEO_TAG_SPLIT_MAX)
+        if len(parts) != EXPECTED_VIDEO_TAG_PARTS:
+            return refinement_text
+
+        prefix = parts[0] + "<video>"
+
+        # Find where the user message ends
+        suffix_markers = ["<SPECIAL_11>Assistant", "<|im_end|>", "</s>"]
+        suffix_start = len(parts[1])
+        for marker in suffix_markers:
+            if marker in parts[1]:
+                suffix_start = parts[1].index(marker)
+                break
+
+        suffix = parts[1][suffix_start:]
+        return prefix + "\n" + refinement_text + suffix
+
+    def generate(
+        self,
+        videos: list[dict[str, Any]],
+        generate_stage2_caption: bool = False,
+        batch_size: int = 16,
+    ) -> list[str]:
+        generated_text = []
+
+        for batch_videos in grouping.split_by_chunk_size(videos, batch_size):
+            model_inputs = list(batch_videos)
+            try:
+                # PASS 1: Generate initial captions
+                outputs = self.model.generate(
+                    model_inputs,
+                    sampling_params=self.sampling_params,
+                    use_tqdm=False,
+                )
+
+                # PASS 2: Refine captions if requested
+                if generate_stage2_caption:
+                    for i, out in enumerate(outputs):
+                        initial_caption = out.outputs[0].text
+                        refinement_text = self.stage2_prompt + initial_caption
+                        original_prompt = model_inputs[i]["prompt"]
+                        model_inputs[i]["prompt"] = self._refine_caption_prompt(
+                            original_prompt, refinement_text
+                        )
+
+                    outputs = self.model.generate(
+                        model_inputs,
+                        sampling_params=self.sampling_params,
+                        use_tqdm=False,
+                    )
+
+                generated_text.extend(out.outputs[0].text for out in outputs)
+
+                if self.verbose:
+                    for i, out in enumerate(outputs):
+                        logger.info(f"Generated caption {i}: {out.outputs[0].text[:100]}...")
+
+            except Exception as e:
+                logger.error(f"Error generating caption for batch: {e}")
+                raise
+
+        return generated_text
+
+    @classmethod
+    def download_weights_on_node(cls, model_dir: str) -> None:
+        """Download or verify NemotronH weights on the node (follows Qwen pattern)."""
+        # If HuggingFace model ID is configured, download from HF
+        if _NEMOTRON_H_NANO_MODEL_ID is not None:
+            model_dir_path = Path(model_dir) / _NEMOTRON_H_NANO_MODEL_ID
+            model_dir_path.mkdir(parents=True, exist_ok=True)
+
+            # Check if already downloaded
+            if model_dir_path.exists() and any(model_dir_path.glob("*.safetensors")):
+                logger.info(f"NemotronH checkpoint already exists at: {model_dir_path}")
+                return
+
+            # Download from HuggingFace
+            download_model_from_hf(
+                model_id=_NEMOTRON_H_NANO_MODEL_ID,
+                local_dir=model_dir_path,
+                revision=_NEMOTRON_H_NANO_MODEL_REVISION,
+            )
+            logger.info(f"NemotronH weights downloaded to: {model_dir_path}")
+        else:
+            # Local checkpoint mode: validate path exists
+            model_path = Path(model_dir)
+            if not model_path.exists():
+                msg = f"NemotronH checkpoint path does not exist: {model_dir}"
+                raise FileNotFoundError(msg)
+
+            # Verify it contains model files
+            if not any(model_path.glob("*.safetensors")) and not any(model_path.glob("*.bin")):
+                msg = (
+                    f"No model files (.safetensors or .bin) found in: {model_dir}\n"
+                    f"Please ensure this directory contains a valid NemotronH checkpoint."
+                )
+                raise FileNotFoundError(msg)
+
+            logger.info(f"Using local NemotronH checkpoint: {model_dir}")
+

--- a/nemo_curator/models/nemotron_prompt_formatter.py
+++ b/nemo_curator/models/nemotron_prompt_formatter.py
@@ -1,0 +1,137 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import numpy.typing as npt
+import torch
+from jinja2 import Template
+from loguru import logger
+
+# Constants for tensor dimensions and channel counts
+EXPECTED_TENSOR_DIMENSIONS = 4
+EXPECTED_NUMPY_DIMENSIONS = 4
+EXPECTED_CHANNELS = 3
+
+
+class NemotronPromptFormatter:
+    """Prompt formatter for NemotronH models using Jinja2 chat templates."""
+
+    def __init__(self, model_path: str):
+        self.model_path = Path(model_path)
+
+        checkpoint_path = self._resolve_checkpoint_path(model_path)
+
+        template_path = checkpoint_path / "chat_template.jinja"
+        if not template_path.exists():
+            msg = (
+                f"chat_template.jinja not found at {template_path}.\n"
+                f"NemotronH models require this template file for proper prompt formatting.\n"
+                f"Please ensure your checkpoint directory contains chat_template.jinja."
+            )
+            raise FileNotFoundError(msg)
+
+        with open(template_path) as f:
+            self.chat_template = f.read()
+        logger.info(f"Loaded chat template from: {template_path}")
+
+    def _resolve_checkpoint_path(self, model_path: str) -> Path:
+        path = Path(model_path)
+
+        if (path / "config.json").exists():
+            return path
+
+        return path
+
+    def generate_inputs(
+        self,
+        prompt: str,
+        video_inputs: torch.Tensor | npt.NDArray[np.uint8] | None = None,
+        add_generation_prompt: bool = True,
+    ) -> dict[str, Any]:
+        video_np = self._convert_video_format(video_inputs)
+        formatted_prompt = self._apply_chat_template(prompt, add_generation_prompt)
+
+        return {
+            "prompt": formatted_prompt,
+            "multi_modal_data": {"video": video_np},
+        }
+
+    def _convert_tensor_to_numpy(self, tensor: torch.Tensor) -> npt.NDArray[np.uint8]:
+        """Convert torch.Tensor (T, C, H, W) to numpy (T, H, W, C)."""
+        if tensor.ndim != EXPECTED_TENSOR_DIMENSIONS:
+            msg = f"Expected 4D torch.Tensor (T, C, H, W), got shape {tensor.shape}"
+            raise ValueError(msg)
+
+        video_np = tensor.permute(0, 2, 3, 1).cpu().numpy()
+        return self._normalize_dtype(video_np)
+
+    def _validate_numpy_array(self, array: npt.NDArray[np.uint8]) -> npt.NDArray[np.uint8]:
+        """Validate and normalize numpy array format."""
+        if array.ndim != EXPECTED_NUMPY_DIMENSIONS:
+            msg = f"Expected 4D numpy array (T, H, W, C), got shape {array.shape}"
+            raise ValueError(msg)
+
+        if array.shape[-1] != EXPECTED_CHANNELS:
+            msg = f"Expected channels-last format (T, H, W, 3), got shape {array.shape}."
+            raise ValueError(msg)
+
+        return self._normalize_dtype(array)
+
+    def _normalize_dtype(self, array: npt.NDArray[np.uint8]) -> npt.NDArray[np.uint8]:
+        """Normalize array dtype to uint8."""
+        if array.dtype != np.uint8:
+            if array.dtype in (np.float32, np.float16) and array.max() <= 1.0:
+                return (array * 255).astype(np.uint8)
+            return array.astype(np.uint8)
+        return array
+
+    def _convert_video_format(
+        self,
+        video_inputs: torch.Tensor | npt.NDArray[np.uint8] | None,
+    ) -> npt.NDArray[np.uint8] | None:
+        """Convert torch.Tensor (T, C, H, W) or np.ndarray to vLLM format (T, H, W, C)."""
+        if video_inputs is None:
+            return None
+
+        if isinstance(video_inputs, torch.Tensor):
+            return self._convert_tensor_to_numpy(video_inputs)
+
+        if isinstance(video_inputs, np.ndarray):
+            return self._validate_numpy_array(video_inputs)
+
+        msg = f"Expected torch.Tensor or np.ndarray, got {type(video_inputs)}"
+        raise TypeError(msg)
+
+    def _apply_chat_template(
+        self,
+        prompt_text: str,
+        add_generation_prompt: bool = True,
+    ) -> str:
+        messages = [
+            {"role": "system", "content": "You are a helpful assistant."},
+            {
+                "role": "user",
+                "content": [{"type": "text", "text": f"<video>\n{prompt_text}"}],
+            },
+        ]
+
+        template = Template(self.chat_template)
+        return template.render(
+            messages=messages,
+            add_generation_prompt=add_generation_prompt,
+        )
+

--- a/nemo_curator/tasks/video.py
+++ b/nemo_curator/tasks/video.py
@@ -41,8 +41,9 @@ class _Window:
     end_frame: int
     # MP4 bytes for this window
     mp4_bytes: bytes | None = None
+    llm_inputs: dict[str, dict[str, Any]] = field(default_factory=dict)
     # Qwen LLM input for this window
-    qwen_llm_input: dict[str, Any] | None = None
+    qwen_llm_input: dict[str, Any] | None = None  # Backward compatibility
     # X1 model input for this window
     x1_input: Any | None = None
     # `caption: {model_name: caption}`
@@ -50,6 +51,13 @@ class _Window:
     enhanced_caption: dict[str, str] = field(default_factory=dict)
     # webp preview
     webp_bytes: bytes | None = None
+
+    def __post_init__(self):
+        """Sync qwen_llm_input with llm_inputs for backward compatibility."""
+        if self.qwen_llm_input is not None:
+            self.llm_inputs["qwen"] = self.qwen_llm_input
+        elif "qwen" in self.llm_inputs:
+            self.qwen_llm_input = self.llm_inputs["qwen"]
 
     def get_major_size(self) -> int:
         """Calculate total memory size of the window.
@@ -61,7 +69,9 @@ class _Window:
         total_size = 0
         total_size += len(self.mp4_bytes) if self.mp4_bytes else 0
         # TODO: this is probably inaccurate
-        total_size += sys.getsizeof(self.qwen_llm_input) if self.qwen_llm_input else 0
+        total_size += sum(sys.getsizeof(v) for v in self.llm_inputs.values())
+        if self.qwen_llm_input is not None and "qwen" not in self.llm_inputs:
+            total_size += sys.getsizeof(self.qwen_llm_input)
         total_size += sys.getsizeof(self.caption)
         total_size += sys.getsizeof(self.enhanced_caption)
         total_size += len(self.webp_bytes) if self.webp_bytes else 0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -121,13 +121,14 @@ video_cpu = [
     "torchvision",
     "einops",
     "easydict",
+    "timm"
 ]
 
 video_cuda12 = [
     "nemo_curator[video_cpu]",
     "nemo_curator[cuda12]",
     "cvcuda_cu12",
-    "flash-attn<=2.8.3; (platform_machine == 'x86_64' and platform_system != 'Darwin')",
+    "flash-attn>=2.7.1,<=2.8.2; (platform_machine == 'x86_64' and platform_system != 'Darwin')",  
     "pycuda",
     "PyNvVideoCodec==2.0.2; (platform_machine == 'x86_64' and platform_system != 'Darwin')",
     "torch<=2.8.0",

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.10, <3.13"
 resolution-markers = [
     "python_full_version >= '3.12' and platform_machine == 'aarch64' and sys_platform == 'darwin'",
@@ -1825,13 +1825,13 @@ wheels = [
 
 [[package]]
 name = "flash-attn"
-version = "2.8.3"
+version = "2.8.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "einops", marker = "platform_machine == 'x86_64' and sys_platform != 'darwin'" },
     { name = "torch", version = "2.8.0+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "platform_machine == 'x86_64' and sys_platform != 'darwin'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/3b/b2/8d76c41ad7974ee264754709c22963447f7f8134613fd9ce80984ed0dab7/flash_attn-2.8.3.tar.gz", hash = "sha256:1e71dd64a9e0280e0447b8a0c2541bad4bf6ac65bdeaa2f90e51a9e57de0370d", size = 8447812, upload-time = "2025-08-15T08:28:12.911Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/63/91/91bcbd7424877fa8da4e7cc04b8a777247a33037b9c1fd976a5ad426c047/flash_attn-2.8.2.tar.gz", hash = "sha256:740a5370f406cbe16155cc6d078ec543a97a137501f32cba89198295e6b80e54", size = 8167111, upload-time = "2025-07-24T16:06:45.953Z" }
 
 [[package]]
 name = "fonttools"
@@ -3963,6 +3963,7 @@ all = [
     { name = "resiliparse" },
     { name = "s5cmd" },
     { name = "sentencepiece" },
+    { name = "timm" },
     { name = "torch", version = "2.7.1", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'x86_64' and sys_platform == 'darwin'" },
     { name = "torch", version = "2.8.0", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine != 'x86_64'" },
     { name = "torch", version = "2.8.0+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "platform_machine == 'x86_64' and sys_platform != 'darwin'" },
@@ -4061,6 +4062,7 @@ video-cpu = [
     { name = "easydict" },
     { name = "einops" },
     { name = "opencv-python" },
+    { name = "timm" },
     { name = "torchvision", version = "0.22.1", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'x86_64' and sys_platform == 'darwin'" },
     { name = "torchvision", version = "0.23.0", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine != 'x86_64'" },
     { name = "torchvision", version = "0.23.0+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "platform_machine == 'x86_64' and sys_platform != 'darwin'" },
@@ -4076,6 +4078,7 @@ video-cuda12 = [
     { name = "pycuda" },
     { name = "pynvml" },
     { name = "pynvvideocodec", marker = "platform_machine == 'x86_64' and sys_platform != 'darwin'" },
+    { name = "timm" },
     { name = "torch", version = "2.7.1", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'x86_64' and sys_platform == 'darwin'" },
     { name = "torch", version = "2.8.0", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine != 'x86_64'" },
     { name = "torch", version = "2.8.0+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "platform_machine == 'x86_64' and sys_platform != 'darwin'" },
@@ -4169,6 +4172,7 @@ requires-dist = [
     { name = "resiliparse", marker = "extra == 'text-cpu'" },
     { name = "s5cmd", marker = "extra == 'text-cpu'" },
     { name = "sentencepiece", marker = "extra == 'text-cpu'" },
+    { name = "timm", marker = "extra == 'video-cpu'" },
     { name = "torch", marker = "platform_machine != 'x86_64' or sys_platform == 'darwin'", index = "https://pypi.org/simple" },
     { name = "torch", marker = "platform_machine == 'x86_64' and sys_platform != 'darwin'", index = "https://download.pytorch.org/whl/cu128" },
     { name = "torch", marker = "platform_machine == 'x86_64' and sys_platform != 'darwin' and extra == 'video-cuda12'", specifier = "<=2.8.0", index = "https://download.pytorch.org/whl/cu128" },
@@ -4181,7 +4185,7 @@ requires-dist = [
     { name = "torchvision", marker = "(platform_machine != 'x86_64' and extra == 'video-cpu') or (sys_platform == 'darwin' and extra == 'video-cpu')", index = "https://pypi.org/simple" },
     { name = "trafilatura", marker = "extra == 'text-cpu'", specifier = "==2.0.0" },
     { name = "transformers", specifier = "==4.55.2" },
-    { name = "vllm", marker = "platform_machine == 'x86_64' and sys_platform != 'darwin' and extra == 'video-cuda12'", specifier = "==0.10.2" },
+    { name = "vllm", marker = "platform_machine == 'x86_64' and sys_platform != 'darwin' and extra == 'video-cuda12'", specifier = ">=0.10.2" },
     { name = "warcio", marker = "extra == 'text-cpu'" },
 ]
 provides-extras = ["cuda12", "deduplication-cuda12", "audio-cpu", "audio-cuda12", "image-cpu", "image-cuda12", "text-cpu", "text-cuda12", "video-cpu", "video-cuda12", "all"]
@@ -7910,6 +7914,26 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/d5/2d/4d77f6feb9292bfdd23d5813e442b3bba883f42d0ac78ef5fdc56873f756/tiktoken-0.11.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7f929255c705efec7a28bf515e29dc74220b2f07544a8c81b8d69e8efc4578bd", size = 1183308, upload-time = "2025-08-08T23:57:48.566Z" },
     { url = "https://files.pythonhosted.org/packages/7a/65/7ff0a65d3bb0fc5a1fb6cc71b03e0f6e71a68c5eea230d1ff1ba3fd6df49/tiktoken-0.11.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:61f1d15822e4404953d499fd1dcc62817a12ae9fb1e4898033ec8fe3915fdf8e", size = 1244301, upload-time = "2025-08-08T23:57:49.642Z" },
     { url = "https://files.pythonhosted.org/packages/f5/6e/5b71578799b72e5bdcef206a214c3ce860d999d579a3b56e74a6c8989ee2/tiktoken-0.11.0-cp312-cp312-win_amd64.whl", hash = "sha256:45927a71ab6643dfd3ef57d515a5db3d199137adf551f66453be098502838b0f", size = 884282, upload-time = "2025-08-08T23:57:50.759Z" },
+]
+
+[[package]]
+name = "timm"
+version = "1.0.20"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "huggingface-hub" },
+    { name = "pyyaml" },
+    { name = "safetensors" },
+    { name = "torch", version = "2.7.1", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'x86_64' and sys_platform == 'darwin'" },
+    { name = "torch", version = "2.8.0", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine != 'x86_64'" },
+    { name = "torch", version = "2.8.0+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "platform_machine == 'x86_64' and sys_platform != 'darwin'" },
+    { name = "torchvision", version = "0.22.1", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'x86_64' and sys_platform == 'darwin'" },
+    { name = "torchvision", version = "0.23.0", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine != 'x86_64'" },
+    { name = "torchvision", version = "0.23.0+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "platform_machine == 'x86_64' and sys_platform != 'darwin'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b5/ba/6f5d96622a4a9fc315da53f58b3ca224c66015efe40aa191df0d523ede7c/timm-1.0.20.tar.gz", hash = "sha256:7468d32a410c359181c1ef961f49c7e213286e0c342bfb898b99534a4221fc54", size = 2360052, upload-time = "2025-09-21T17:26:35.492Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c5/74/5573615570bf010f788e977ac57c4b49db0aaf6d634134f6a9212d8dcdfd/timm-1.0.20-py3-none-any.whl", hash = "sha256:f6e62f780358476691996c47aa49de87b95cc507edf923c3042f74a07e45b7fe", size = 2504047, upload-time = "2025-09-21T17:26:33.487Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Description
Adds support for the Nemotron Nano 12B V2 VLM

## Usage
1) Download model checkpoints
2) Run
```bash
python tutorials/video/getting-started/video_split_clip_example.py \
  --video-dir </path/to/videos_directory/> \
  --output-clip-path ./outputs \
  --generate-captions \
  --captioning-algorithm nemotron \
  --captioning-model-path </path/to/checkpoints/> \
  --captioning-batch-size 8 \
  --no-generate-embeddings 
```
## Checklist
<!--
Note: All commits need to be signed and signed off. This can be done via `-sS` flags while commiting
`git commit -sS -m "...."
-->
- [X] I am familiar with the [Contributing Guide](https://github.com/NVIDIA-NeMo/Curator/blob/main/CONTRIBUTING.md).
- [ ] New or Existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
