### PR TITLE
Add ray_shutdown method to RayDataStageActorAdapter

### DIFF
--- a/nemo_curator/backends/ray_data/adapter.py
+++ b/nemo_curator/backends/ray_data/adapter.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from collections.abc import Callable
+from contextlib import suppress
 from typing import Any
 
 from loguru import logger
@@ -54,6 +55,15 @@ class RayDataStageAdapter(BaseStageAdapter):
     def batch_size(self) -> int | None:
         """Get the batch size for this stage."""
         return self._batch_size
+
+    def __ray_shutdown__(self):
+        """
+        Called automatically by Ray when the actor is being destroyed.
+        Ensures resources like GPU memory, subprocesses, etc. are cleaned up.
+        """
+        with suppress(Exception):
+            if hasattr(self.stage, "teardown"):
+                self.stage.teardown()
 
     def _process_batch_internal(self, batch: dict[str, Any]) -> dict[str, Any]:
         """Internal method that handles the actual batch processing logic.


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
Added __ray_shutdown__ to RayDataStageActorAdapter so stages properly clean up resources (e.g., GPU memory, subprocesses) when actors are destroyed.

## Checklist
<!--
Note: All commits need to be signed and signed off. This can be done via `-sS` flags while commiting
`git commit -sS -m "...."
-->
- [ y] I am familiar with the [Contributing Guide](https://github.com/NVIDIA-NeMo/Curator/blob/main/CONTRIBUTING.md).
- [ y] New or Existing tests cover these changes.
- [ y] The documentation is up to date with these changes.

Closes: https://github.com/issues/assigned?issue=NVIDIA-NeMo%7CCurator%7C1617
