### PR TITLE
docs: expand tutorials Quick Start with docs and Core Concepts links

### DIFF
--- a/tutorials/README.md
+++ b/tutorials/README.md
@@ -4,7 +4,7 @@ Hands-on tutorials for curating data across all modalities with NeMo Curator. Co
 
 ## Quick Start
 
-**New to NeMo Curator?** Start with the [Getting Started Guide](https://docs.nvidia.com/nemo/curator/latest/get-started/index.html) or try the [`quickstart.py`](quickstart.py) example to understand core concepts.
+**New to NeMo Curator?** Start with the [`quickstart.py`](quickstart.py) example to understand core concepts.
 
 ## Tutorials by Modality
 

--- a/tutorials/README.md
+++ b/tutorials/README.md
@@ -4,7 +4,11 @@ Hands-on tutorials for curating data across all modalities with NeMo Curator. Co
 
 ## Quick Start
 
-**New to NeMo Curator?** Start with the [`quickstart.py`](quickstart.py) example to understand core concepts.
+**New to NeMo Curator?**
+
+1. [Install and run a modality quickstart](https://docs.nvidia.com/nemo/curator/latest/get-started/) from the [documentation](https://docs.nvidia.com/nemo/curator/latest/)
+2. Read [Core Concepts](https://docs.nvidia.com/nemo/curator/latest/about/concepts) to learn the pipeline architecture
+3. Run [`quickstart.py`](quickstart.py) for a hands-on example of Tasks, Stages, and Pipelines
 
 ## Tutorials by Modality
 


### PR DESCRIPTION
## Summary

Builds on #1802 with a content-strategy fix for the tutorials README Quick Start section.

- Removes the mislabeled Getting Started link (it pointed to install/modality quickstarts, not core concepts)
- Adds a clear onboarding sequence: [documentation](https://docs.nvidia.com/nemo/curator/latest/) → [Core Concepts](https://docs.nvidia.com/nemo/curator/latest/about/concepts) → [`quickstart.py`](tutorials/quickstart.py)
- Keeps the docs ↔ in-repo tutorials bridge instead of collapsing onboarding to quickstart-only

## Test plan

- [ ] Verify Quick Start links resolve: get-started, main docs, Core Concepts, quickstart.py
- [ ] Confirm onboarding copy matches each destination's purpose


Made with [Cursor](https://cursor.com)