### PR TITLE
feat(audio-postprocessing): agent-ready timestamp mapper (refined-span + multi-speaker fixes)

### DIFF
--- a/nemo_curator/stages/audio/_agent_ready.py
+++ b/nemo_curator/stages/audio/_agent_ready.py
@@ -1,0 +1,318 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field, is_dataclass
+from enum import Enum
+from typing import TYPE_CHECKING, Any, ClassVar, Literal
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+AudioForm = Literal["file", "waveform"]
+ProducedForm = Literal["tensor", "disk"]
+Cardinality = Literal["1:1", "1:1 nested-list", "1:N fan-out", "N:1", "filter"]
+Dispatch = Literal["process", "process_batch", "auto"]
+# How a stage handles per-item failures at runtime. "unknown" means the stage
+# has not declared a uniform policy (the default for most stages today).
+ErrorPolicy = Literal["skip", "fail", "annotate", "unknown"]
+
+# Semantic role vocabulary. Because key *names* are agent-configurable
+# (config-knobs-only standardization: every read/written key is a ``*_key``
+# constructor field that an agent may rename), two stages can only be chained
+# reliably by matching the *role* a key plays, not its literal string. Roles are
+# resolved from the invariant ``*_key`` field name (see ``_roles.py``), so they
+# survive an agent renaming a key's value. ``"unknown"`` is the safe default and
+# never blocks composition.
+Role = Literal[
+    "audio_filepath",
+    "waveform",
+    "sample_rate",
+    "duration",
+    "num_samples",
+    "segments",
+    "diar_segments",
+    "vad_segments",
+    "overlap_segments",
+    "timestamps",
+    "start",
+    "end",
+    "start_ms",
+    "end_ms",
+    "text",
+    "pred_text",
+    "reference_text",
+    "words",
+    "alignment",
+    "speaker_id",
+    "num_speakers",
+    "score",
+    "metrics",
+    "prediction",
+    "segment_num",
+    "original_file",
+    "item_id",
+    "windows",
+    "manifest_path",
+    "output_path",
+    "unknown",
+]
+
+
+@dataclass(frozen=True)
+class ParamSpec:
+    """A single constructor parameter an agent can set on a stage.
+
+    Usually derived automatically from the stage's dataclass fields (or
+    ``__init__`` signature) via
+    :func:`nemo_curator.stages.audio._agent_registry.stage_params`, but a stage
+    may also override/augment entries in ``StageContract.params``.
+    """
+
+    name: str
+    type: str = "Any"
+    default: Any = None
+    required: bool = False
+    choices: list[Any] | None = None  # populated for Literal[...] params
+    description: str | None = None
+    role: Role | None = None  # semantic role of the key this param configures
+
+
+@dataclass(frozen=True)
+class IOSpec:
+    """Task data keys and audio forms read or written by a stage."""
+
+    data_keys: list[str] = field(default_factory=list)
+    segment_data_keys: list[str] = field(default_factory=list)
+    accepts: list[AudioForm] = field(default_factory=list)
+    produces: list[ProducedForm] = field(default_factory=list)
+
+
+@dataclass(frozen=True)
+class Gates:
+    """Execution gates or side effects an agent should know before wrapping a stage."""
+
+    writes_to_disk: bool = False
+    requires_gpu: bool = False
+    requires_internet_first_run: bool = False
+    requires_ffmpeg: bool = False
+    lifecycle_side_effects: bool = False
+    runtime_secrets: list[str] = field(default_factory=list)
+    # Serializability contract for sinks (distinguishes the two JSON sinks):
+    #   requires_serializable_input — this stage serializes task.data as-is (e.g.
+    #     raw json.dumps) and will fail on a resident tensor/audio blob.
+    #   sanitizes_output — this stage strips tensors/audio blobs, so anything
+    #     downstream of it is serialization-safe.
+    requires_serializable_input: bool = False
+    sanitizes_output: bool = False
+
+
+@dataclass(frozen=True)
+class SizeEnvelope:
+    """Coarse size and memory hints for agent planning."""
+
+    max_input_sec: float | None = None
+    allowed_sample_rates: list[int] | None = None
+    channels: Literal["mono", "stereo", "any"] = "any"
+    memory_hint: str | None = None
+
+
+@dataclass(frozen=True)
+class StaticHints:
+    """Instance-independent hints a stage may declare for discovery/planning.
+
+    Lets a stage expose ``cardinality_options``, ``gates``, ``dispatch``,
+    ``error_policy``, ``description`` and ``stage_id`` *without* being
+    instantiated (see :meth:`AgentReady.describe_static`). Declared on a class
+    via the ``AGENT_STATIC`` ClassVar; every field defaults so declaring it is
+    fully optional and additive.
+    """
+
+    cardinality_options: list[str] = field(default_factory=list)
+    gates: Gates = field(default_factory=Gates)
+    dispatch: Dispatch = "auto"
+    error_policy: ErrorPolicy = "unknown"
+    description: str | None = None
+    stage_id: str | None = None
+
+
+@dataclass(frozen=True)
+class StageContract:
+    """Read-only discovery contract for an agent-ready processing stage."""
+
+    reads: IOSpec = field(default_factory=IOSpec)
+    writes: IOSpec = field(default_factory=IOSpec)
+    reads_one_of: list[IOSpec] = field(default_factory=list)
+    metadata_reads: list[str] = field(default_factory=list)
+    metadata_writes: list[str] = field(default_factory=list)
+    cardinality: Cardinality = "1:1"
+    cardinality_options: list[str] = field(default_factory=list)
+    iteration_key: str | None = None
+    preserves_upstream_keys: bool = True
+    wrappable: bool = True
+    size_envelope: SizeEnvelope = field(default_factory=SizeEnvelope)
+    gates: Gates = field(default_factory=Gates)
+    # Agent-facing metadata (advisory; defaults keep older describe() calls valid).
+    stage_id: str | None = None  # stable semantic id; defaults to the class name when None
+    description: str | None = None  # one-line human summary for planners/UIs
+    params: list[ParamSpec] = field(default_factory=list)  # usually auto-derived at discovery time
+    dispatch: Dispatch = "auto"  # "auto" => infer from the stage at runtime
+    error_policy: ErrorPolicy = "unknown"
+    # Resolved-key-value -> semantic role. Populated at discovery time by
+    # ``_agent_registry.build_contract``; empty when a contract is built by hand.
+    key_roles: dict[str, Role] = field(default_factory=dict)
+    # True when the stage only implements ``process_batch`` (``process`` raises).
+    # Auto-derived at discovery time; agents must not call ``process`` on these.
+    batch_only: bool = False
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a JSON-safe dict of this contract (``json.dumps`` never raises)."""
+        return {
+            "reads": asdict(self.reads),
+            "writes": asdict(self.writes),
+            "reads_one_of": [asdict(spec) for spec in self.reads_one_of],
+            "metadata_reads": list(self.metadata_reads),
+            "metadata_writes": list(self.metadata_writes),
+            "cardinality": self.cardinality,
+            "cardinality_options": list(self.cardinality_options),
+            "iteration_key": self.iteration_key,
+            "preserves_upstream_keys": self.preserves_upstream_keys,
+            "wrappable": self.wrappable,
+            "size_envelope": asdict(self.size_envelope),
+            "gates": asdict(self.gates),
+            "stage_id": self.stage_id,
+            "description": self.description,
+            "params": [_paramspec_to_dict(p) for p in self.params],
+            "dispatch": self.dispatch,
+            "error_policy": self.error_policy,
+            "key_roles": dict(self.key_roles),
+            "batch_only": self.batch_only,
+        }
+
+
+def _jsonable_default(value: Any) -> Any:  # noqa: ANN401, PLR0911 (complexity accepted: one early return per JSON type family)
+    """Coerce an arbitrary param default to a JSON-serializable value.
+
+    Non-serializable objects (tensors, models, callables) become a short
+    ``"<non-serializable: Type>"`` sentinel rather than raising.
+    """
+    if value is None or isinstance(value, (str, int, float, bool)):
+        return value
+    if isinstance(value, (list, tuple, set)):
+        return [_jsonable_default(v) for v in value]
+    if isinstance(value, dict):
+        return {str(k): _jsonable_default(v) for k, v in value.items()}
+    if isinstance(value, Enum):
+        return value.value
+    if is_dataclass(value) and not isinstance(value, type):
+        try:
+            return {k: _jsonable_default(v) for k, v in asdict(value).items()}
+        except Exception:  # noqa: BLE001
+            return f"<non-serializable: {type(value).__name__}>"
+    return f"<non-serializable: {type(value).__name__}>"
+
+
+def _paramspec_to_dict(p: ParamSpec) -> dict[str, Any]:
+    return {
+        "name": p.name,
+        "type": p.type,
+        "default": _jsonable_default(p.default),
+        "required": p.required,
+        "choices": None if p.choices is None else [_jsonable_default(c) for c in p.choices],
+        "description": p.description,
+        "role": p.role,
+    }
+
+
+def _json_type(type_str: str | None) -> str | None:
+    """Map a rendered ParamSpec.type string to a JSON-Schema type (or None to omit)."""
+    if not type_str:
+        return None
+    t = type_str.replace(" ", "").replace("|None", "")
+    if t.startswith("Optional["):
+        t = t[len("Optional[") : -1] if t.endswith("]") else t
+    scalar = {"str": "string", "int": "integer", "float": "number", "bool": "boolean"}
+    if t in scalar:
+        return scalar[t]
+    lowered = t.lower()
+    if lowered.startswith(("list", "sequence", "tuple")):
+        return "array"
+    if lowered.startswith(("dict", "mapping")):
+        return "object"
+    return None
+
+
+def to_json_schema(params: list[ParamSpec]) -> dict[str, Any]:
+    """Build a JSON-Schema ``object`` describing a stage's configurable params.
+
+    Suitable as the argument schema for an agent's stage-configuration form.
+    """
+    properties: dict[str, Any] = {}
+    required: list[str] = []
+    for p in params:
+        schema: dict[str, Any] = {}
+        json_type = _json_type(p.type)
+        if json_type is not None:
+            schema["type"] = json_type
+        if p.choices is not None:
+            schema["enum"] = [_jsonable_default(c) for c in p.choices]
+        if p.default is not None:
+            schema["default"] = _jsonable_default(p.default)
+        if p.description:
+            schema["description"] = p.description
+        if p.role:
+            schema["x-role"] = p.role
+        properties[p.name] = schema
+        if p.required:
+            required.append(p.name)
+    out: dict[str, Any] = {"type": "object", "properties": properties}
+    if required:
+        out["required"] = required
+    return out
+
+
+class AgentReady:
+    """Mixin for stages that expose a read-only agent discovery contract."""
+
+    # Opt-in, instance-independent discovery hints. Annotated as ClassVar so
+    # dataclass stages do NOT treat these as fields. All optional/additive.
+    AGENT_STATIC: ClassVar[StaticHints | None] = None
+    # Set True on stages whose ``process`` raises (only ``process_batch`` works).
+    BATCH_ONLY: ClassVar[bool] = False
+    # Rare per-field role overrides keyed by ``*_key`` field name. Consulted
+    # before the shared ``_roles.KEY_ROLES`` table.
+    KEY_ROLE_OVERRIDES: ClassVar[Mapping[str, Role]] = {}
+
+    def describe(self) -> StageContract:
+        raise NotImplementedError
+
+    @classmethod
+    def describe_static(cls) -> StageContract:
+        """Instance-free contract for discovery/planning.
+
+        Uses class defaults + ``AGENT_STATIC`` and never runs ``__init__`` side
+        effects, so it is safe for stages with required constructor args. Prefer
+        the instance-level :meth:`describe` (or
+        ``_agent_registry.build_contract``) when resolved key *values* are
+        needed.
+        """
+        from nemo_curator.stages.audio._agent_registry import static_contract
+
+        return static_contract(cls)
+
+
+# (resolve_contract was removed: dead code whose signature promised class
+# acceptance the body rejected. Instances: use stage.describe() / build_contract;
+# classes: use describe_static() / static_contract.)

--- a/nemo_curator/stages/audio/_residency.py
+++ b/nemo_curator/stages/audio/_residency.py
@@ -21,12 +21,52 @@ from typing import TYPE_CHECKING, Any, Literal
 
 import soundfile as sf
 
+from nemo_curator.stages.audio._agent_ready import AudioForm, IOSpec
 from nemo_curator.stages.audio.common import ensure_waveform_2d, load_audio_file
 
 if TYPE_CHECKING:
     from collections.abc import Callable
 
 InputResidency = Literal["file", "waveform", "auto"]
+
+
+def accepts_for_residency(residency: str) -> list[AudioForm]:
+    """Audio forms an instance actually consumes, given its ``input_residency``.
+
+    The single source of truth a stage's ``describe()`` derives ``accepts`` from,
+    so a ``file``-mode instance can never advertise ``waveform`` (the drift /
+    "lying accepts" bug). ``auto`` accepts either; ``file``/``waveform`` accept
+    only that form.
+    """
+    if residency == "waveform":
+        return ["waveform"]
+    if residency == "file":
+        return ["file"]
+    return ["file", "waveform"]  # "auto"
+
+
+def residency_read_specs(
+    input_residency: str,
+    *,
+    audio_filepath_key: str,
+    waveform_key: str = "waveform",
+    sample_rate_key: str = "sample_rate",
+) -> list[IOSpec]:
+    """The residency-filtered audio read options for a stage's ``reads_one_of``.
+
+    ``file`` -> ``[file spec]``; ``waveform`` -> ``[waveform spec]``; ``auto`` ->
+    ``[waveform spec, file spec]``. Keeps ``accepts`` **and** ``data_keys`` in
+    lockstep with ``input_residency`` so a stage can never advertise (or require)
+    a form it won't consume for its current setting — which lets the deterministic
+    role check enforce residency compatibility with no extra check.
+    """
+    forms = accepts_for_residency(input_residency)
+    specs: list[IOSpec] = []
+    if "waveform" in forms:
+        specs.append(IOSpec(data_keys=[waveform_key, sample_rate_key], accepts=["waveform"]))
+    if "file" in forms:
+        specs.append(IOSpec(data_keys=[audio_filepath_key], accepts=["file"]))
+    return specs
 
 
 def resolve_audio(  # noqa: PLR0913 (complexity accepted: keyword-only residency/key knobs mirror the stage fields)

--- a/nemo_curator/stages/audio/_residency.py
+++ b/nemo_curator/stages/audio/_residency.py
@@ -1,0 +1,157 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import contextlib
+import os
+import tempfile
+from typing import TYPE_CHECKING, Any, Literal
+
+import soundfile as sf
+
+from nemo_curator.stages.audio.common import ensure_waveform_2d, load_audio_file
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+InputResidency = Literal["file", "waveform", "auto"]
+
+
+def resolve_audio(  # noqa: PLR0913 (complexity accepted: keyword-only residency/key knobs mirror the stage fields)
+    item: dict[str, Any],
+    *,
+    residency: InputResidency = "auto",
+    audio_filepath_key: str = "audio_filepath",
+    waveform_key: str = "waveform",
+    sample_rate_key: str = "sample_rate",
+    mono: bool = True,
+    loader: Callable[..., tuple[Any, int]] | None = None,
+) -> tuple[Any, int] | None:
+    """Return ``(waveform_2d, sample_rate)`` from tensor keys or a file path.
+
+    ``auto`` prefers an existing waveform, then falls back to file loading.
+    ``waveform`` never falls back to disk. ``file`` always loads from the
+    configured path key.
+
+    ``loader`` overrides the file-loading callable (default
+    :func:`~nemo_curator.stages.audio.common.load_audio_file`); stages pass
+    their own module-level symbol so callers can patch it at the stage module.
+    """
+    waveform = item.get(waveform_key)
+    sample_rate = item.get(sample_rate_key)
+    if residency != "file" and waveform is not None and sample_rate is not None:
+        return ensure_waveform_2d(waveform), int(sample_rate)
+
+    if residency == "waveform":
+        return None
+
+    path = item.get(audio_filepath_key)
+    if path:
+        expanded = os.path.expanduser(str(path))
+        if os.path.exists(expanded):
+            return (loader or load_audio_file)(expanded, mono=mono)
+    return None
+
+
+def _as_soundfile_array(waveform: Any) -> Any:  # noqa: ANN401
+    waveform = ensure_waveform_2d(waveform)
+    if hasattr(waveform, "detach"):
+        waveform = waveform.detach()
+    if hasattr(waveform, "cpu"):
+        waveform = waveform.cpu()
+    if hasattr(waveform, "numpy"):
+        waveform = waveform.numpy()
+    if getattr(waveform, "ndim", 0) == 2:  # noqa: PLR2004 - 2 == a (channels, samples) 2-D array
+        channels, samples = waveform.shape
+        if channels == 1:
+            return waveform[0]
+        if channels < samples:
+            return waveform.T
+    return waveform
+
+
+def resolve_audio_path(  # noqa: PLR0913 (complexity accepted: keyword-only residency/key knobs mirror the stage fields)
+    item: dict[str, Any],
+    *,
+    residency: InputResidency = "auto",
+    audio_filepath_key: str = "audio_filepath",
+    waveform_key: str = "waveform",
+    sample_rate_key: str = "sample_rate",
+    temp_dir: str | None = None,
+    register_temp: list[str] | None = None,
+) -> str | None:
+    """Return an audio path, writing a temp WAV when only a waveform exists.
+
+    When a temp WAV is materialized from an in-memory waveform and
+    ``register_temp`` is provided, the temp path is appended to that list so the
+    caller can delete it after use (see :func:`cleanup_temp_files`). Without
+    ``register_temp`` the caller is responsible for cleanup itself.
+    """
+    path = item.get(audio_filepath_key)
+    local_path: str | None = None
+    if residency != "waveform" and path:
+        local_path = os.path.expanduser(str(path))
+        if os.path.exists(local_path):
+            return local_path
+        # Protocol-prefixed paths (file://, http(s)://, s3://, ...) were handled
+        # by the stages' own fsspec machinery before the residency layer existed;
+        # keep accepting them when the target exists remotely.
+        if "://" in str(path):
+            try:
+                from fsspec.core import url_to_fs
+
+                fs, fspath = url_to_fs(str(path))
+                if fs.exists(fspath):
+                    return path
+            except Exception:  # noqa: BLE001, S110 - unknown protocol/creds -> deliberate fall-through
+                pass
+
+    if residency == "file":
+        # Pre-residency stages handed unverified paths straight to their own
+        # downstream machinery (ffmpeg/NeMo/fsspec) and let it report the
+        # failure; keep that contract instead of gating on os.path.exists.
+        return local_path
+
+    waveform = item.get(waveform_key)
+    sample_rate = item.get(sample_rate_key)
+    if waveform is None or sample_rate is None:
+        return local_path
+
+    fd, tmp = tempfile.mkstemp(suffix=".wav", dir=temp_dir)
+    os.close(fd)
+    sf.write(tmp, _as_soundfile_array(waveform), int(sample_rate))
+    if register_temp is not None:
+        register_temp.append(tmp)
+    return tmp
+
+
+def cleanup_temp_files(paths: list[str] | None) -> None:
+    """Best-effort removal of temp files created by :func:`resolve_audio_path`."""
+    for path in paths or ():
+        with contextlib.suppress(OSError):
+            os.remove(path)
+
+
+def produce_audio_filepath(
+    item: dict[str, Any],
+    new_path: str,
+    *,
+    key: str = "audio_filepath",
+    original_key: str = "original_audio_filepath",
+) -> None:
+    """Update a canonical audio path while preserving the first prior value."""
+    if key in item and original_key not in item:
+        item[original_key] = item[key]
+    item[key] = new_path

--- a/nemo_curator/stages/audio/common.py
+++ b/nemo_curator/stages/audio/common.py
@@ -25,6 +25,7 @@ from fsspec.core import url_to_fs
 from loguru import logger
 
 from nemo_curator.backends.base import NodeInfo, WorkerMetadata
+from nemo_curator.stages.audio._agent_ready import AgentReady, Gates, IOSpec, StageContract
 from nemo_curator.stages.base import CompositeStage, ProcessingStage
 from nemo_curator.stages.file_partitioning import FilePartitioningStage
 from nemo_curator.tasks import AudioTask, EmptyTask, FileGroupTask
@@ -41,7 +42,7 @@ def get_audio_duration(audio_filepath: str) -> float:
 
 
 @dataclass
-class GetAudioDurationStage(ProcessingStage[AudioTask, AudioTask]):
+class GetAudioDurationStage(AgentReady, ProcessingStage[AudioTask, AudioTask]):
     """Compute audio duration from the file at *audio_filepath_key* and
     store the result under *duration_key*.
 
@@ -65,6 +66,12 @@ class GetAudioDurationStage(ProcessingStage[AudioTask, AudioTask]):
     def outputs(self) -> tuple[list[str], list[str]]:
         return [], [self.duration_key]
 
+    def describe(self) -> StageContract:
+        return StageContract(
+            reads=IOSpec(data_keys=[self.audio_filepath_key], accepts=["file"]),
+            writes=IOSpec(data_keys=[self.duration_key]),
+        )
+
     def process(self, task: AudioTask) -> AudioTask:
         t0 = time.perf_counter()
         audio_filepath = task.data[self.audio_filepath_key]
@@ -74,7 +81,7 @@ class GetAudioDurationStage(ProcessingStage[AudioTask, AudioTask]):
         return task
 
 
-class PreserveByValueStage(ProcessingStage[AudioTask, AudioTask]):
+class PreserveByValueStage(AgentReady, ProcessingStage[AudioTask, AudioTask]):
     """Filter entries by comparing *input_value_key* against *target_value*.
 
     Returns ``None`` from ``process()`` to drop entries that fail the
@@ -87,6 +94,7 @@ class PreserveByValueStage(ProcessingStage[AudioTask, AudioTask]):
     """
 
     name: str = "PreserveByValueStage"
+    BATCH_ONLY = True  # process() raises; only process_batch is implemented (agent-discovery hint)
 
     def __init__(
         self,
@@ -107,6 +115,13 @@ class PreserveByValueStage(ProcessingStage[AudioTask, AudioTask]):
 
     def outputs(self) -> tuple[list[str], list[str]]:
         return [], [self.input_value_key]
+
+    def describe(self) -> StageContract:
+        return StageContract(
+            reads=IOSpec(data_keys=[self.input_value_key]),
+            writes=IOSpec(data_keys=[self.input_value_key]),
+            cardinality="filter",
+        )
 
     def process(self, task: AudioTask) -> AudioTask | None:
         msg = "PreserveByValueStage only supports process_batch"
@@ -133,7 +148,7 @@ class PreserveByValueStage(ProcessingStage[AudioTask, AudioTask]):
 
 
 @dataclass
-class ManifestReaderStage(ProcessingStage[FileGroupTask, AudioTask]):
+class ManifestReaderStage(AgentReady, ProcessingStage[FileGroupTask, AudioTask]):
     """Read JSONL manifest files from a FileGroupTask and emit one AudioTask per line.
 
     Uses line-by-line streaming via fsspec (no Pandas) to keep memory at ~1x file size.
@@ -177,9 +192,16 @@ class ManifestReaderStage(ProcessingStage[FileGroupTask, AudioTask]):
     def num_workers(self) -> int | None:
         return 1
 
+    def describe(self) -> StageContract:
+        return StageContract(
+            writes=IOSpec(data_keys=["audio_filepath"]),
+            cardinality="1:N fan-out",
+            gates=Gates(lifecycle_side_effects=True),
+        )
+
 
 @dataclass
-class ManifestReader(CompositeStage[EmptyTask, AudioTask]):
+class ManifestReader(AgentReady, CompositeStage[EmptyTask, AudioTask]):
     """Composite stage for reading JSONL manifests.
 
     Decomposes into:
@@ -227,9 +249,12 @@ class ManifestReader(CompositeStage[EmptyTask, AudioTask]):
             parts.append(f"with target blocksize {self.blocksize}")
         return ", ".join(parts)
 
+    def describe(self) -> StageContract:
+        return StageContract(cardinality="1:N fan-out", wrappable=False)
+
 
 @dataclass
-class ManifestWriterStage(ProcessingStage[AudioTask, AudioTask]):
+class ManifestWriterStage(AgentReady, ProcessingStage[AudioTask, AudioTask]):
     """Append a single AudioTask to a JSONL manifest file.
 
     The output file is truncated once in ``setup()`` (called on the driver)
@@ -290,6 +315,18 @@ class ManifestWriterStage(ProcessingStage[AudioTask, AudioTask]):
     def num_workers(self) -> int | None:
         return 1
 
+    def describe(self) -> StageContract:
+        return StageContract(
+            gates=Gates(
+                writes_to_disk=True,
+                lifecycle_side_effects=True,
+                # Serializes task.data as-is via json.dumps; a resident tensor
+                # (e.g. a waveform) will crash it. Route through
+                # AudioToDocumentStage (which sanitizes) if one may be present.
+                requires_serializable_input=True,
+            ),
+        )
+
 
 def load_audio_file(audio_path: str, mono: bool = True) -> tuple[torch.Tensor, int]:
     """Load audio file and return waveform tensor (channels, samples) and sample rate."""
@@ -327,6 +364,13 @@ def resolve_waveform_from_item(
     item['audio_filepath'], resolves missing sample_rate from file header.
     Updates item in-place when loading from file.
     Returns None if resolution fails.
+
+    .. note::
+       The canonical resolver is :func:`nemo_curator.stages.audio._residency.resolve_audio`.
+       This helper is retained for its unique behavior — reading ``sample_rate`` from the
+       file header *without* reloading an already-present waveform, and writing the loaded
+       waveform/sample_rate back into ``item`` — which ``resolve_audio`` does not replicate.
+       Prefer ``resolve_audio`` in new code.
     """
     waveform = item.get("waveform")
     sample_rate = item.get("sample_rate")

--- a/nemo_curator/stages/audio/postprocessing/timestamp_mapper.py
+++ b/nemo_curator/stages/audio/postprocessing/timestamp_mapper.py
@@ -40,6 +40,7 @@ from typing import Any
 
 from loguru import logger
 
+from nemo_curator.stages.audio._agent_ready import AgentReady, IOSpec, StageContract
 from nemo_curator.stages.base import ProcessingStage
 from nemo_curator.stages.resources import Resources
 from nemo_curator.tasks import AudioTask
@@ -102,7 +103,7 @@ def _translate_to_original(
 
 
 @dataclass
-class TimestampMapperStage(ProcessingStage[AudioTask, AudioTask]):
+class TimestampMapperStage(AgentReady, ProcessingStage[AudioTask, AudioTask]):
     """
     Normalize task data at the pipeline output boundary.
 
@@ -124,6 +125,17 @@ class TimestampMapperStage(ProcessingStage[AudioTask, AudioTask]):
     """
 
     passthrough_keys: list[str] | None = field(default=None)
+    audio_filepath_key: str = "audio_filepath"
+    original_file_key: str = "original_file"
+    original_start_ms_key: str = "original_start_ms"
+    original_end_ms_key: str = "original_end_ms"
+    duration_ms_key: str = "duration_ms"
+    duration_key: str = "duration"
+    start_ms_key: str = "start_ms"
+    end_ms_key: str = "end_ms"
+    diar_segments_key: str = "diar_segments"
+    speaking_duration_key: str = "speaking_duration"
+    mappings_key: str = "segment_mappings"
     name: str = "TimestampMapper"
     batch_size: int = 1
     resources: Resources = field(default_factory=lambda: Resources(cpus=1.0))
@@ -144,38 +156,100 @@ class TimestampMapperStage(ProcessingStage[AudioTask, AudioTask]):
         return [], []
 
     def outputs(self) -> tuple[list[str], list[str]]:
-        return [], ["original_file", "original_start_ms", "original_end_ms", "duration_ms", "duration"]
+        return [], [
+            self.original_file_key,
+            self.original_start_ms_key,
+            self.original_end_ms_key,
+            self.duration_ms_key,
+            self.duration_key,
+        ]
+
+    def describe(self) -> StageContract:
+        return StageContract(
+            # original_file is optional-with-fallback in every branch (process()
+            # falls back to audio_filepath / 'unknown'), so it must NOT gate
+            # composition — requiring it false-rejected runnable topologies.
+            reads_one_of=[
+                IOSpec(data_keys=[self.start_ms_key, self.end_ms_key]),
+                IOSpec(data_keys=[self.diar_segments_key]),
+                IOSpec(data_keys=[self.duration_key]),
+            ],
+            writes=IOSpec(
+                data_keys=[
+                    self.original_file_key,
+                    self.original_start_ms_key,
+                    self.original_end_ms_key,
+                    self.duration_ms_key,
+                    self.duration_key,
+                    self.diar_segments_key,
+                    self.speaking_duration_key,
+                ]
+            ),
+            metadata_reads=[self.mappings_key],
+            preserves_upstream_keys=False,
+        )
 
     def process(self, task: AudioTask) -> AudioTask | list[AudioTask]:
-        mappings = (task._metadata or {}).get("segment_mappings")
+        mappings = (task._metadata or {}).get(self.mappings_key)
         item = task.data
 
         if mappings:
-            concat_start = item.get("start_ms", 0)
-            concat_end = item.get("end_ms", 0)
-            if concat_end <= concat_start:
-                logger.warning(
-                    f"[TimestampMapper] Skipping task with invalid range: start_ms={concat_start}, end_ms={concat_end}"
-                )
-                return []
-            original_ranges = _translate_to_original(mappings, concat_start, concat_end)
-
-            if len(original_ranges) > 1:
-                logger.debug(
-                    f"[TimestampMapper] Rejecting segment "
-                    f"[{concat_start}-{concat_end}ms] that spans "
-                    f"{len(original_ranges)} concat mappings"
-                )
-                return []
-
-            if len(original_ranges) == 1:
-                result = self._build_output_item(item, original_ranges[0])
+            # start_ms/end_ms (from a VAD pass) is the most precise per-segment
+            # range, so map it through the concat->original mappings FIRST; fall
+            # back to composing coarser diar_segments only when it is absent
+            # (e.g. SpeakerSep with no trailing VAD).
+            #
+            # Coordinate frame: VAD always runs on a FULL-LENGTH signal — either
+            # the concatenated stream (single-speaker VAD->Concat) or the
+            # separator's full-length per-speaker stem (SpeakerSep->VAD; the
+            # separator overlays each speaker's audio onto a silent track at its
+            # concat-time position, so the stem is concat-length, NOT a compacted
+            # 0-based clip). So start_ms/end_ms are ALWAYS concat-time here and map
+            # directly — same for single- and multi-speaker. (A future separator
+            # that emitted compacted 0-based speaker clips would have to tag its
+            # coordinate frame explicitly so we could add the offset before
+            # mapping; we must NOT infer that from the mere presence of
+            # diar_segments — doing so collapsed every per-speaker VAD sub-segment
+            # onto the diar union and produced duplicate whole-clip rows.)
+            start_ms = item.get(self.start_ms_key)
+            end_ms = item.get(self.end_ms_key)
+            diar_segments = item.get(self.diar_segments_key)
+            if start_ms is not None and end_ms is not None:
+                if end_ms <= start_ms:
+                    logger.warning(
+                        f"[TimestampMapper] Skipping task with invalid range: start_ms={start_ms}, end_ms={end_ms}"
+                    )
+                    return []
+                original_ranges = _translate_to_original(mappings, start_ms, end_ms)
+                if len(original_ranges) > 1:
+                    logger.warning(
+                        f"[TimestampMapper] Rejecting segment "
+                        f"[{start_ms}-{end_ms}ms] that spans "
+                        f"{len(original_ranges)} concat mappings"
+                    )
+                    return []
+                if len(original_ranges) == 1:
+                    result = self._build_output_item(item, original_ranges[0])
+                else:
+                    logger.warning(
+                        f"[TimestampMapper] No overlapping mappings for task {task.task_id} "
+                        f"[{start_ms}-{end_ms}ms], dropping"
+                    )
+                    return []
             else:
-                logger.warning(
-                    f"[TimestampMapper] No overlapping mappings for task {task.task_id} "
-                    f"[{concat_start}-{concat_end}ms], dropping"
-                )
-                return []
+                if not diar_segments:
+                    logger.warning(
+                        f"[TimestampMapper] Task {task.task_id} has mappings but no start_ms/end_ms "
+                        f"or diar_segments to resolve against, dropping"
+                    )
+                    return []
+                result = self._build_output_from_diar_and_mappings(item, diar_segments, mappings)
+                if result is None:
+                    logger.warning(
+                        f"[TimestampMapper] No overlapping mappings for diar segments in task "
+                        f"{task.task_id}, dropping"
+                    )
+                    return []
         else:
             result = self._build_output_item_no_mapping(item)
 
@@ -192,63 +266,94 @@ class TimestampMapperStage(ProcessingStage[AudioTask, AudioTask]):
 
     def _build_output_item(self, item: dict[str, Any], orig: dict[str, Any]) -> dict[str, Any]:
         result: dict[str, Any] = {
-            "original_file": orig["original_file"],
-            "original_start_ms": orig["original_start_ms"],
-            "original_end_ms": orig["original_end_ms"],
-            "duration_ms": orig["duration_ms"],
-            "duration": orig["duration_ms"] / 1000.0,
+            self.original_file_key: orig["original_file"],
+            self.original_start_ms_key: orig["original_start_ms"],
+            self.original_end_ms_key: orig["original_end_ms"],
+            self.duration_ms_key: orig["duration_ms"],
+            self.duration_key: orig["duration_ms"] / 1000.0,
         }
+        self._copy_passthrough(item, result)
+        return result
+
+    def _build_output_from_diar_and_mappings(
+        self,
+        item: dict[str, Any],
+        diar_segments: list,
+        mappings: list[dict[str, Any]],
+    ) -> dict[str, Any] | None:
+        """Compose concat-time diar segments through concat->original mappings.
+
+        Each diar segment is ``[start_sec, end_sec]`` in concatenated time.
+        We translate every segment to original-file time and span the union.
+        Returns ``None`` if no segment overlaps any mapping.
+        """
+        ranges: list[dict[str, Any]] = []
+        for seg in diar_segments:
+            try:
+                start_sec, end_sec = float(seg[0]), float(seg[1])
+            except (TypeError, IndexError, ValueError):
+                continue
+            ranges.extend(_translate_to_original(mappings, int(start_sec * 1000), int(end_sec * 1000)))
+        if not ranges:
+            return None
+        result: dict[str, Any] = {
+            self.original_file_key: ranges[0]["original_file"],
+            self.original_start_ms_key: min(r["original_start_ms"] for r in ranges),
+            self.original_end_ms_key: max(r["original_end_ms"] for r in ranges),
+        }
+        result[self.duration_ms_key] = result[self.original_end_ms_key] - result[self.original_start_ms_key]
+        result[self.duration_key] = result[self.duration_ms_key] / 1000.0
         self._copy_passthrough(item, result)
         return result
 
     def _build_output_item_no_mapping(self, item: dict[str, Any]) -> dict[str, Any]:
         result: dict[str, Any] = {
-            "original_file": item.get("original_file", item.get("audio_filepath", "unknown")),
+            self.original_file_key: item.get(self.original_file_key, item.get(self.audio_filepath_key, "unknown")),
         }
 
-        start_ms = item.get("start_ms")
-        end_ms = item.get("end_ms")
+        start_ms = item.get(self.start_ms_key)
+        end_ms = item.get(self.end_ms_key)
 
         if start_ms is not None and end_ms is not None and end_ms > start_ms:
-            result["original_start_ms"] = int(start_ms)
-            result["original_end_ms"] = int(end_ms)
-            result["duration_ms"] = int(end_ms - start_ms)
-            result["duration"] = (end_ms - start_ms) / 1000.0
+            result[self.original_start_ms_key] = int(start_ms)
+            result[self.original_end_ms_key] = int(end_ms)
+            result[self.duration_ms_key] = int(end_ms - start_ms)
+            result[self.duration_key] = (end_ms - start_ms) / 1000.0
             self._copy_passthrough(item, result)
             return result
 
-        diar_segments = item.get("diar_segments")
+        diar_segments = item.get(self.diar_segments_key)
         if diar_segments and len(diar_segments) > 0:
             diar_segments = sorted(diar_segments, key=lambda x: x[0])
             first_start = diar_segments[0][0]
             last_end = diar_segments[-1][1]
-            result["original_start_ms"] = int(first_start * 1000)
-            result["original_end_ms"] = int(last_end * 1000)
-            result["duration_ms"] = int((last_end - first_start) * 1000)
-            result["duration"] = last_end - first_start
+            result[self.original_start_ms_key] = int(first_start * 1000)
+            result[self.original_end_ms_key] = int(last_end * 1000)
+            result[self.duration_ms_key] = int((last_end - first_start) * 1000)
+            result[self.duration_key] = last_end - first_start
             speaking = sum(end - start for start, end in diar_segments)
-            result["speaking_duration"] = round(speaking, 3)
-            result["diar_segments"] = [[round(s, 3), round(e, 3)] for s, e in diar_segments]
+            result[self.speaking_duration_key] = round(speaking, 3)
+            result[self.diar_segments_key] = [[round(s, 3), round(e, 3)] for s, e in diar_segments]
             self._copy_passthrough(item, result)
             return result
 
-        dur = item.get("duration")
+        dur = item.get(self.duration_key)
         if dur is not None and float(dur) > 0:
             duration_ms = int(float(dur) * 1000)
-            result["original_start_ms"] = 0
-            result["original_end_ms"] = duration_ms
-            result["duration_ms"] = duration_ms
-            result["duration"] = float(dur)
+            result[self.original_start_ms_key] = 0
+            result[self.original_end_ms_key] = duration_ms
+            result[self.duration_ms_key] = duration_ms
+            result[self.duration_key] = float(dur)
         else:
             logger.warning(
                 f"[TimestampMapper] No timing information found for "
-                f"{result['original_file']!r} — emitting zero-duration row. "
+                f"{result[self.original_file_key]!r} — emitting zero-duration row. "
                 f"This may indicate a corrupted or zero-length source file."
             )
-            result["original_start_ms"] = 0
-            result["original_end_ms"] = 0
-            result["duration_ms"] = 0
-            result["duration"] = 0.0
+            result[self.original_start_ms_key] = 0
+            result[self.original_end_ms_key] = 0
+            result[self.duration_ms_key] = 0
+            result[self.duration_key] = 0.0
 
         self._copy_passthrough(item, result)
         return result


### PR DESCRIPTION
## Summary
Makes `TimestampMapperStage` agent-ready and fixes two timestamp-correctness bugs.

### What the stage does
Translates per-segment times measured on concatenated/processed audio back to the original source timeline, using the `segment_mappings` metadata produced upstream (see `_translate_to_original`).

### Fixes
- Refined-span preference ("Failure 1"): when a segment carries refined `start_ms`/`end_ms` (e.g. from a VAD pass) AND coarser `diar_segments`, the refined values are now mapped through and preferred; diarization spans are used only as a fallback when refined times are absent.
- Multi-speaker: each speaker's segment maps to its own distinct window instead of collapsing to a shared/union span (no cross-speaker assignment).

### Contract
- `describe()` declares OR-shaped reads (`start_ms`+`end_ms` | `diar_segments` | `duration`) and `metadata_reads=[segment_mappings]`.

## Notes for reviewers
- Behavior change to be aware of: the stage sets `preserves_upstream_keys=False` and REPLACES `task.data`, keeping only a `passthrough_keys` whitelist (defaults keep filter scores + speaker metadata like `speaker_id`). Non-whitelisted keys (e.g. `text`, `segment_num`) are dropped — set `passthrough_keys` to retain them.
- Worth a look: `_translate_to_original` (overlap/offset math, ms units) and the refined-vs-diar branch.

## Test plan
- [ ] `pytest tests/stages/audio/postprocessing -q`
- [ ] `pytest tests/stages/audio -q -k timestamp_mapper`