### PR TITLE
docs: fix tutorial doc links and add data curation challenges

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,16 @@ Video and audio pipelines depend on system codec libraries; the published contai
 
 ## Why NeMo Curator
 
+Model quality depends on data quality. Raw web-scale corpora contain duplicate content, low-quality text, unsafe material, and modality-specific noise. Without systematic curation, teams waste compute on redundant or harmful data and see weaker downstream performance.
+
+NeMo Curator helps mitigate these common challenges:
+
+- **Scale** — process terabyte-to-petabyte datasets across laptops or multi-node GPU clusters
+- **Quality** — filter, classify, and score content with GPU-accelerated pipeline stages
+- **Deduplication** — remove exact, fuzzy, and semantic duplicates that inflate token counts
+- **Throughput** — streaming execution and auto-balanced stages keep GPUs utilized end-to-end
+- **Repeatability** — modular stages you can compose, version, and rerun in production
+
 ### Proven at scale: Nemotron
 
 NeMo Curator powers the data pipelines behind [NVIDIA Nemotron](https://developer.nvidia.com/nemotron) models. The [Nemotron-4 pre-training dataset](https://arxiv.org/abs/2402.16819) was curated using NeMo Curator's text pipeline across 8+ trillion tokens of multilingual web data — quality filtering, deduplication, and domain classification at scale.

--- a/tutorials/README.md
+++ b/tutorials/README.md
@@ -35,7 +35,7 @@ The [`quickstart.py`](quickstart.py) demonstrates NeMo Curator's foundational ar
 
 | Category | Links |
 |----------|-------|
-| **Getting Started** | [Installation](https://docs.nvidia.com/nemo/curator/latest/admin/installation.html) • [Core Concepts](https://docs.nvidia.com/nemo/curator/latest/about/concepts/index.html) |
+| **Getting Started** | [Installation](https://docs.nvidia.com/nemo/curator/latest/get-started/installation) • [Setup & Deployment](https://docs.nvidia.com/nemo/curator/latest/admin/) • [Core Concepts](https://docs.nvidia.com/nemo/curator/latest/about/concepts/) |
 | **Modality Guides** | [Text Curation](https://docs.nvidia.com/nemo/curator/latest/curate-text/index.html) • [Image Curation](https://docs.nvidia.com/nemo/curator/latest/curate-images/index.html) • [Video Curation](https://docs.nvidia.com/nemo/curator/latest/curate-video/index.html) |
 | **Advanced** | [Custom Pipelines](https://docs.nvidia.com/nemo/curator/latest/reference/index.html) • [Execution Backends](https://docs.nvidia.com/nemo/curator/latest/reference/infrastructure/execution-backends.html) • [API Reference](https://docs.nvidia.com/nemo/curator/latest/apidocs/index.html) |
 


### PR DESCRIPTION
## Summary
- Fix broken/stale documentation links in `tutorials/README.md` — Installation now points to the canonical get-started URL, and Setup & Deployment replaces the removed Configuration link
- Add a brief "why data curation matters" section to the README with common challenges NeMo Curator helps mitigate (scale, quality, deduplication, throughput, repeatability)

Closes #1264
Closes #1549

## Test plan
- [x] Verified Installation, Setup & Deployment, and Core Concepts URLs return 200
- [x] README renders correctly with new challenges bullets under "Why NeMo Curator"


Made with [Cursor](https://cursor.com)