### PR TITLE
feat(audio-filtering): agent-ready band/sigmos/utmos filters (residency + filter/annotate)

### DIFF
--- a/nemo_curator/stages/audio/_agent_ready.py
+++ b/nemo_curator/stages/audio/_agent_ready.py
@@ -1,0 +1,318 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field, is_dataclass
+from enum import Enum
+from typing import TYPE_CHECKING, Any, ClassVar, Literal
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+AudioForm = Literal["file", "waveform"]
+ProducedForm = Literal["tensor", "disk"]
+Cardinality = Literal["1:1", "1:1 nested-list", "1:N fan-out", "N:1", "filter"]
+Dispatch = Literal["process", "process_batch", "auto"]
+# How a stage handles per-item failures at runtime. "unknown" means the stage
+# has not declared a uniform policy (the default for most stages today).
+ErrorPolicy = Literal["skip", "fail", "annotate", "unknown"]
+
+# Semantic role vocabulary. Because key *names* are agent-configurable
+# (config-knobs-only standardization: every read/written key is a ``*_key``
+# constructor field that an agent may rename), two stages can only be chained
+# reliably by matching the *role* a key plays, not its literal string. Roles are
+# resolved from the invariant ``*_key`` field name (see ``_roles.py``), so they
+# survive an agent renaming a key's value. ``"unknown"`` is the safe default and
+# never blocks composition.
+Role = Literal[
+    "audio_filepath",
+    "waveform",
+    "sample_rate",
+    "duration",
+    "num_samples",
+    "segments",
+    "diar_segments",
+    "vad_segments",
+    "overlap_segments",
+    "timestamps",
+    "start",
+    "end",
+    "start_ms",
+    "end_ms",
+    "text",
+    "pred_text",
+    "reference_text",
+    "words",
+    "alignment",
+    "speaker_id",
+    "num_speakers",
+    "score",
+    "metrics",
+    "prediction",
+    "segment_num",
+    "original_file",
+    "item_id",
+    "windows",
+    "manifest_path",
+    "output_path",
+    "unknown",
+]
+
+
+@dataclass(frozen=True)
+class ParamSpec:
+    """A single constructor parameter an agent can set on a stage.
+
+    Usually derived automatically from the stage's dataclass fields (or
+    ``__init__`` signature) via
+    :func:`nemo_curator.stages.audio._agent_registry.stage_params`, but a stage
+    may also override/augment entries in ``StageContract.params``.
+    """
+
+    name: str
+    type: str = "Any"
+    default: Any = None
+    required: bool = False
+    choices: list[Any] | None = None  # populated for Literal[...] params
+    description: str | None = None
+    role: Role | None = None  # semantic role of the key this param configures
+
+
+@dataclass(frozen=True)
+class IOSpec:
+    """Task data keys and audio forms read or written by a stage."""
+
+    data_keys: list[str] = field(default_factory=list)
+    segment_data_keys: list[str] = field(default_factory=list)
+    accepts: list[AudioForm] = field(default_factory=list)
+    produces: list[ProducedForm] = field(default_factory=list)
+
+
+@dataclass(frozen=True)
+class Gates:
+    """Execution gates or side effects an agent should know before wrapping a stage."""
+
+    writes_to_disk: bool = False
+    requires_gpu: bool = False
+    requires_internet_first_run: bool = False
+    requires_ffmpeg: bool = False
+    lifecycle_side_effects: bool = False
+    runtime_secrets: list[str] = field(default_factory=list)
+    # Serializability contract for sinks (distinguishes the two JSON sinks):
+    #   requires_serializable_input — this stage serializes task.data as-is (e.g.
+    #     raw json.dumps) and will fail on a resident tensor/audio blob.
+    #   sanitizes_output — this stage strips tensors/audio blobs, so anything
+    #     downstream of it is serialization-safe.
+    requires_serializable_input: bool = False
+    sanitizes_output: bool = False
+
+
+@dataclass(frozen=True)
+class SizeEnvelope:
+    """Coarse size and memory hints for agent planning."""
+
+    max_input_sec: float | None = None
+    allowed_sample_rates: list[int] | None = None
+    channels: Literal["mono", "stereo", "any"] = "any"
+    memory_hint: str | None = None
+
+
+@dataclass(frozen=True)
+class StaticHints:
+    """Instance-independent hints a stage may declare for discovery/planning.
+
+    Lets a stage expose ``cardinality_options``, ``gates``, ``dispatch``,
+    ``error_policy``, ``description`` and ``stage_id`` *without* being
+    instantiated (see :meth:`AgentReady.describe_static`). Declared on a class
+    via the ``AGENT_STATIC`` ClassVar; every field defaults so declaring it is
+    fully optional and additive.
+    """
+
+    cardinality_options: list[str] = field(default_factory=list)
+    gates: Gates = field(default_factory=Gates)
+    dispatch: Dispatch = "auto"
+    error_policy: ErrorPolicy = "unknown"
+    description: str | None = None
+    stage_id: str | None = None
+
+
+@dataclass(frozen=True)
+class StageContract:
+    """Read-only discovery contract for an agent-ready processing stage."""
+
+    reads: IOSpec = field(default_factory=IOSpec)
+    writes: IOSpec = field(default_factory=IOSpec)
+    reads_one_of: list[IOSpec] = field(default_factory=list)
+    metadata_reads: list[str] = field(default_factory=list)
+    metadata_writes: list[str] = field(default_factory=list)
+    cardinality: Cardinality = "1:1"
+    cardinality_options: list[str] = field(default_factory=list)
+    iteration_key: str | None = None
+    preserves_upstream_keys: bool = True
+    wrappable: bool = True
+    size_envelope: SizeEnvelope = field(default_factory=SizeEnvelope)
+    gates: Gates = field(default_factory=Gates)
+    # Agent-facing metadata (advisory; defaults keep older describe() calls valid).
+    stage_id: str | None = None  # stable semantic id; defaults to the class name when None
+    description: str | None = None  # one-line human summary for planners/UIs
+    params: list[ParamSpec] = field(default_factory=list)  # usually auto-derived at discovery time
+    dispatch: Dispatch = "auto"  # "auto" => infer from the stage at runtime
+    error_policy: ErrorPolicy = "unknown"
+    # Resolved-key-value -> semantic role. Populated at discovery time by
+    # ``_agent_registry.build_contract``; empty when a contract is built by hand.
+    key_roles: dict[str, Role] = field(default_factory=dict)
+    # True when the stage only implements ``process_batch`` (``process`` raises).
+    # Auto-derived at discovery time; agents must not call ``process`` on these.
+    batch_only: bool = False
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a JSON-safe dict of this contract (``json.dumps`` never raises)."""
+        return {
+            "reads": asdict(self.reads),
+            "writes": asdict(self.writes),
+            "reads_one_of": [asdict(spec) for spec in self.reads_one_of],
+            "metadata_reads": list(self.metadata_reads),
+            "metadata_writes": list(self.metadata_writes),
+            "cardinality": self.cardinality,
+            "cardinality_options": list(self.cardinality_options),
+            "iteration_key": self.iteration_key,
+            "preserves_upstream_keys": self.preserves_upstream_keys,
+            "wrappable": self.wrappable,
+            "size_envelope": asdict(self.size_envelope),
+            "gates": asdict(self.gates),
+            "stage_id": self.stage_id,
+            "description": self.description,
+            "params": [_paramspec_to_dict(p) for p in self.params],
+            "dispatch": self.dispatch,
+            "error_policy": self.error_policy,
+            "key_roles": dict(self.key_roles),
+            "batch_only": self.batch_only,
+        }
+
+
+def _jsonable_default(value: Any) -> Any:  # noqa: ANN401, PLR0911 (complexity accepted: one early return per JSON type family)
+    """Coerce an arbitrary param default to a JSON-serializable value.
+
+    Non-serializable objects (tensors, models, callables) become a short
+    ``"<non-serializable: Type>"`` sentinel rather than raising.
+    """
+    if value is None or isinstance(value, (str, int, float, bool)):
+        return value
+    if isinstance(value, (list, tuple, set)):
+        return [_jsonable_default(v) for v in value]
+    if isinstance(value, dict):
+        return {str(k): _jsonable_default(v) for k, v in value.items()}
+    if isinstance(value, Enum):
+        return value.value
+    if is_dataclass(value) and not isinstance(value, type):
+        try:
+            return {k: _jsonable_default(v) for k, v in asdict(value).items()}
+        except Exception:  # noqa: BLE001
+            return f"<non-serializable: {type(value).__name__}>"
+    return f"<non-serializable: {type(value).__name__}>"
+
+
+def _paramspec_to_dict(p: ParamSpec) -> dict[str, Any]:
+    return {
+        "name": p.name,
+        "type": p.type,
+        "default": _jsonable_default(p.default),
+        "required": p.required,
+        "choices": None if p.choices is None else [_jsonable_default(c) for c in p.choices],
+        "description": p.description,
+        "role": p.role,
+    }
+
+
+def _json_type(type_str: str | None) -> str | None:
+    """Map a rendered ParamSpec.type string to a JSON-Schema type (or None to omit)."""
+    if not type_str:
+        return None
+    t = type_str.replace(" ", "").replace("|None", "")
+    if t.startswith("Optional["):
+        t = t[len("Optional[") : -1] if t.endswith("]") else t
+    scalar = {"str": "string", "int": "integer", "float": "number", "bool": "boolean"}
+    if t in scalar:
+        return scalar[t]
+    lowered = t.lower()
+    if lowered.startswith(("list", "sequence", "tuple")):
+        return "array"
+    if lowered.startswith(("dict", "mapping")):
+        return "object"
+    return None
+
+
+def to_json_schema(params: list[ParamSpec]) -> dict[str, Any]:
+    """Build a JSON-Schema ``object`` describing a stage's configurable params.
+
+    Suitable as the argument schema for an agent's stage-configuration form.
+    """
+    properties: dict[str, Any] = {}
+    required: list[str] = []
+    for p in params:
+        schema: dict[str, Any] = {}
+        json_type = _json_type(p.type)
+        if json_type is not None:
+            schema["type"] = json_type
+        if p.choices is not None:
+            schema["enum"] = [_jsonable_default(c) for c in p.choices]
+        if p.default is not None:
+            schema["default"] = _jsonable_default(p.default)
+        if p.description:
+            schema["description"] = p.description
+        if p.role:
+            schema["x-role"] = p.role
+        properties[p.name] = schema
+        if p.required:
+            required.append(p.name)
+    out: dict[str, Any] = {"type": "object", "properties": properties}
+    if required:
+        out["required"] = required
+    return out
+
+
+class AgentReady:
+    """Mixin for stages that expose a read-only agent discovery contract."""
+
+    # Opt-in, instance-independent discovery hints. Annotated as ClassVar so
+    # dataclass stages do NOT treat these as fields. All optional/additive.
+    AGENT_STATIC: ClassVar[StaticHints | None] = None
+    # Set True on stages whose ``process`` raises (only ``process_batch`` works).
+    BATCH_ONLY: ClassVar[bool] = False
+    # Rare per-field role overrides keyed by ``*_key`` field name. Consulted
+    # before the shared ``_roles.KEY_ROLES`` table.
+    KEY_ROLE_OVERRIDES: ClassVar[Mapping[str, Role]] = {}
+
+    def describe(self) -> StageContract:
+        raise NotImplementedError
+
+    @classmethod
+    def describe_static(cls) -> StageContract:
+        """Instance-free contract for discovery/planning.
+
+        Uses class defaults + ``AGENT_STATIC`` and never runs ``__init__`` side
+        effects, so it is safe for stages with required constructor args. Prefer
+        the instance-level :meth:`describe` (or
+        ``_agent_registry.build_contract``) when resolved key *values* are
+        needed.
+        """
+        from nemo_curator.stages.audio._agent_registry import static_contract
+
+        return static_contract(cls)
+
+
+# (resolve_contract was removed: dead code whose signature promised class
+# acceptance the body rejected. Instances: use stage.describe() / build_contract;
+# classes: use describe_static() / static_contract.)

--- a/nemo_curator/stages/audio/_residency.py
+++ b/nemo_curator/stages/audio/_residency.py
@@ -21,12 +21,52 @@ from typing import TYPE_CHECKING, Any, Literal
 
 import soundfile as sf
 
+from nemo_curator.stages.audio._agent_ready import AudioForm, IOSpec
 from nemo_curator.stages.audio.common import ensure_waveform_2d, load_audio_file
 
 if TYPE_CHECKING:
     from collections.abc import Callable
 
 InputResidency = Literal["file", "waveform", "auto"]
+
+
+def accepts_for_residency(residency: str) -> list[AudioForm]:
+    """Audio forms an instance actually consumes, given its ``input_residency``.
+
+    The single source of truth a stage's ``describe()`` derives ``accepts`` from,
+    so a ``file``-mode instance can never advertise ``waveform`` (the drift /
+    "lying accepts" bug). ``auto`` accepts either; ``file``/``waveform`` accept
+    only that form.
+    """
+    if residency == "waveform":
+        return ["waveform"]
+    if residency == "file":
+        return ["file"]
+    return ["file", "waveform"]  # "auto"
+
+
+def residency_read_specs(
+    input_residency: str,
+    *,
+    audio_filepath_key: str,
+    waveform_key: str = "waveform",
+    sample_rate_key: str = "sample_rate",
+) -> list[IOSpec]:
+    """The residency-filtered audio read options for a stage's ``reads_one_of``.
+
+    ``file`` -> ``[file spec]``; ``waveform`` -> ``[waveform spec]``; ``auto`` ->
+    ``[waveform spec, file spec]``. Keeps ``accepts`` **and** ``data_keys`` in
+    lockstep with ``input_residency`` so a stage can never advertise (or require)
+    a form it won't consume for its current setting — which lets the deterministic
+    role check enforce residency compatibility with no extra check.
+    """
+    forms = accepts_for_residency(input_residency)
+    specs: list[IOSpec] = []
+    if "waveform" in forms:
+        specs.append(IOSpec(data_keys=[waveform_key, sample_rate_key], accepts=["waveform"]))
+    if "file" in forms:
+        specs.append(IOSpec(data_keys=[audio_filepath_key], accepts=["file"]))
+    return specs
 
 
 def resolve_audio(  # noqa: PLR0913 (complexity accepted: keyword-only residency/key knobs mirror the stage fields)

--- a/nemo_curator/stages/audio/_residency.py
+++ b/nemo_curator/stages/audio/_residency.py
@@ -1,0 +1,157 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import contextlib
+import os
+import tempfile
+from typing import TYPE_CHECKING, Any, Literal
+
+import soundfile as sf
+
+from nemo_curator.stages.audio.common import ensure_waveform_2d, load_audio_file
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+InputResidency = Literal["file", "waveform", "auto"]
+
+
+def resolve_audio(  # noqa: PLR0913 (complexity accepted: keyword-only residency/key knobs mirror the stage fields)
+    item: dict[str, Any],
+    *,
+    residency: InputResidency = "auto",
+    audio_filepath_key: str = "audio_filepath",
+    waveform_key: str = "waveform",
+    sample_rate_key: str = "sample_rate",
+    mono: bool = True,
+    loader: Callable[..., tuple[Any, int]] | None = None,
+) -> tuple[Any, int] | None:
+    """Return ``(waveform_2d, sample_rate)`` from tensor keys or a file path.
+
+    ``auto`` prefers an existing waveform, then falls back to file loading.
+    ``waveform`` never falls back to disk. ``file`` always loads from the
+    configured path key.
+
+    ``loader`` overrides the file-loading callable (default
+    :func:`~nemo_curator.stages.audio.common.load_audio_file`); stages pass
+    their own module-level symbol so callers can patch it at the stage module.
+    """
+    waveform = item.get(waveform_key)
+    sample_rate = item.get(sample_rate_key)
+    if residency != "file" and waveform is not None and sample_rate is not None:
+        return ensure_waveform_2d(waveform), int(sample_rate)
+
+    if residency == "waveform":
+        return None
+
+    path = item.get(audio_filepath_key)
+    if path:
+        expanded = os.path.expanduser(str(path))
+        if os.path.exists(expanded):
+            return (loader or load_audio_file)(expanded, mono=mono)
+    return None
+
+
+def _as_soundfile_array(waveform: Any) -> Any:  # noqa: ANN401
+    waveform = ensure_waveform_2d(waveform)
+    if hasattr(waveform, "detach"):
+        waveform = waveform.detach()
+    if hasattr(waveform, "cpu"):
+        waveform = waveform.cpu()
+    if hasattr(waveform, "numpy"):
+        waveform = waveform.numpy()
+    if getattr(waveform, "ndim", 0) == 2:  # noqa: PLR2004 - 2 == a (channels, samples) 2-D array
+        channels, samples = waveform.shape
+        if channels == 1:
+            return waveform[0]
+        if channels < samples:
+            return waveform.T
+    return waveform
+
+
+def resolve_audio_path(  # noqa: PLR0913 (complexity accepted: keyword-only residency/key knobs mirror the stage fields)
+    item: dict[str, Any],
+    *,
+    residency: InputResidency = "auto",
+    audio_filepath_key: str = "audio_filepath",
+    waveform_key: str = "waveform",
+    sample_rate_key: str = "sample_rate",
+    temp_dir: str | None = None,
+    register_temp: list[str] | None = None,
+) -> str | None:
+    """Return an audio path, writing a temp WAV when only a waveform exists.
+
+    When a temp WAV is materialized from an in-memory waveform and
+    ``register_temp`` is provided, the temp path is appended to that list so the
+    caller can delete it after use (see :func:`cleanup_temp_files`). Without
+    ``register_temp`` the caller is responsible for cleanup itself.
+    """
+    path = item.get(audio_filepath_key)
+    local_path: str | None = None
+    if residency != "waveform" and path:
+        local_path = os.path.expanduser(str(path))
+        if os.path.exists(local_path):
+            return local_path
+        # Protocol-prefixed paths (file://, http(s)://, s3://, ...) were handled
+        # by the stages' own fsspec machinery before the residency layer existed;
+        # keep accepting them when the target exists remotely.
+        if "://" in str(path):
+            try:
+                from fsspec.core import url_to_fs
+
+                fs, fspath = url_to_fs(str(path))
+                if fs.exists(fspath):
+                    return path
+            except Exception:  # noqa: BLE001, S110 - unknown protocol/creds -> deliberate fall-through
+                pass
+
+    if residency == "file":
+        # Pre-residency stages handed unverified paths straight to their own
+        # downstream machinery (ffmpeg/NeMo/fsspec) and let it report the
+        # failure; keep that contract instead of gating on os.path.exists.
+        return local_path
+
+    waveform = item.get(waveform_key)
+    sample_rate = item.get(sample_rate_key)
+    if waveform is None or sample_rate is None:
+        return local_path
+
+    fd, tmp = tempfile.mkstemp(suffix=".wav", dir=temp_dir)
+    os.close(fd)
+    sf.write(tmp, _as_soundfile_array(waveform), int(sample_rate))
+    if register_temp is not None:
+        register_temp.append(tmp)
+    return tmp
+
+
+def cleanup_temp_files(paths: list[str] | None) -> None:
+    """Best-effort removal of temp files created by :func:`resolve_audio_path`."""
+    for path in paths or ():
+        with contextlib.suppress(OSError):
+            os.remove(path)
+
+
+def produce_audio_filepath(
+    item: dict[str, Any],
+    new_path: str,
+    *,
+    key: str = "audio_filepath",
+    original_key: str = "original_audio_filepath",
+) -> None:
+    """Update a canonical audio path while preserving the first prior value."""
+    if key in item and original_key not in item:
+        item[original_key] = item[key]
+    item[key] = new_path

--- a/nemo_curator/stages/audio/common.py
+++ b/nemo_curator/stages/audio/common.py
@@ -25,6 +25,7 @@ from fsspec.core import url_to_fs
 from loguru import logger
 
 from nemo_curator.backends.base import NodeInfo, WorkerMetadata
+from nemo_curator.stages.audio._agent_ready import AgentReady, Gates, IOSpec, StageContract
 from nemo_curator.stages.base import CompositeStage, ProcessingStage
 from nemo_curator.stages.file_partitioning import FilePartitioningStage
 from nemo_curator.tasks import AudioTask, EmptyTask, FileGroupTask
@@ -41,7 +42,7 @@ def get_audio_duration(audio_filepath: str) -> float:
 
 
 @dataclass
-class GetAudioDurationStage(ProcessingStage[AudioTask, AudioTask]):
+class GetAudioDurationStage(AgentReady, ProcessingStage[AudioTask, AudioTask]):
     """Compute audio duration from the file at *audio_filepath_key* and
     store the result under *duration_key*.
 
@@ -65,6 +66,12 @@ class GetAudioDurationStage(ProcessingStage[AudioTask, AudioTask]):
     def outputs(self) -> tuple[list[str], list[str]]:
         return [], [self.duration_key]
 
+    def describe(self) -> StageContract:
+        return StageContract(
+            reads=IOSpec(data_keys=[self.audio_filepath_key], accepts=["file"]),
+            writes=IOSpec(data_keys=[self.duration_key]),
+        )
+
     def process(self, task: AudioTask) -> AudioTask:
         t0 = time.perf_counter()
         audio_filepath = task.data[self.audio_filepath_key]
@@ -74,7 +81,7 @@ class GetAudioDurationStage(ProcessingStage[AudioTask, AudioTask]):
         return task
 
 
-class PreserveByValueStage(ProcessingStage[AudioTask, AudioTask]):
+class PreserveByValueStage(AgentReady, ProcessingStage[AudioTask, AudioTask]):
     """Filter entries by comparing *input_value_key* against *target_value*.
 
     Returns ``None`` from ``process()`` to drop entries that fail the
@@ -87,6 +94,7 @@ class PreserveByValueStage(ProcessingStage[AudioTask, AudioTask]):
     """
 
     name: str = "PreserveByValueStage"
+    BATCH_ONLY = True  # process() raises; only process_batch is implemented (agent-discovery hint)
 
     def __init__(
         self,
@@ -107,6 +115,13 @@ class PreserveByValueStage(ProcessingStage[AudioTask, AudioTask]):
 
     def outputs(self) -> tuple[list[str], list[str]]:
         return [], [self.input_value_key]
+
+    def describe(self) -> StageContract:
+        return StageContract(
+            reads=IOSpec(data_keys=[self.input_value_key]),
+            writes=IOSpec(data_keys=[self.input_value_key]),
+            cardinality="filter",
+        )
 
     def process(self, task: AudioTask) -> AudioTask | None:
         msg = "PreserveByValueStage only supports process_batch"
@@ -133,7 +148,7 @@ class PreserveByValueStage(ProcessingStage[AudioTask, AudioTask]):
 
 
 @dataclass
-class ManifestReaderStage(ProcessingStage[FileGroupTask, AudioTask]):
+class ManifestReaderStage(AgentReady, ProcessingStage[FileGroupTask, AudioTask]):
     """Read JSONL manifest files from a FileGroupTask and emit one AudioTask per line.
 
     Uses line-by-line streaming via fsspec (no Pandas) to keep memory at ~1x file size.
@@ -177,9 +192,16 @@ class ManifestReaderStage(ProcessingStage[FileGroupTask, AudioTask]):
     def num_workers(self) -> int | None:
         return 1
 
+    def describe(self) -> StageContract:
+        return StageContract(
+            writes=IOSpec(data_keys=["audio_filepath"]),
+            cardinality="1:N fan-out",
+            gates=Gates(lifecycle_side_effects=True),
+        )
+
 
 @dataclass
-class ManifestReader(CompositeStage[EmptyTask, AudioTask]):
+class ManifestReader(AgentReady, CompositeStage[EmptyTask, AudioTask]):
     """Composite stage for reading JSONL manifests.
 
     Decomposes into:
@@ -227,9 +249,12 @@ class ManifestReader(CompositeStage[EmptyTask, AudioTask]):
             parts.append(f"with target blocksize {self.blocksize}")
         return ", ".join(parts)
 
+    def describe(self) -> StageContract:
+        return StageContract(cardinality="1:N fan-out", wrappable=False)
+
 
 @dataclass
-class ManifestWriterStage(ProcessingStage[AudioTask, AudioTask]):
+class ManifestWriterStage(AgentReady, ProcessingStage[AudioTask, AudioTask]):
     """Append a single AudioTask to a JSONL manifest file.
 
     The output file is truncated once in ``setup()`` (called on the driver)
@@ -290,6 +315,18 @@ class ManifestWriterStage(ProcessingStage[AudioTask, AudioTask]):
     def num_workers(self) -> int | None:
         return 1
 
+    def describe(self) -> StageContract:
+        return StageContract(
+            gates=Gates(
+                writes_to_disk=True,
+                lifecycle_side_effects=True,
+                # Serializes task.data as-is via json.dumps; a resident tensor
+                # (e.g. a waveform) will crash it. Route through
+                # AudioToDocumentStage (which sanitizes) if one may be present.
+                requires_serializable_input=True,
+            ),
+        )
+
 
 def load_audio_file(audio_path: str, mono: bool = True) -> tuple[torch.Tensor, int]:
     """Load audio file and return waveform tensor (channels, samples) and sample rate."""
@@ -327,6 +364,13 @@ def resolve_waveform_from_item(
     item['audio_filepath'], resolves missing sample_rate from file header.
     Updates item in-place when loading from file.
     Returns None if resolution fails.
+
+    .. note::
+       The canonical resolver is :func:`nemo_curator.stages.audio._residency.resolve_audio`.
+       This helper is retained for its unique behavior — reading ``sample_rate`` from the
+       file header *without* reloading an already-present waveform, and writing the loaded
+       waveform/sample_rate back into ``item`` — which ``resolve_audio`` does not replicate.
+       Prefer ``resolve_audio`` in new code.
     """
     waveform = item.get("waveform")
     sample_rate = item.get("sample_rate")

--- a/nemo_curator/stages/audio/filtering/band.py
+++ b/nemo_curator/stages/audio/filtering/band.py
@@ -40,7 +40,7 @@ from loguru import logger
 
 from nemo_curator.backends.base import NodeInfo, WorkerMetadata
 from nemo_curator.stages.audio._agent_ready import AgentReady, Gates, IOSpec, StageContract
-from nemo_curator.stages.audio._residency import resolve_audio
+from nemo_curator.stages.audio._residency import residency_read_specs, resolve_audio
 from nemo_curator.stages.audio.filtering.band_filter_module.predict import BandPredictor
 from nemo_curator.stages.base import ProcessingStage
 from nemo_curator.stages.resources import Resources
@@ -132,8 +132,12 @@ class BandFilterStage(AgentReady, ProcessingStage[AudioTask, AudioTask]):
     def describe(self) -> StageContract:
         return StageContract(
             reads_one_of=[
-                IOSpec(data_keys=[self.waveform_key, self.sample_rate_key], accepts=["waveform"]),
-                IOSpec(data_keys=[self.audio_filepath_key], accepts=["file"]),
+                *residency_read_specs(
+                    self.input_residency,
+                    audio_filepath_key=self.audio_filepath_key,
+                    waveform_key=self.waveform_key,
+                    sample_rate_key=self.sample_rate_key,
+                ),
                 IOSpec(data_keys=[self.segments_key]),
             ],
             writes=IOSpec(data_keys=[self.prediction_key], segment_data_keys=[self.prediction_key]),

--- a/nemo_curator/stages/audio/filtering/band.py
+++ b/nemo_curator/stages/audio/filtering/band.py
@@ -39,7 +39,8 @@ from huggingface_hub import hf_hub_download
 from loguru import logger
 
 from nemo_curator.backends.base import NodeInfo, WorkerMetadata
-from nemo_curator.stages.audio.common import resolve_waveform_from_item
+from nemo_curator.stages.audio._agent_ready import AgentReady, Gates, IOSpec, StageContract
+from nemo_curator.stages.audio._residency import resolve_audio
 from nemo_curator.stages.audio.filtering.band_filter_module.predict import BandPredictor
 from nemo_curator.stages.base import ProcessingStage
 from nemo_curator.stages.resources import Resources
@@ -47,21 +48,36 @@ from nemo_curator.tasks import AudioTask
 
 _HF_REPO_ID = "nvidia/nemocurator-speech-bandwidth-filter"
 _HF_MODEL_FILENAME = "band_classifier_model_band_7000_samples.joblib"
+_VALID_MODES = {"task", "segments", "auto"}
+_VALID_ACTIONS = {"filter", "annotate"}
 
 
 @dataclass
-class BandFilterStage(ProcessingStage[AudioTask, AudioTask]):
+class BandFilterStage(AgentReady, ProcessingStage[AudioTask, AudioTask]):
     """
     Band filter stage for bandwidth classification.
 
-    Classifies audio as "full_band" or "narrow_band" and filters
-    based on the specified band_value to pass.
+    Classifies audio as "full_band" or "narrow_band". With action="filter"
+    (default) only items matching band_value pass; with action="annotate" every
+    item is kept and only the prediction is recorded.
 
     Args:
         model_path: Local path to band classifier model (.joblib). If not provided,
             the model is downloaded from HuggingFace (nvidia/nemocurator-speech-bandwidth-filter).
         cache_dir: Directory to cache downloaded models.
         band_value: Which band type to pass ("full_band" or "narrow_band")
+        mode: Where to classify — "task" (top-level audio), "segments" (nested segments list),
+            or "auto" (segments when segments_key is present, else task; default). Setting
+            "task" or "segments" overrides the auto-detection.
+        action: "filter" drops items that fail the band check; "annotate" keeps every item —
+            including items that fail or cannot be classified — and only writes prediction_key.
+        audio_filepath_key: Key in data dict for the input audio file path.
+        waveform_key: Key in data dict for the in-memory waveform tensor.
+        sample_rate_key: Key in data dict for the waveform sample rate.
+        segments_key: Key in data dict holding the nested segments list (segments/auto mode).
+        prediction_key: Key where the band prediction ("full_band"/"narrow_band") is written.
+        input_residency: Which input to use — "waveform" (in-memory only), "file"
+            (audio_filepath only), or "auto" (waveform first, file fallback; default).
 
     Note:
         GPU is used automatically when resources specify gpus > 0.
@@ -78,6 +94,14 @@ class BandFilterStage(ProcessingStage[AudioTask, AudioTask]):
     model_path: str | None = None
     cache_dir: str | None = None
     band_value: Literal["full_band", "narrow_band"] = "full_band"
+    mode: Literal["task", "segments", "auto"] = "auto"
+    action: Literal["filter", "annotate"] = "filter"
+    audio_filepath_key: str = "audio_filepath"
+    waveform_key: str = "waveform"
+    sample_rate_key: str = "sample_rate"
+    segments_key: str = "segments"
+    prediction_key: str = "band_prediction"
+    input_residency: Literal["file", "waveform", "auto"] = "auto"
 
     name: str = "BandFilter"
     batch_size: int = 1
@@ -92,12 +116,31 @@ class BandFilterStage(ProcessingStage[AudioTask, AudioTask]):
         if self.band_value not in self._VALID_BAND_VALUES:
             msg = f"band_value must be one of {self._VALID_BAND_VALUES!r}, got {self.band_value!r}"
             raise ValueError(msg)
+        if self.mode not in _VALID_MODES:
+            msg = f"mode must be one of {_VALID_MODES!r}, got {self.mode!r}"
+            raise ValueError(msg)
+        if self.action not in _VALID_ACTIONS:
+            msg = f"action must be one of {_VALID_ACTIONS!r}, got {self.action!r}"
+            raise ValueError(msg)
 
     def inputs(self) -> tuple[list[str], list[str]]:
         return [], []
 
     def outputs(self) -> tuple[list[str], list[str]]:
-        return [], ["band_prediction"]
+        return [], [self.prediction_key]
+
+    def describe(self) -> StageContract:
+        return StageContract(
+            reads_one_of=[
+                IOSpec(data_keys=[self.waveform_key, self.sample_rate_key], accepts=["waveform"]),
+                IOSpec(data_keys=[self.audio_filepath_key], accepts=["file"]),
+                IOSpec(data_keys=[self.segments_key]),
+            ],
+            writes=IOSpec(data_keys=[self.prediction_key], segment_data_keys=[self.prediction_key]),
+            cardinality="filter" if self.action == "filter" else "1:1",
+            cardinality_options=["filter", "annotate"],
+            gates=Gates(requires_gpu=self.resources.gpus > 0, requires_internet_first_run=self.model_path is None),
+        )
 
     def setup_on_node(
         self, _node_info: NodeInfo | None = None, _worker_metadata: WorkerMetadata | None = None
@@ -147,24 +190,30 @@ class BandFilterStage(ProcessingStage[AudioTask, AudioTask]):
 
     def process(self, task: AudioTask) -> AudioTask | list[AudioTask]:
         """
-        Filter audio based on bandwidth classification.
+        Filter or annotate audio based on bandwidth classification.
 
-        When ``task.data`` contains a ``"segments"`` key (nested mode from VAD),
-        each segment is evaluated individually and only survivors are kept.
+        Segment handling follows ``mode``: with ``mode="auto"`` (default), nested
+        mode is used when ``task.data`` contains the ``segments_key``; ``mode="task"``
+        or ``mode="segments"`` overrides that auto-detection. In nested mode each
+        segment is evaluated individually. With ``action="filter"`` only survivors
+        are kept; with ``action="annotate"`` every item is kept — including items
+        that fail the band check or cannot be classified — and only the prediction
+        annotation is written.
 
         Returns:
-            AudioTask if passes the band filter, [] if filtered out.
+            AudioTask if it passes (or ``action="annotate"``), [] if filtered out.
         """
-        if "segments" in task.data:
+        use_segments = self.mode == "segments" or (self.mode == "auto" and self.segments_key in task.data)
+        if use_segments:
             survivors = []
-            for seg in task.data["segments"]:
+            for seg in task.data.get(self.segments_key, []):
                 temp = AudioTask(data=seg)
                 result = self._process_single(temp)
-                if result is not None:
+                if result is not None or self.action == "annotate":
                     survivors.append(temp.data)
-            task.data["segments"] = survivors
-            return task if survivors else []
-        return self._process_single(task) or []
+            task.data[self.segments_key] = survivors
+            return task if survivors or self.action == "annotate" else []
+        return self._process_single(task) or (task if self.action == "annotate" else [])
 
     def _process_single(self, task: AudioTask) -> AudioTask | None:
         """Run band classification on a single (non-nested) task."""
@@ -172,7 +221,17 @@ class BandFilterStage(ProcessingStage[AudioTask, AudioTask]):
             logger.error("Band predictor not available")
             return None
 
-        audio = resolve_waveform_from_item(task.data, task.task_id)
+        try:
+            audio = resolve_audio(
+                task.data,
+                residency=self.input_residency,  # type: ignore[arg-type]
+                audio_filepath_key=self.audio_filepath_key,
+                waveform_key=self.waveform_key,
+                sample_rate_key=self.sample_rate_key,
+            )
+        except (OSError, RuntimeError) as e:  # corrupt/unreadable audio -> skip the row, don't crash the batch
+            logger.error(f"Failed to load audio for {task.data.get(self.audio_filepath_key)!r}: {e}")
+            return None
         if audio is None:
             return None
         waveform, sample_rate = audio
@@ -180,16 +239,16 @@ class BandFilterStage(ProcessingStage[AudioTask, AudioTask]):
         try:
             pred = self._predictor.predict_audio(waveform, sample_rate)
             if isinstance(pred, str) and not pred.startswith("Error") and pred in ("full_band", "narrow_band"):
-                task.data["band_prediction"] = pred
+                task.data[self.prediction_key] = pred
             else:
                 logger.warning(f"[{task.task_id}] BandFilter: unexpected prediction value: {pred!r}")
         except Exception as e:  # noqa: BLE001
             logger.exception(f"[BandFilter] Prediction error: {e}")
             return None
 
-        actual = task.data.get("band_prediction", "unknown")
+        actual = task.data.get(self.prediction_key, "unknown")
         if actual != self.band_value:
             logger.info(f"[{task.task_id}] BAND FILTER FAILED: prediction '{actual}' != target '{self.band_value}'")
-            return None
+            return task if self.action == "annotate" else None
 
         return task

--- a/nemo_curator/stages/audio/filtering/sigmos.py
+++ b/nemo_curator/stages/audio/filtering/sigmos.py
@@ -51,7 +51,7 @@ from loguru import logger
 
 from nemo_curator.backends.base import NodeInfo, WorkerMetadata
 from nemo_curator.stages.audio._agent_ready import AgentReady, Gates, IOSpec, StageContract
-from nemo_curator.stages.audio._residency import resolve_audio
+from nemo_curator.stages.audio._residency import residency_read_specs, resolve_audio
 from nemo_curator.stages.audio.common import ensure_mono, ensure_waveform_2d
 from nemo_curator.stages.audio.filtering.sigmos_filter_module.third_party.sigmos.sigmos import build_sigmos_model
 from nemo_curator.stages.base import ProcessingStage
@@ -232,8 +232,12 @@ class SIGMOSFilterStage(AgentReady, ProcessingStage[AudioTask, AudioTask]):
         ]
         return StageContract(
             reads_one_of=[
-                IOSpec(data_keys=[self.waveform_key, self.sample_rate_key], accepts=["waveform"]),
-                IOSpec(data_keys=[self.audio_filepath_key], accepts=["file"]),
+                *residency_read_specs(
+                    self.input_residency,
+                    audio_filepath_key=self.audio_filepath_key,
+                    waveform_key=self.waveform_key,
+                    sample_rate_key=self.sample_rate_key,
+                ),
                 IOSpec(data_keys=[self.segments_key]),
             ],
             writes=IOSpec(data_keys=score_keys, segment_data_keys=score_keys),

--- a/nemo_curator/stages/audio/filtering/sigmos.py
+++ b/nemo_curator/stages/audio/filtering/sigmos.py
@@ -42,7 +42,7 @@ Example:
 import os
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 
 import numpy as np
 import requests
@@ -50,7 +50,9 @@ import torch
 from loguru import logger
 
 from nemo_curator.backends.base import NodeInfo, WorkerMetadata
-from nemo_curator.stages.audio.common import load_audio_file
+from nemo_curator.stages.audio._agent_ready import AgentReady, Gates, IOSpec, StageContract
+from nemo_curator.stages.audio._residency import resolve_audio
+from nemo_curator.stages.audio.common import ensure_mono, ensure_waveform_2d
 from nemo_curator.stages.audio.filtering.sigmos_filter_module.third_party.sigmos.sigmos import build_sigmos_model
 from nemo_curator.stages.base import ProcessingStage
 from nemo_curator.stages.resources import Resources
@@ -62,9 +64,19 @@ _SIGMOS_MODEL_URL = (
 )
 _SIGMOS_MODEL_FILENAME = "model-sigmos_1697718653_41d092e8-epo-200.onnx"
 _DEFAULT_MODEL_DIR = str(Path.home() / ".cache" / "nemo_curator" / "sigmos_model")
+_VALID_MODES = {"task", "segments", "auto"}
+_VALID_ACTIONS = {"filter", "annotate"}
 
 
-def _get_audio_numpy_sr(item: dict[str, Any], task_id: str) -> tuple[np.ndarray, int] | None:
+def _get_audio_numpy_sr(  # noqa: PLR0913 (complexity accepted: keyword-only residency/key knobs mirror the stage fields)
+    item: dict[str, Any],
+    task_id: str,
+    *,
+    input_residency: Literal["file", "waveform", "auto"] = "auto",
+    audio_filepath_key: str = "audio_filepath",
+    waveform_key: str = "waveform",
+    sample_rate_key: str = "sample_rate",
+) -> tuple[np.ndarray, int] | None:
     """
     Get (audio mono float32 numpy, sample_rate) from item.
 
@@ -74,33 +86,39 @@ def _get_audio_numpy_sr(item: dict[str, Any], task_id: str) -> tuple[np.ndarray,
 
     Returns None if unavailable or load fails.
     """
-    waveform = item.get("waveform")
-    sample_rate = item.get("sample_rate")
+    # Thin wrapper over the shared resolver (_residency.resolve_audio): delegate
+    # file/waveform resolution, then return a mono float32 1-D numpy array.
+    # Audio-file load errors are swallowed and reported as None (matches the
+    # original); a waveform without sample_rate falls back to the file path,
+    # exactly like resolve_audio.
+    try:
+        resolved = resolve_audio(
+            item,
+            residency=input_residency,
+            audio_filepath_key=audio_filepath_key,
+            waveform_key=waveform_key,
+            sample_rate_key=sample_rate_key,
+            mono=True,
+        )
+    except Exception as e:  # noqa: BLE001
+        logger.error(f"[{task_id}] Failed to load audio file: {e}")
+        return None
 
-    if waveform is not None and sample_rate is not None:
-        audio = waveform.cpu().numpy() if torch.is_tensor(waveform) else np.asarray(waveform, dtype=np.float32)
-        if audio.ndim > 1:
-            audio = np.mean(audio, axis=0)
-        if audio.dtype != np.float32:
-            audio = audio.astype(np.float32)
-        return audio, int(sample_rate)
+    if resolved is None:
+        if input_residency == "waveform":
+            logger.warning(f"[{task_id}] No {waveform_key}+{sample_rate_key} found")
+        else:
+            logger.warning(f"[{task_id}] No {waveform_key}+{sample_rate_key} or valid {audio_filepath_key} found")
+        return None
 
-    path = item.get("audio_filepath")
-    if path and os.path.isfile(path):
-        try:
-            wf, sr = load_audio_file(path, mono=True)
-            audio = wf.squeeze(0).numpy().astype(np.float32)
-            return audio, int(sr)
-        except Exception as e:  # noqa: BLE001
-            logger.error(f"[{task_id}] Failed to load audio file: {e}")
-            return None
-
-    logger.warning(f"[{task_id}] No waveform+sample_rate or valid audio_filepath found")
-    return None
+    waveform, sample_rate = resolved
+    mono = ensure_mono(ensure_waveform_2d(waveform))
+    audio = mono.squeeze(0).detach().cpu().numpy().astype(np.float32)
+    return audio, int(sample_rate)
 
 
 @dataclass
-class SIGMOSFilterStage(ProcessingStage[AudioTask, AudioTask]):
+class SIGMOSFilterStage(AgentReady, ProcessingStage[AudioTask, AudioTask]):
     """
     SIGMOS quality assessment filter stage.
 
@@ -126,6 +144,24 @@ class SIGMOSFilterStage(ProcessingStage[AudioTask, AudioTask]):
         disc_threshold: Minimum discontinuity score (None to disable)
         loud_threshold: Minimum loudness score (None to disable)
         reverb_threshold: Minimum reverb score (None to disable)
+        input_residency: Which input to use — "waveform" (in-memory only), "file"
+            (audio_filepath only), or "auto" (waveform first, file fallback; default).
+        mode: Where to score — "task" (top-level audio), "segments" (nested segments list),
+            or "auto" (segments when segments_key is present, else task; default). Setting
+            "task" or "segments" overrides the auto-detection.
+        action: "filter" drops items below the thresholds; "annotate" keeps every item —
+            including items that fail or cannot be scored — and only writes the score keys.
+        audio_filepath_key: Key in data dict for the input audio file path.
+        waveform_key: Key in data dict for the in-memory waveform tensor.
+        sample_rate_key: Key in data dict for the waveform sample rate.
+        segments_key: Key in data dict holding the nested segments list (segments/auto mode).
+        noise_key: Key where the SIGMOS noise score is written.
+        ovrl_key: Key where the SIGMOS overall score is written.
+        sig_key: Key where the SIGMOS signal score is written.
+        col_key: Key where the SIGMOS coloration score is written.
+        disc_key: Key where the SIGMOS discontinuity score is written.
+        loud_key: Key where the SIGMOS loudness score is written.
+        reverb_key: Key where the SIGMOS reverberation score is written.
 
     Note:
         GPU assignment is handled by the executor via _resources.
@@ -141,6 +177,20 @@ class SIGMOSFilterStage(ProcessingStage[AudioTask, AudioTask]):
     disc_threshold: float | None = None
     loud_threshold: float | None = None
     reverb_threshold: float | None = None
+    input_residency: Literal["file", "waveform", "auto"] = "auto"
+    mode: Literal["task", "segments", "auto"] = "auto"
+    action: Literal["filter", "annotate"] = "filter"
+    audio_filepath_key: str = "audio_filepath"
+    waveform_key: str = "waveform"
+    sample_rate_key: str = "sample_rate"
+    segments_key: str = "segments"
+    noise_key: str = "sigmos_noise"
+    ovrl_key: str = "sigmos_ovrl"
+    sig_key: str = "sigmos_sig"
+    col_key: str = "sigmos_col"
+    disc_key: str = "sigmos_disc"
+    loud_key: str = "sigmos_loud"
+    reverb_key: str = "sigmos_reverb"
 
     name: str = "SIGMOSFilter"
     batch_size: int = 1
@@ -148,6 +198,12 @@ class SIGMOSFilterStage(ProcessingStage[AudioTask, AudioTask]):
 
     def __post_init__(self):
         super().__init__()
+        if self.mode not in _VALID_MODES:
+            msg = f"mode must be one of {_VALID_MODES!r}, got {self.mode!r}"
+            raise ValueError(msg)
+        if self.action not in _VALID_ACTIONS:
+            msg = f"action must be one of {_VALID_ACTIONS!r}, got {self.action!r}"
+            raise ValueError(msg)
         self._model = None
 
     def inputs(self) -> tuple[list[str], list[str]]:
@@ -155,14 +211,36 @@ class SIGMOSFilterStage(ProcessingStage[AudioTask, AudioTask]):
 
     def outputs(self) -> tuple[list[str], list[str]]:
         return [], [
-            "sigmos_noise",
-            "sigmos_ovrl",
-            "sigmos_sig",
-            "sigmos_col",
-            "sigmos_disc",
-            "sigmos_loud",
-            "sigmos_reverb",
+            self.noise_key,
+            self.ovrl_key,
+            self.sig_key,
+            self.col_key,
+            self.disc_key,
+            self.loud_key,
+            self.reverb_key,
         ]
+
+    def describe(self) -> StageContract:
+        score_keys = [
+            self.noise_key,
+            self.ovrl_key,
+            self.sig_key,
+            self.col_key,
+            self.disc_key,
+            self.loud_key,
+            self.reverb_key,
+        ]
+        return StageContract(
+            reads_one_of=[
+                IOSpec(data_keys=[self.waveform_key, self.sample_rate_key], accepts=["waveform"]),
+                IOSpec(data_keys=[self.audio_filepath_key], accepts=["file"]),
+                IOSpec(data_keys=[self.segments_key]),
+            ],
+            writes=IOSpec(data_keys=score_keys, segment_data_keys=score_keys),
+            cardinality="filter" if self.action == "filter" else "1:1",
+            cardinality_options=["filter", "annotate"],
+            gates=Gates(requires_gpu=self.resources.gpus > 0, requires_internet_first_run=self.model_path is None),
+        )
 
     @staticmethod
     def _download_model(model_dir: str) -> str:
@@ -280,25 +358,36 @@ class SIGMOSFilterStage(ProcessingStage[AudioTask, AudioTask]):
         return passed, fail_reasons
 
     def process(self, task: AudioTask) -> AudioTask | list[AudioTask]:
-        """Process a single AudioTask and filter by SIGMOS quality metrics.
+        """Process a single AudioTask and filter or annotate by SIGMOS quality metrics.
 
-        When ``task.data`` contains a ``"segments"`` key (nested mode from VAD),
-        each segment is evaluated individually and only survivors are kept.
+        Segment mode applies when ``mode="segments"``, or when ``mode="auto"``
+        (default) and ``task.data`` contains the ``segments_key``; each segment is
+        then evaluated individually. With ``action="filter"`` only survivors are
+        kept; with ``action="annotate"`` every item is kept — including items that
+        fail the thresholds or cannot be scored — and only the scores are written.
         """
-        if "segments" in task.data:
+        use_segments = self.mode == "segments" or (self.mode == "auto" and self.segments_key in task.data)
+        if use_segments:
             survivors = []
-            for seg in task.data["segments"]:
+            for seg in task.data.get(self.segments_key, []):
                 temp = AudioTask(data=seg)
                 result = self._process_single(temp)
-                if result is not None:
+                if result is not None or self.action == "annotate":
                     survivors.append(temp.data)
-            task.data["segments"] = survivors
-            return task if survivors else []
-        return self._process_single(task) or []
+            task.data[self.segments_key] = survivors
+            return task if survivors or self.action == "annotate" else []
+        return self._process_single(task) or (task if self.action == "annotate" else [])
 
     def _process_single(self, task: AudioTask) -> AudioTask | None:
         """Run SIGMOS scoring on a single (non-nested) task."""
-        audio_result = _get_audio_numpy_sr(task.data, task.task_id)
+        audio_result = _get_audio_numpy_sr(
+            task.data,
+            task.task_id,
+            input_residency=self.input_residency,
+            audio_filepath_key=self.audio_filepath_key,
+            waveform_key=self.waveform_key,
+            sample_rate_key=self.sample_rate_key,
+        )
         if audio_result is None:
             return None
         audio_np, sample_rate = audio_result
@@ -314,6 +403,13 @@ class SIGMOSFilterStage(ProcessingStage[AudioTask, AudioTask]):
 
         s = self._scores_from_prediction(score_data)
         passed, fail_reasons = self._check_thresholds(s)
+        task.data[self.noise_key] = s["noise"]
+        task.data[self.ovrl_key] = s["ovrl"]
+        task.data[self.sig_key] = s["sig"]
+        task.data[self.col_key] = s["col"]
+        task.data[self.disc_key] = s["disc"]
+        task.data[self.loud_key] = s["loud"]
+        task.data[self.reverb_key] = s["reverb"]
 
         logger.debug(
             f"[{task.task_id}] SIGMOS NOISE={s['noise']:.3f}, OVRL={s['ovrl']:.3f}, SIG={s['sig']:.3f}, "
@@ -321,13 +417,6 @@ class SIGMOSFilterStage(ProcessingStage[AudioTask, AudioTask]):
         )
         if not passed:
             logger.info(f"[{task.task_id}] SIGMOS FAILED: {', '.join(fail_reasons)}")
-            return None
+            return task if self.action == "annotate" else None
 
-        task.data["sigmos_noise"] = s["noise"]
-        task.data["sigmos_ovrl"] = s["ovrl"]
-        task.data["sigmos_sig"] = s["sig"]
-        task.data["sigmos_col"] = s["col"]
-        task.data["sigmos_disc"] = s["disc"]
-        task.data["sigmos_loud"] = s["loud"]
-        task.data["sigmos_reverb"] = s["reverb"]
         return task

--- a/nemo_curator/stages/audio/filtering/utmos.py
+++ b/nemo_curator/stages/audio/filtering/utmos.py
@@ -33,17 +33,17 @@ Example:
     )
 """
 
-import os
 from dataclasses import dataclass, field
-from typing import Any
+from typing import Any, Literal
 
-import numpy as np
 import torch
 import torchaudio
 from loguru import logger
 
 from nemo_curator.backends.base import NodeInfo, WorkerMetadata
-from nemo_curator.stages.audio.common import load_audio_file
+from nemo_curator.stages.audio._agent_ready import AgentReady, Gates, IOSpec, StageContract
+from nemo_curator.stages.audio._residency import resolve_audio
+from nemo_curator.stages.audio.common import ensure_mono, ensure_waveform_2d
 from nemo_curator.stages.base import ProcessingStage
 from nemo_curator.stages.resources import Resources
 from nemo_curator.tasks import AudioTask
@@ -51,45 +51,60 @@ from nemo_curator.tasks import AudioTask
 _UTMOS_REPO = "tarepan/SpeechMOS:v1.2.0"
 _UTMOS_ENTRYPOINT = "utmos22_strong"
 _UTMOS_TARGET_SR = 16000
+_VALID_MODES = {"task", "segments", "auto"}
+_VALID_ACTIONS = {"filter", "annotate"}
 
 
-def _load_waveform_tensor(item: dict[str, Any], task_id: str) -> tuple[torch.Tensor, int] | None:
+def _load_waveform_tensor(  # noqa: PLR0913 (complexity accepted: keyword-only residency/key knobs mirror the stage fields)
+    item: dict[str, Any],
+    task_id: str,
+    *,
+    input_residency: Literal["file", "waveform", "auto"] = "auto",
+    audio_filepath_key: str = "audio_filepath",
+    waveform_key: str = "waveform",
+    sample_rate_key: str = "sample_rate",
+) -> tuple[torch.Tensor, int] | None:
     """
     Extract a mono waveform tensor (1, N) and sample_rate from an item.
 
     Supports waveform (Tensor/ndarray) + sample_rate or audio_filepath.
     Returns None if unavailable.
     """
-    waveform = item.get("waveform")
-    sample_rate = item.get("sample_rate")
-
-    if waveform is not None and sample_rate is not None:
-        if not torch.is_tensor(waveform):
-            waveform = torch.from_numpy(np.asarray(waveform, dtype=np.float32))
-        if waveform.dim() == 1:
-            waveform = waveform.unsqueeze(0)
-        if waveform.shape[0] > 1:
-            waveform = waveform.mean(dim=0, keepdim=True)
-        return waveform, int(sample_rate)
-
-    if waveform is not None and sample_rate is None:
-        logger.warning(f"[{task_id}] Waveform present but 'sample_rate' missing - item skipped")
+    # Thin wrapper over the shared resolver (_residency.resolve_audio): delegate
+    # file/waveform resolution, then force mono (1, N). Two behaviors are kept
+    # to match the original exactly: (1) a waveform present without sample_rate
+    # is unusable (no file fallback for it); (2) audio-file load errors are
+    # swallowed and reported as None.
+    if input_residency != "file" and item.get(waveform_key) is not None and item.get(sample_rate_key) is None:
+        logger.warning(f"[{task_id}] Waveform present but {sample_rate_key!r} missing - item skipped")
         return None
 
-    path = item.get("audio_filepath")
-    if path and os.path.isfile(path):
-        try:
-            return load_audio_file(path, mono=True)
-        except Exception as e:  # noqa: BLE001
-            logger.error(f"[{task_id}] Failed to load audio file: {e}")
-            return None
+    try:
+        resolved = resolve_audio(
+            item,
+            residency=input_residency,
+            audio_filepath_key=audio_filepath_key,
+            waveform_key=waveform_key,
+            sample_rate_key=sample_rate_key,
+            mono=True,
+        )
+    except Exception as e:  # noqa: BLE001
+        logger.error(f"[{task_id}] Failed to load audio file: {e}")
+        return None
 
-    logger.warning(f"[{task_id}] No waveform+sample_rate or valid audio_filepath found")
-    return None
+    if resolved is None:
+        if input_residency == "waveform":
+            logger.warning(f"[{task_id}] No {waveform_key}+{sample_rate_key} found")
+        else:
+            logger.warning(f"[{task_id}] No {waveform_key}+{sample_rate_key} or valid {audio_filepath_key} found")
+        return None
+
+    waveform, sample_rate = resolved
+    return ensure_mono(ensure_waveform_2d(waveform)), int(sample_rate)
 
 
 @dataclass
-class UTMOSFilterStage(ProcessingStage[AudioTask, AudioTask]):
+class UTMOSFilterStage(AgentReady, ProcessingStage[AudioTask, AudioTask]):
     """
     UTMOS quality assessment filter stage.
 
@@ -100,6 +115,18 @@ class UTMOSFilterStage(ProcessingStage[AudioTask, AudioTask]):
     Args:
         mos_threshold: Minimum MOS score to pass (None to disable)
         sample_rate: Target sample rate for UTMOS inference (default 16000)
+        input_residency: Which input to use — "waveform" (in-memory only), "file"
+            (audio_filepath only), or "auto" (waveform first, file fallback; default).
+        mode: Where to score — "task" (top-level audio), "segments" (nested segments list),
+            or "auto" (segments when segments_key is present, else task; default). Setting
+            "task" or "segments" overrides the auto-detection.
+        action: "filter" drops items below mos_threshold; "annotate" keeps every item —
+            including items that fail or cannot be scored — and only writes score_key.
+        audio_filepath_key: Key in data dict for the input audio file path.
+        waveform_key: Key in data dict for the in-memory waveform tensor.
+        sample_rate_key: Key in data dict for the waveform sample rate.
+        segments_key: Key in data dict holding the nested segments list (segments/auto mode).
+        score_key: Key where the UTMOS MOS score is written.
 
     Note:
         GPU assignment is handled by the executor via _resources.
@@ -108,6 +135,14 @@ class UTMOSFilterStage(ProcessingStage[AudioTask, AudioTask]):
 
     mos_threshold: float | None = 3.5
     sample_rate: int = _UTMOS_TARGET_SR
+    input_residency: Literal["file", "waveform", "auto"] = "auto"
+    mode: Literal["task", "segments", "auto"] = "auto"
+    action: Literal["filter", "annotate"] = "filter"
+    audio_filepath_key: str = "audio_filepath"
+    waveform_key: str = "waveform"
+    sample_rate_key: str = "sample_rate"
+    segments_key: str = "segments"
+    score_key: str = "utmos_mos"
 
     name: str = "UTMOSFilter"
     batch_size: int = 1
@@ -115,6 +150,12 @@ class UTMOSFilterStage(ProcessingStage[AudioTask, AudioTask]):
 
     def __post_init__(self):
         super().__init__()
+        if self.mode not in _VALID_MODES:
+            msg = f"mode must be one of {_VALID_MODES!r}, got {self.mode!r}"
+            raise ValueError(msg)
+        if self.action not in _VALID_ACTIONS:
+            msg = f"action must be one of {_VALID_ACTIONS!r}, got {self.action!r}"
+            raise ValueError(msg)
         self._model = None
         self._model_failed = False
         self._resamplers: dict[int, Any] = {}
@@ -123,7 +164,20 @@ class UTMOSFilterStage(ProcessingStage[AudioTask, AudioTask]):
         return [], []
 
     def outputs(self) -> tuple[list[str], list[str]]:
-        return [], ["utmos_mos"]
+        return [], [self.score_key]
+
+    def describe(self) -> StageContract:
+        return StageContract(
+            reads_one_of=[
+                IOSpec(data_keys=[self.waveform_key, self.sample_rate_key], accepts=["waveform"]),
+                IOSpec(data_keys=[self.audio_filepath_key], accepts=["file"]),
+                IOSpec(data_keys=[self.segments_key]),
+            ],
+            writes=IOSpec(data_keys=[self.score_key], segment_data_keys=[self.score_key]),
+            cardinality="filter" if self.action == "filter" else "1:1",
+            cardinality_options=["filter", "annotate"],
+            gates=Gates(requires_gpu=self.resources.gpus > 0, requires_internet_first_run=True),
+        )
 
     def setup_on_node(
         self, _node_info: NodeInfo | None = None, _worker_metadata: WorkerMetadata | None = None
@@ -194,25 +248,36 @@ class UTMOSFilterStage(ProcessingStage[AudioTask, AudioTask]):
         logger.info(f"UTMOS model loaded on {device}")
 
     def process(self, task: AudioTask) -> AudioTask | list[AudioTask]:
-        """Process a single AudioTask and filter by UTMOS MOS score.
+        """Process a single AudioTask and filter or annotate by UTMOS MOS score.
 
-        When ``task.data`` contains a ``"segments"`` key (nested mode from VAD),
-        each segment is evaluated individually and only survivors are kept.
+        Segment mode applies when ``mode="segments"``, or when ``mode="auto"``
+        (default) and ``task.data`` contains the ``segments_key``; each segment is
+        then evaluated individually. With ``action="filter"`` only survivors are
+        kept; with ``action="annotate"`` every item is kept — including items that
+        fail mos_threshold or cannot be scored — and only the score is written.
         """
-        if "segments" in task.data:
+        use_segments = self.mode == "segments" or (self.mode == "auto" and self.segments_key in task.data)
+        if use_segments:
             survivors = []
-            for seg in task.data["segments"]:
+            for seg in task.data.get(self.segments_key, []):
                 temp = AudioTask(data=seg)
                 result = self._process_single(temp)
-                if result is not None:
+                if result is not None or self.action == "annotate":
                     survivors.append(temp.data)
-            task.data["segments"] = survivors
-            return task if survivors else []
-        return self._process_single(task) or []
+            task.data[self.segments_key] = survivors
+            return task if survivors or self.action == "annotate" else []
+        return self._process_single(task) or (task if self.action == "annotate" else [])
 
     def _process_single(self, task: AudioTask) -> AudioTask | None:
         """Run UTMOS scoring on a single (non-nested) task."""
-        audio_result = _load_waveform_tensor(task.data, task.task_id)
+        audio_result = _load_waveform_tensor(
+            task.data,
+            task.task_id,
+            input_residency=self.input_residency,
+            audio_filepath_key=self.audio_filepath_key,
+            waveform_key=self.waveform_key,
+            sample_rate_key=self.sample_rate_key,
+        )
         if audio_result is None:
             return None
         waveform, sr = audio_result
@@ -239,9 +304,10 @@ class UTMOSFilterStage(ProcessingStage[AudioTask, AudioTask]):
 
         logger.debug(f"[{task.task_id}] UTMOS MOS={mos:.3f}")
 
+        task.data[self.score_key] = mos
+
         if self.mos_threshold is not None and mos < self.mos_threshold:
             logger.info(f"[{task.task_id}] UTMOS FAILED: MOS {mos:.3f} < {self.mos_threshold}")
-            return None
+            return task if self.action == "annotate" else None
 
-        task.data["utmos_mos"] = mos
         return task

--- a/nemo_curator/stages/audio/filtering/utmos.py
+++ b/nemo_curator/stages/audio/filtering/utmos.py
@@ -42,7 +42,7 @@ from loguru import logger
 
 from nemo_curator.backends.base import NodeInfo, WorkerMetadata
 from nemo_curator.stages.audio._agent_ready import AgentReady, Gates, IOSpec, StageContract
-from nemo_curator.stages.audio._residency import resolve_audio
+from nemo_curator.stages.audio._residency import residency_read_specs, resolve_audio
 from nemo_curator.stages.audio.common import ensure_mono, ensure_waveform_2d
 from nemo_curator.stages.base import ProcessingStage
 from nemo_curator.stages.resources import Resources
@@ -169,8 +169,12 @@ class UTMOSFilterStage(AgentReady, ProcessingStage[AudioTask, AudioTask]):
     def describe(self) -> StageContract:
         return StageContract(
             reads_one_of=[
-                IOSpec(data_keys=[self.waveform_key, self.sample_rate_key], accepts=["waveform"]),
-                IOSpec(data_keys=[self.audio_filepath_key], accepts=["file"]),
+                *residency_read_specs(
+                    self.input_residency,
+                    audio_filepath_key=self.audio_filepath_key,
+                    waveform_key=self.waveform_key,
+                    sample_rate_key=self.sample_rate_key,
+                ),
                 IOSpec(data_keys=[self.segments_key]),
             ],
             writes=IOSpec(data_keys=[self.score_key], segment_data_keys=[self.score_key]),


### PR DESCRIPTION
## Summary
Makes the quality/bandwidth filters agent-ready, unifies their audio loading, and adds an annotate mode.

### All three (`utmos.py`, `sigmos.py`, `band.py`)
- Now subclass `AgentReady` with a `describe()` contract, and gain configurable data keys (`audio_filepath_key` / `waveform_key` / `sample_rate_key` / `segments_key` / score keys) plus `input_residency`.
- New `mode` (`task` / `segments` / `auto`) selects whether to score the top-level audio or each item in a nested `segments` list (`auto` = segments if present).
- New `action` (`filter` / `annotate`): `filter` (default) drops items that fail the threshold; `annotate` keeps every item and only writes the score/prediction.
- utmos/sigmos now load audio via the shared `resolve_audio` resolver instead of their own inline loaders — behavior preserved for the default path, including the "waveform present but no `sample_rate`" (skip) and "file load error → return None" cases.

## Notes for reviewers
- Backward compatible: `action="filter"`, `mode="auto"`; thresholds and score keys unchanged by default.
- Residency default `"auto"` prefers in-memory waveform over file when both exist.
- Worth a look: `band.py` catches `(OSError, RuntimeError)` on load (previously broader) — confirm that is the intended failure surface.

## Test plan
- [ ] `pytest tests/stages/audio/filtering -q`