### PR TITLE
feat(audio-inference): agent-ready ASR/VAD/diarization (residency + fan-out provenance fix)

### DIFF
--- a/nemo_curator/stages/audio/_agent_ready.py
+++ b/nemo_curator/stages/audio/_agent_ready.py
@@ -1,0 +1,318 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field, is_dataclass
+from enum import Enum
+from typing import TYPE_CHECKING, Any, ClassVar, Literal
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+AudioForm = Literal["file", "waveform"]
+ProducedForm = Literal["tensor", "disk"]
+Cardinality = Literal["1:1", "1:1 nested-list", "1:N fan-out", "N:1", "filter"]
+Dispatch = Literal["process", "process_batch", "auto"]
+# How a stage handles per-item failures at runtime. "unknown" means the stage
+# has not declared a uniform policy (the default for most stages today).
+ErrorPolicy = Literal["skip", "fail", "annotate", "unknown"]
+
+# Semantic role vocabulary. Because key *names* are agent-configurable
+# (config-knobs-only standardization: every read/written key is a ``*_key``
+# constructor field that an agent may rename), two stages can only be chained
+# reliably by matching the *role* a key plays, not its literal string. Roles are
+# resolved from the invariant ``*_key`` field name (see ``_roles.py``), so they
+# survive an agent renaming a key's value. ``"unknown"`` is the safe default and
+# never blocks composition.
+Role = Literal[
+    "audio_filepath",
+    "waveform",
+    "sample_rate",
+    "duration",
+    "num_samples",
+    "segments",
+    "diar_segments",
+    "vad_segments",
+    "overlap_segments",
+    "timestamps",
+    "start",
+    "end",
+    "start_ms",
+    "end_ms",
+    "text",
+    "pred_text",
+    "reference_text",
+    "words",
+    "alignment",
+    "speaker_id",
+    "num_speakers",
+    "score",
+    "metrics",
+    "prediction",
+    "segment_num",
+    "original_file",
+    "item_id",
+    "windows",
+    "manifest_path",
+    "output_path",
+    "unknown",
+]
+
+
+@dataclass(frozen=True)
+class ParamSpec:
+    """A single constructor parameter an agent can set on a stage.
+
+    Usually derived automatically from the stage's dataclass fields (or
+    ``__init__`` signature) via
+    :func:`nemo_curator.stages.audio._agent_registry.stage_params`, but a stage
+    may also override/augment entries in ``StageContract.params``.
+    """
+
+    name: str
+    type: str = "Any"
+    default: Any = None
+    required: bool = False
+    choices: list[Any] | None = None  # populated for Literal[...] params
+    description: str | None = None
+    role: Role | None = None  # semantic role of the key this param configures
+
+
+@dataclass(frozen=True)
+class IOSpec:
+    """Task data keys and audio forms read or written by a stage."""
+
+    data_keys: list[str] = field(default_factory=list)
+    segment_data_keys: list[str] = field(default_factory=list)
+    accepts: list[AudioForm] = field(default_factory=list)
+    produces: list[ProducedForm] = field(default_factory=list)
+
+
+@dataclass(frozen=True)
+class Gates:
+    """Execution gates or side effects an agent should know before wrapping a stage."""
+
+    writes_to_disk: bool = False
+    requires_gpu: bool = False
+    requires_internet_first_run: bool = False
+    requires_ffmpeg: bool = False
+    lifecycle_side_effects: bool = False
+    runtime_secrets: list[str] = field(default_factory=list)
+    # Serializability contract for sinks (distinguishes the two JSON sinks):
+    #   requires_serializable_input — this stage serializes task.data as-is (e.g.
+    #     raw json.dumps) and will fail on a resident tensor/audio blob.
+    #   sanitizes_output — this stage strips tensors/audio blobs, so anything
+    #     downstream of it is serialization-safe.
+    requires_serializable_input: bool = False
+    sanitizes_output: bool = False
+
+
+@dataclass(frozen=True)
+class SizeEnvelope:
+    """Coarse size and memory hints for agent planning."""
+
+    max_input_sec: float | None = None
+    allowed_sample_rates: list[int] | None = None
+    channels: Literal["mono", "stereo", "any"] = "any"
+    memory_hint: str | None = None
+
+
+@dataclass(frozen=True)
+class StaticHints:
+    """Instance-independent hints a stage may declare for discovery/planning.
+
+    Lets a stage expose ``cardinality_options``, ``gates``, ``dispatch``,
+    ``error_policy``, ``description`` and ``stage_id`` *without* being
+    instantiated (see :meth:`AgentReady.describe_static`). Declared on a class
+    via the ``AGENT_STATIC`` ClassVar; every field defaults so declaring it is
+    fully optional and additive.
+    """
+
+    cardinality_options: list[str] = field(default_factory=list)
+    gates: Gates = field(default_factory=Gates)
+    dispatch: Dispatch = "auto"
+    error_policy: ErrorPolicy = "unknown"
+    description: str | None = None
+    stage_id: str | None = None
+
+
+@dataclass(frozen=True)
+class StageContract:
+    """Read-only discovery contract for an agent-ready processing stage."""
+
+    reads: IOSpec = field(default_factory=IOSpec)
+    writes: IOSpec = field(default_factory=IOSpec)
+    reads_one_of: list[IOSpec] = field(default_factory=list)
+    metadata_reads: list[str] = field(default_factory=list)
+    metadata_writes: list[str] = field(default_factory=list)
+    cardinality: Cardinality = "1:1"
+    cardinality_options: list[str] = field(default_factory=list)
+    iteration_key: str | None = None
+    preserves_upstream_keys: bool = True
+    wrappable: bool = True
+    size_envelope: SizeEnvelope = field(default_factory=SizeEnvelope)
+    gates: Gates = field(default_factory=Gates)
+    # Agent-facing metadata (advisory; defaults keep older describe() calls valid).
+    stage_id: str | None = None  # stable semantic id; defaults to the class name when None
+    description: str | None = None  # one-line human summary for planners/UIs
+    params: list[ParamSpec] = field(default_factory=list)  # usually auto-derived at discovery time
+    dispatch: Dispatch = "auto"  # "auto" => infer from the stage at runtime
+    error_policy: ErrorPolicy = "unknown"
+    # Resolved-key-value -> semantic role. Populated at discovery time by
+    # ``_agent_registry.build_contract``; empty when a contract is built by hand.
+    key_roles: dict[str, Role] = field(default_factory=dict)
+    # True when the stage only implements ``process_batch`` (``process`` raises).
+    # Auto-derived at discovery time; agents must not call ``process`` on these.
+    batch_only: bool = False
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a JSON-safe dict of this contract (``json.dumps`` never raises)."""
+        return {
+            "reads": asdict(self.reads),
+            "writes": asdict(self.writes),
+            "reads_one_of": [asdict(spec) for spec in self.reads_one_of],
+            "metadata_reads": list(self.metadata_reads),
+            "metadata_writes": list(self.metadata_writes),
+            "cardinality": self.cardinality,
+            "cardinality_options": list(self.cardinality_options),
+            "iteration_key": self.iteration_key,
+            "preserves_upstream_keys": self.preserves_upstream_keys,
+            "wrappable": self.wrappable,
+            "size_envelope": asdict(self.size_envelope),
+            "gates": asdict(self.gates),
+            "stage_id": self.stage_id,
+            "description": self.description,
+            "params": [_paramspec_to_dict(p) for p in self.params],
+            "dispatch": self.dispatch,
+            "error_policy": self.error_policy,
+            "key_roles": dict(self.key_roles),
+            "batch_only": self.batch_only,
+        }
+
+
+def _jsonable_default(value: Any) -> Any:  # noqa: ANN401, PLR0911 (complexity accepted: one early return per JSON type family)
+    """Coerce an arbitrary param default to a JSON-serializable value.
+
+    Non-serializable objects (tensors, models, callables) become a short
+    ``"<non-serializable: Type>"`` sentinel rather than raising.
+    """
+    if value is None or isinstance(value, (str, int, float, bool)):
+        return value
+    if isinstance(value, (list, tuple, set)):
+        return [_jsonable_default(v) for v in value]
+    if isinstance(value, dict):
+        return {str(k): _jsonable_default(v) for k, v in value.items()}
+    if isinstance(value, Enum):
+        return value.value
+    if is_dataclass(value) and not isinstance(value, type):
+        try:
+            return {k: _jsonable_default(v) for k, v in asdict(value).items()}
+        except Exception:  # noqa: BLE001
+            return f"<non-serializable: {type(value).__name__}>"
+    return f"<non-serializable: {type(value).__name__}>"
+
+
+def _paramspec_to_dict(p: ParamSpec) -> dict[str, Any]:
+    return {
+        "name": p.name,
+        "type": p.type,
+        "default": _jsonable_default(p.default),
+        "required": p.required,
+        "choices": None if p.choices is None else [_jsonable_default(c) for c in p.choices],
+        "description": p.description,
+        "role": p.role,
+    }
+
+
+def _json_type(type_str: str | None) -> str | None:
+    """Map a rendered ParamSpec.type string to a JSON-Schema type (or None to omit)."""
+    if not type_str:
+        return None
+    t = type_str.replace(" ", "").replace("|None", "")
+    if t.startswith("Optional["):
+        t = t[len("Optional[") : -1] if t.endswith("]") else t
+    scalar = {"str": "string", "int": "integer", "float": "number", "bool": "boolean"}
+    if t in scalar:
+        return scalar[t]
+    lowered = t.lower()
+    if lowered.startswith(("list", "sequence", "tuple")):
+        return "array"
+    if lowered.startswith(("dict", "mapping")):
+        return "object"
+    return None
+
+
+def to_json_schema(params: list[ParamSpec]) -> dict[str, Any]:
+    """Build a JSON-Schema ``object`` describing a stage's configurable params.
+
+    Suitable as the argument schema for an agent's stage-configuration form.
+    """
+    properties: dict[str, Any] = {}
+    required: list[str] = []
+    for p in params:
+        schema: dict[str, Any] = {}
+        json_type = _json_type(p.type)
+        if json_type is not None:
+            schema["type"] = json_type
+        if p.choices is not None:
+            schema["enum"] = [_jsonable_default(c) for c in p.choices]
+        if p.default is not None:
+            schema["default"] = _jsonable_default(p.default)
+        if p.description:
+            schema["description"] = p.description
+        if p.role:
+            schema["x-role"] = p.role
+        properties[p.name] = schema
+        if p.required:
+            required.append(p.name)
+    out: dict[str, Any] = {"type": "object", "properties": properties}
+    if required:
+        out["required"] = required
+    return out
+
+
+class AgentReady:
+    """Mixin for stages that expose a read-only agent discovery contract."""
+
+    # Opt-in, instance-independent discovery hints. Annotated as ClassVar so
+    # dataclass stages do NOT treat these as fields. All optional/additive.
+    AGENT_STATIC: ClassVar[StaticHints | None] = None
+    # Set True on stages whose ``process`` raises (only ``process_batch`` works).
+    BATCH_ONLY: ClassVar[bool] = False
+    # Rare per-field role overrides keyed by ``*_key`` field name. Consulted
+    # before the shared ``_roles.KEY_ROLES`` table.
+    KEY_ROLE_OVERRIDES: ClassVar[Mapping[str, Role]] = {}
+
+    def describe(self) -> StageContract:
+        raise NotImplementedError
+
+    @classmethod
+    def describe_static(cls) -> StageContract:
+        """Instance-free contract for discovery/planning.
+
+        Uses class defaults + ``AGENT_STATIC`` and never runs ``__init__`` side
+        effects, so it is safe for stages with required constructor args. Prefer
+        the instance-level :meth:`describe` (or
+        ``_agent_registry.build_contract``) when resolved key *values* are
+        needed.
+        """
+        from nemo_curator.stages.audio._agent_registry import static_contract
+
+        return static_contract(cls)
+
+
+# (resolve_contract was removed: dead code whose signature promised class
+# acceptance the body rejected. Instances: use stage.describe() / build_contract;
+# classes: use describe_static() / static_contract.)

--- a/nemo_curator/stages/audio/_residency.py
+++ b/nemo_curator/stages/audio/_residency.py
@@ -21,12 +21,52 @@ from typing import TYPE_CHECKING, Any, Literal
 
 import soundfile as sf
 
+from nemo_curator.stages.audio._agent_ready import AudioForm, IOSpec
 from nemo_curator.stages.audio.common import ensure_waveform_2d, load_audio_file
 
 if TYPE_CHECKING:
     from collections.abc import Callable
 
 InputResidency = Literal["file", "waveform", "auto"]
+
+
+def accepts_for_residency(residency: str) -> list[AudioForm]:
+    """Audio forms an instance actually consumes, given its ``input_residency``.
+
+    The single source of truth a stage's ``describe()`` derives ``accepts`` from,
+    so a ``file``-mode instance can never advertise ``waveform`` (the drift /
+    "lying accepts" bug). ``auto`` accepts either; ``file``/``waveform`` accept
+    only that form.
+    """
+    if residency == "waveform":
+        return ["waveform"]
+    if residency == "file":
+        return ["file"]
+    return ["file", "waveform"]  # "auto"
+
+
+def residency_read_specs(
+    input_residency: str,
+    *,
+    audio_filepath_key: str,
+    waveform_key: str = "waveform",
+    sample_rate_key: str = "sample_rate",
+) -> list[IOSpec]:
+    """The residency-filtered audio read options for a stage's ``reads_one_of``.
+
+    ``file`` -> ``[file spec]``; ``waveform`` -> ``[waveform spec]``; ``auto`` ->
+    ``[waveform spec, file spec]``. Keeps ``accepts`` **and** ``data_keys`` in
+    lockstep with ``input_residency`` so a stage can never advertise (or require)
+    a form it won't consume for its current setting — which lets the deterministic
+    role check enforce residency compatibility with no extra check.
+    """
+    forms = accepts_for_residency(input_residency)
+    specs: list[IOSpec] = []
+    if "waveform" in forms:
+        specs.append(IOSpec(data_keys=[waveform_key, sample_rate_key], accepts=["waveform"]))
+    if "file" in forms:
+        specs.append(IOSpec(data_keys=[audio_filepath_key], accepts=["file"]))
+    return specs
 
 
 def resolve_audio(  # noqa: PLR0913 (complexity accepted: keyword-only residency/key knobs mirror the stage fields)

--- a/nemo_curator/stages/audio/_residency.py
+++ b/nemo_curator/stages/audio/_residency.py
@@ -1,0 +1,157 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import contextlib
+import os
+import tempfile
+from typing import TYPE_CHECKING, Any, Literal
+
+import soundfile as sf
+
+from nemo_curator.stages.audio.common import ensure_waveform_2d, load_audio_file
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+InputResidency = Literal["file", "waveform", "auto"]
+
+
+def resolve_audio(  # noqa: PLR0913 (complexity accepted: keyword-only residency/key knobs mirror the stage fields)
+    item: dict[str, Any],
+    *,
+    residency: InputResidency = "auto",
+    audio_filepath_key: str = "audio_filepath",
+    waveform_key: str = "waveform",
+    sample_rate_key: str = "sample_rate",
+    mono: bool = True,
+    loader: Callable[..., tuple[Any, int]] | None = None,
+) -> tuple[Any, int] | None:
+    """Return ``(waveform_2d, sample_rate)`` from tensor keys or a file path.
+
+    ``auto`` prefers an existing waveform, then falls back to file loading.
+    ``waveform`` never falls back to disk. ``file`` always loads from the
+    configured path key.
+
+    ``loader`` overrides the file-loading callable (default
+    :func:`~nemo_curator.stages.audio.common.load_audio_file`); stages pass
+    their own module-level symbol so callers can patch it at the stage module.
+    """
+    waveform = item.get(waveform_key)
+    sample_rate = item.get(sample_rate_key)
+    if residency != "file" and waveform is not None and sample_rate is not None:
+        return ensure_waveform_2d(waveform), int(sample_rate)
+
+    if residency == "waveform":
+        return None
+
+    path = item.get(audio_filepath_key)
+    if path:
+        expanded = os.path.expanduser(str(path))
+        if os.path.exists(expanded):
+            return (loader or load_audio_file)(expanded, mono=mono)
+    return None
+
+
+def _as_soundfile_array(waveform: Any) -> Any:  # noqa: ANN401
+    waveform = ensure_waveform_2d(waveform)
+    if hasattr(waveform, "detach"):
+        waveform = waveform.detach()
+    if hasattr(waveform, "cpu"):
+        waveform = waveform.cpu()
+    if hasattr(waveform, "numpy"):
+        waveform = waveform.numpy()
+    if getattr(waveform, "ndim", 0) == 2:  # noqa: PLR2004 - 2 == a (channels, samples) 2-D array
+        channels, samples = waveform.shape
+        if channels == 1:
+            return waveform[0]
+        if channels < samples:
+            return waveform.T
+    return waveform
+
+
+def resolve_audio_path(  # noqa: PLR0913 (complexity accepted: keyword-only residency/key knobs mirror the stage fields)
+    item: dict[str, Any],
+    *,
+    residency: InputResidency = "auto",
+    audio_filepath_key: str = "audio_filepath",
+    waveform_key: str = "waveform",
+    sample_rate_key: str = "sample_rate",
+    temp_dir: str | None = None,
+    register_temp: list[str] | None = None,
+) -> str | None:
+    """Return an audio path, writing a temp WAV when only a waveform exists.
+
+    When a temp WAV is materialized from an in-memory waveform and
+    ``register_temp`` is provided, the temp path is appended to that list so the
+    caller can delete it after use (see :func:`cleanup_temp_files`). Without
+    ``register_temp`` the caller is responsible for cleanup itself.
+    """
+    path = item.get(audio_filepath_key)
+    local_path: str | None = None
+    if residency != "waveform" and path:
+        local_path = os.path.expanduser(str(path))
+        if os.path.exists(local_path):
+            return local_path
+        # Protocol-prefixed paths (file://, http(s)://, s3://, ...) were handled
+        # by the stages' own fsspec machinery before the residency layer existed;
+        # keep accepting them when the target exists remotely.
+        if "://" in str(path):
+            try:
+                from fsspec.core import url_to_fs
+
+                fs, fspath = url_to_fs(str(path))
+                if fs.exists(fspath):
+                    return path
+            except Exception:  # noqa: BLE001, S110 - unknown protocol/creds -> deliberate fall-through
+                pass
+
+    if residency == "file":
+        # Pre-residency stages handed unverified paths straight to their own
+        # downstream machinery (ffmpeg/NeMo/fsspec) and let it report the
+        # failure; keep that contract instead of gating on os.path.exists.
+        return local_path
+
+    waveform = item.get(waveform_key)
+    sample_rate = item.get(sample_rate_key)
+    if waveform is None or sample_rate is None:
+        return local_path
+
+    fd, tmp = tempfile.mkstemp(suffix=".wav", dir=temp_dir)
+    os.close(fd)
+    sf.write(tmp, _as_soundfile_array(waveform), int(sample_rate))
+    if register_temp is not None:
+        register_temp.append(tmp)
+    return tmp
+
+
+def cleanup_temp_files(paths: list[str] | None) -> None:
+    """Best-effort removal of temp files created by :func:`resolve_audio_path`."""
+    for path in paths or ():
+        with contextlib.suppress(OSError):
+            os.remove(path)
+
+
+def produce_audio_filepath(
+    item: dict[str, Any],
+    new_path: str,
+    *,
+    key: str = "audio_filepath",
+    original_key: str = "original_audio_filepath",
+) -> None:
+    """Update a canonical audio path while preserving the first prior value."""
+    if key in item and original_key not in item:
+        item[original_key] = item[key]
+    item[key] = new_path

--- a/nemo_curator/stages/audio/common.py
+++ b/nemo_curator/stages/audio/common.py
@@ -25,6 +25,7 @@ from fsspec.core import url_to_fs
 from loguru import logger
 
 from nemo_curator.backends.base import NodeInfo, WorkerMetadata
+from nemo_curator.stages.audio._agent_ready import AgentReady, Gates, IOSpec, StageContract
 from nemo_curator.stages.base import CompositeStage, ProcessingStage
 from nemo_curator.stages.file_partitioning import FilePartitioningStage
 from nemo_curator.tasks import AudioTask, EmptyTask, FileGroupTask
@@ -41,7 +42,7 @@ def get_audio_duration(audio_filepath: str) -> float:
 
 
 @dataclass
-class GetAudioDurationStage(ProcessingStage[AudioTask, AudioTask]):
+class GetAudioDurationStage(AgentReady, ProcessingStage[AudioTask, AudioTask]):
     """Compute audio duration from the file at *audio_filepath_key* and
     store the result under *duration_key*.
 
@@ -65,6 +66,12 @@ class GetAudioDurationStage(ProcessingStage[AudioTask, AudioTask]):
     def outputs(self) -> tuple[list[str], list[str]]:
         return [], [self.duration_key]
 
+    def describe(self) -> StageContract:
+        return StageContract(
+            reads=IOSpec(data_keys=[self.audio_filepath_key], accepts=["file"]),
+            writes=IOSpec(data_keys=[self.duration_key]),
+        )
+
     def process(self, task: AudioTask) -> AudioTask:
         t0 = time.perf_counter()
         audio_filepath = task.data[self.audio_filepath_key]
@@ -74,7 +81,7 @@ class GetAudioDurationStage(ProcessingStage[AudioTask, AudioTask]):
         return task
 
 
-class PreserveByValueStage(ProcessingStage[AudioTask, AudioTask]):
+class PreserveByValueStage(AgentReady, ProcessingStage[AudioTask, AudioTask]):
     """Filter entries by comparing *input_value_key* against *target_value*.
 
     Returns ``None`` from ``process()`` to drop entries that fail the
@@ -87,6 +94,7 @@ class PreserveByValueStage(ProcessingStage[AudioTask, AudioTask]):
     """
 
     name: str = "PreserveByValueStage"
+    BATCH_ONLY = True  # process() raises; only process_batch is implemented (agent-discovery hint)
 
     def __init__(
         self,
@@ -107,6 +115,13 @@ class PreserveByValueStage(ProcessingStage[AudioTask, AudioTask]):
 
     def outputs(self) -> tuple[list[str], list[str]]:
         return [], [self.input_value_key]
+
+    def describe(self) -> StageContract:
+        return StageContract(
+            reads=IOSpec(data_keys=[self.input_value_key]),
+            writes=IOSpec(data_keys=[self.input_value_key]),
+            cardinality="filter",
+        )
 
     def process(self, task: AudioTask) -> AudioTask | None:
         msg = "PreserveByValueStage only supports process_batch"
@@ -133,7 +148,7 @@ class PreserveByValueStage(ProcessingStage[AudioTask, AudioTask]):
 
 
 @dataclass
-class ManifestReaderStage(ProcessingStage[FileGroupTask, AudioTask]):
+class ManifestReaderStage(AgentReady, ProcessingStage[FileGroupTask, AudioTask]):
     """Read JSONL manifest files from a FileGroupTask and emit one AudioTask per line.
 
     Uses line-by-line streaming via fsspec (no Pandas) to keep memory at ~1x file size.
@@ -177,9 +192,16 @@ class ManifestReaderStage(ProcessingStage[FileGroupTask, AudioTask]):
     def num_workers(self) -> int | None:
         return 1
 
+    def describe(self) -> StageContract:
+        return StageContract(
+            writes=IOSpec(data_keys=["audio_filepath"]),
+            cardinality="1:N fan-out",
+            gates=Gates(lifecycle_side_effects=True),
+        )
+
 
 @dataclass
-class ManifestReader(CompositeStage[EmptyTask, AudioTask]):
+class ManifestReader(AgentReady, CompositeStage[EmptyTask, AudioTask]):
     """Composite stage for reading JSONL manifests.
 
     Decomposes into:
@@ -227,9 +249,12 @@ class ManifestReader(CompositeStage[EmptyTask, AudioTask]):
             parts.append(f"with target blocksize {self.blocksize}")
         return ", ".join(parts)
 
+    def describe(self) -> StageContract:
+        return StageContract(cardinality="1:N fan-out", wrappable=False)
+
 
 @dataclass
-class ManifestWriterStage(ProcessingStage[AudioTask, AudioTask]):
+class ManifestWriterStage(AgentReady, ProcessingStage[AudioTask, AudioTask]):
     """Append a single AudioTask to a JSONL manifest file.
 
     The output file is truncated once in ``setup()`` (called on the driver)
@@ -290,6 +315,18 @@ class ManifestWriterStage(ProcessingStage[AudioTask, AudioTask]):
     def num_workers(self) -> int | None:
         return 1
 
+    def describe(self) -> StageContract:
+        return StageContract(
+            gates=Gates(
+                writes_to_disk=True,
+                lifecycle_side_effects=True,
+                # Serializes task.data as-is via json.dumps; a resident tensor
+                # (e.g. a waveform) will crash it. Route through
+                # AudioToDocumentStage (which sanitizes) if one may be present.
+                requires_serializable_input=True,
+            ),
+        )
+
 
 def load_audio_file(audio_path: str, mono: bool = True) -> tuple[torch.Tensor, int]:
     """Load audio file and return waveform tensor (channels, samples) and sample rate."""
@@ -327,6 +364,13 @@ def resolve_waveform_from_item(
     item['audio_filepath'], resolves missing sample_rate from file header.
     Updates item in-place when loading from file.
     Returns None if resolution fails.
+
+    .. note::
+       The canonical resolver is :func:`nemo_curator.stages.audio._residency.resolve_audio`.
+       This helper is retained for its unique behavior — reading ``sample_rate`` from the
+       file header *without* reloading an already-present waveform, and writing the loaded
+       waveform/sample_rate back into ``item`` — which ``resolve_audio`` does not replicate.
+       Prefer ``resolve_audio`` in new code.
     """
     waveform = item.get("waveform")
     sample_rate = item.get("sample_rate")

--- a/nemo_curator/stages/audio/inference/asr/asr_nemo.py
+++ b/nemo_curator/stages/audio/inference/asr/asr_nemo.py
@@ -20,13 +20,15 @@ import nemo.collections.asr as nemo_asr
 import torch
 
 from nemo_curator.backends.base import NodeInfo, WorkerMetadata
+from nemo_curator.stages.audio._agent_ready import AgentReady, Gates, IOSpec, StageContract
+from nemo_curator.stages.audio._residency import cleanup_temp_files, resolve_audio_path
 from nemo_curator.stages.base import ProcessingStage
 from nemo_curator.stages.resources import Resources
 from nemo_curator.tasks import AudioTask
 
 
 @dataclass
-class InferenceAsrNemoStage(ProcessingStage[AudioTask, AudioTask]):
+class InferenceAsrNemoStage(AgentReady, ProcessingStage[AudioTask, AudioTask]):
     """Speech recognition inference using a NeMo ASR model.
 
     Overrides ``process_batch`` for batched GPU inference.
@@ -42,10 +44,14 @@ class InferenceAsrNemoStage(ProcessingStage[AudioTask, AudioTask]):
     """
 
     name: str = "ASR_inference"
+    BATCH_ONLY = True  # process() raises; only process_batch is implemented (agent-discovery hint)
     model_name: str = ""
     cache_dir: str | None = None
     asr_model: Any | None = field(default=None, repr=False)
     filepath_key: str = "audio_filepath"
+    waveform_key: str = "waveform"
+    sample_rate_key: str = "sample_rate"
+    input_residency: str = "file"
     pred_text_key: str = "pred_text"
     resources: Resources = field(default_factory=lambda: Resources(cpus=1.0))
     batch_size: int = 16
@@ -92,6 +98,16 @@ class InferenceAsrNemoStage(ProcessingStage[AudioTask, AudioTask]):
     def outputs(self) -> tuple[list[str], list[str]]:
         return [], [self.filepath_key, self.pred_text_key]
 
+    def describe(self) -> StageContract:
+        return StageContract(
+            reads=IOSpec(data_keys=[self.filepath_key], accepts=["file", "waveform"]),
+            writes=IOSpec(data_keys=[self.pred_text_key]),
+            gates=Gates(
+                requires_gpu=self.resources.gpus > 0,
+                requires_internet_first_run=self.asr_model is None,
+            ),
+        )
+
     def transcribe(self, files: list[str]) -> list[str]:
         outputs = self.asr_model.transcribe(files)
 
@@ -114,17 +130,37 @@ class InferenceAsrNemoStage(ProcessingStage[AudioTask, AudioTask]):
             return []
         t0 = time.perf_counter()
         for task in tasks:
-            if not self.validate_input(task):
+            has_file = self.filepath_key in task.data
+            has_waveform = self.waveform_key in task.data and self.sample_rate_key in task.data
+            if not (has_file or has_waveform):
                 msg = f"Task {task.task_id} missing required columns for {type(self).__name__}: {self.inputs()}"
                 raise ValueError(msg)
-        files = [t.data[self.filepath_key] for t in tasks]
-        texts = self.transcribe(files)
-        for task, text in zip(tasks, texts, strict=True):
-            task.data[self.pred_text_key] = text
-        self._log_metrics(
-            {
-                "process_time": time.perf_counter() - t0,
-                "files_transcribed": len(files),
-            }
-        )
-        return tasks
+        temp_paths: list[str] = []
+        files = []
+        for task in tasks:
+            path = resolve_audio_path(
+                task.data,
+                residency=self.input_residency,  # type: ignore[arg-type]
+                audio_filepath_key=self.filepath_key,
+                waveform_key=self.waveform_key,
+                sample_rate_key=self.sample_rate_key,
+                register_temp=temp_paths,
+            )
+            if path is None:
+                cleanup_temp_files(temp_paths)
+                msg = f"Task {task.task_id} missing audio input for {type(self).__name__}: {self.inputs()}"
+                raise ValueError(msg)
+            files.append(path)
+        try:
+            texts = self.transcribe(files)
+            for task, text in zip(tasks, texts, strict=True):
+                task.data[self.pred_text_key] = text
+            self._log_metrics(
+                {
+                    "process_time": time.perf_counter() - t0,
+                    "files_transcribed": len(files),
+                }
+            )
+            return tasks
+        finally:
+            cleanup_temp_files(temp_paths)

--- a/nemo_curator/stages/audio/inference/asr/asr_nemo.py
+++ b/nemo_curator/stages/audio/inference/asr/asr_nemo.py
@@ -21,7 +21,7 @@ import torch
 
 from nemo_curator.backends.base import NodeInfo, WorkerMetadata
 from nemo_curator.stages.audio._agent_ready import AgentReady, Gates, IOSpec, StageContract
-from nemo_curator.stages.audio._residency import cleanup_temp_files, resolve_audio_path
+from nemo_curator.stages.audio._residency import InputResidency, cleanup_temp_files, residency_read_specs, resolve_audio_path
 from nemo_curator.stages.base import ProcessingStage
 from nemo_curator.stages.resources import Resources
 from nemo_curator.tasks import AudioTask
@@ -51,7 +51,7 @@ class InferenceAsrNemoStage(AgentReady, ProcessingStage[AudioTask, AudioTask]):
     filepath_key: str = "audio_filepath"
     waveform_key: str = "waveform"
     sample_rate_key: str = "sample_rate"
-    input_residency: str = "file"
+    input_residency: InputResidency = "file"
     pred_text_key: str = "pred_text"
     resources: Resources = field(default_factory=lambda: Resources(cpus=1.0))
     batch_size: int = 16
@@ -100,7 +100,12 @@ class InferenceAsrNemoStage(AgentReady, ProcessingStage[AudioTask, AudioTask]):
 
     def describe(self) -> StageContract:
         return StageContract(
-            reads=IOSpec(data_keys=[self.filepath_key], accepts=["file", "waveform"]),
+            reads_one_of=residency_read_specs(
+                self.input_residency,
+                audio_filepath_key=self.filepath_key,
+                waveform_key=self.waveform_key,
+                sample_rate_key=self.sample_rate_key,
+            ),
             writes=IOSpec(data_keys=[self.pred_text_key]),
             gates=Gates(
                 requires_gpu=self.resources.gpus > 0,

--- a/nemo_curator/stages/audio/inference/speaker_diarization/pyannote.py
+++ b/nemo_curator/stages/audio/inference/speaker_diarization/pyannote.py
@@ -36,7 +36,7 @@ from pyannote.core import Segment
 from nemo_curator.backends.base import NodeInfo, WorkerMetadata
 from nemo_curator.backends.utils import RayStageSpecKeys
 from nemo_curator.stages.audio._agent_ready import AgentReady, Gates, IOSpec, StageContract
-from nemo_curator.stages.audio._residency import cleanup_temp_files, resolve_audio_path
+from nemo_curator.stages.audio._residency import InputResidency, cleanup_temp_files, residency_read_specs, resolve_audio_path
 from nemo_curator.stages.audio.common import get_audio_duration
 from nemo_curator.stages.audio.inference.vad.whisperx_vad import WhisperXVADModel
 from nemo_curator.stages.audio.tagging.utils import add_non_speaker_segments
@@ -109,7 +109,7 @@ class PyAnnoteDiarizationStage(AgentReady, ProcessingStage[AudioTask, AudioTask]
     sample_rate_key: str = "sample_rate"
     segments_key: str = "segments"
     overlap_segments_key: str = "overlap_segments"
-    input_residency: str = "file"
+    input_residency: InputResidency = "file"
     write_rttm: bool = True
     vad_onset: float = 0.5
     vad_offset: float = 0.363
@@ -171,7 +171,12 @@ class PyAnnoteDiarizationStage(AgentReady, ProcessingStage[AudioTask, AudioTask]
             writes = [self.segments_key, self.overlap_segments_key]
             cardinality = "1:1"
         return StageContract(
-            reads=IOSpec(data_keys=[self.audio_filepath_key], accepts=["file", "waveform"]),
+            reads_one_of=residency_read_specs(
+                self.input_residency,
+                audio_filepath_key=self.audio_filepath_key,
+                waveform_key=self.waveform_key,
+                sample_rate_key=self.sample_rate_key,
+            ),
             writes=IOSpec(data_keys=writes),
             cardinality=cardinality,
             cardinality_options=["passthrough", "fan_out"],

--- a/nemo_curator/stages/audio/inference/speaker_diarization/pyannote.py
+++ b/nemo_curator/stages/audio/inference/speaker_diarization/pyannote.py
@@ -34,6 +34,9 @@ from pyannote.audio.pipelines.utils.hook import ProgressHook
 from pyannote.core import Segment
 
 from nemo_curator.backends.base import NodeInfo, WorkerMetadata
+from nemo_curator.backends.utils import RayStageSpecKeys
+from nemo_curator.stages.audio._agent_ready import AgentReady, Gates, IOSpec, StageContract
+from nemo_curator.stages.audio._residency import cleanup_temp_files, resolve_audio_path
 from nemo_curator.stages.audio.common import get_audio_duration
 from nemo_curator.stages.audio.inference.vad.whisperx_vad import WhisperXVADModel
 from nemo_curator.stages.audio.tagging.utils import add_non_speaker_segments
@@ -73,7 +76,7 @@ def has_overlap(turn: Segment, overlaps: list) -> bool:
 
 
 @dataclass
-class PyAnnoteDiarizationStage(ProcessingStage[AudioTask, AudioTask]):
+class PyAnnoteDiarizationStage(AgentReady, ProcessingStage[AudioTask, AudioTask]):
     """
     Stage that performs speaker diarization and overlap detection using PyAnnote.
 
@@ -102,8 +105,23 @@ class PyAnnoteDiarizationStage(ProcessingStage[AudioTask, AudioTask]):
     max_length: float = 40.0
 
     audio_filepath_key: str = "resampled_audio_filepath"
+    waveform_key: str = "waveform"
+    sample_rate_key: str = "sample_rate"
     segments_key: str = "segments"
     overlap_segments_key: str = "overlap_segments"
+    input_residency: str = "file"
+    write_rttm: bool = True
+    vad_onset: float = 0.5
+    vad_offset: float = 0.363
+    fanout: bool = False
+    start_key: str = "start"
+    end_key: str = "end"
+    start_ms_key: str = "start_ms"
+    end_ms_key: str = "end_ms"
+    duration_key: str = "duration"
+    segment_num_key: str = "segment_num"
+    speaker_key: str = "speaker"
+    original_file_key: str = "original_file"
 
     # Stage metadata
     name: str = "PyAnnoteDiarization"
@@ -121,7 +139,102 @@ class PyAnnoteDiarizationStage(ProcessingStage[AudioTask, AudioTask]):
         return [], [self.audio_filepath_key]
 
     def outputs(self) -> tuple[list[str], list[str]]:
+        if self.fanout:
+            return [], [
+                self.audio_filepath_key,
+                self.start_key,
+                self.end_key,
+                self.start_ms_key,
+                self.end_ms_key,
+                self.duration_key,
+                self.segment_num_key,
+                self.speaker_key,
+                self.original_file_key,
+            ]
         return [], [self.audio_filepath_key, self.segments_key, self.overlap_segments_key]
+
+    def describe(self) -> StageContract:
+        if self.fanout:
+            writes = [
+                self.audio_filepath_key,
+                self.start_key,
+                self.end_key,
+                self.start_ms_key,
+                self.end_ms_key,
+                self.duration_key,
+                self.segment_num_key,
+                self.speaker_key,
+                self.original_file_key,
+            ]
+            cardinality = "1:N fan-out"
+        else:
+            writes = [self.segments_key, self.overlap_segments_key]
+            cardinality = "1:1"
+        return StageContract(
+            reads=IOSpec(data_keys=[self.audio_filepath_key], accepts=["file", "waveform"]),
+            writes=IOSpec(data_keys=writes),
+            cardinality=cardinality,
+            cardinality_options=["passthrough", "fan_out"],
+            iteration_key=self.segments_key if self.fanout else None,
+            gates=Gates(
+                requires_gpu=self.resources.gpus > 0,
+                writes_to_disk=self.write_rttm,
+                runtime_secrets=["HF_TOKEN"],
+            ),
+        )
+
+    def ray_stage_spec(self) -> dict[str, Any]:
+        if self.fanout:
+            return {RayStageSpecKeys.IS_FANOUT_STAGE: True}
+        return {}
+
+    def _segment_child_data(
+        self,
+        item: dict[str, Any],
+        segment: dict[str, Any],
+        segment_num: int,
+    ) -> dict[str, Any]:
+        child = {
+            k: v
+            for k, v in item.items()
+            if k not in {self.segments_key, self.overlap_segments_key}
+        }
+        child.update({k: v for k, v in segment.items() if k not in {"start", "end", "speaker"}})
+        start = float(segment.get("start", 0.0))
+        end = float(segment.get("end", start))
+        child[self.start_key] = start
+        child[self.end_key] = end
+        child[self.start_ms_key] = round(start * 1000)
+        child[self.end_ms_key] = round(end * 1000)
+        child[self.duration_key] = max(0.0, end - start)
+        child[self.segment_num_key] = segment_num
+        if "speaker" in segment:
+            child[self.speaker_key] = segment["speaker"]
+        # provenance chain mirrors whisperx: configured key, then the CANONICAL
+        # audio_filepath, then the legacy resampled key — never skip canonical
+        # (with the default audio_filepath_key='resampled_audio_filepath' the
+        # old chain probed the same key twice and fell to "unknown").
+        original_file = item.get(
+            self.original_file_key,
+            item.get(
+                self.audio_filepath_key,
+                item.get("audio_filepath", item.get("resampled_audio_filepath", "unknown")),
+            ),
+        )
+        child.setdefault(self.original_file_key, original_file)
+        return child
+
+    def _fanout_segments(self, task: AudioTask, segments: list[dict[str, Any]]) -> list[AudioTask]:
+        return [
+            AudioTask(
+                dataset_name=task.dataset_name,
+                filepath_key=task.filepath_key or self.audio_filepath_key,
+                data=self._segment_child_data(task.data, segment, index),
+                _metadata=dict(task._metadata or {}),
+                _stage_perf=list(task._stage_perf),
+            )
+            for index, segment in enumerate(segments)
+        ]
 
     def num_workers(self) -> int | None:
         return self.xenna_num_workers
@@ -140,8 +253,8 @@ class PyAnnoteDiarizationStage(ProcessingStage[AudioTask, AudioTask]):
         if self._vad_model is None:
             self._vad_model = WhisperXVADModel(
                 device="cpu",
-                vad_onset=0.5,
-                vad_offset=0.363,
+                vad_onset=self.vad_onset,
+                vad_offset=self.vad_offset,
             )
 
     def setup(self, _: WorkerMetadata | None = None) -> None:
@@ -154,8 +267,8 @@ class PyAnnoteDiarizationStage(ProcessingStage[AudioTask, AudioTask]):
         if self._vad_model is None:
             self._vad_model = WhisperXVADModel(
                 device=self._device,
-                vad_onset=0.5,
-                vad_offset=0.363,
+                vad_onset=self.vad_onset,
+                vad_offset=self.vad_offset,
             )
 
         self._pipeline.to(torch.device(self._device))
@@ -212,15 +325,46 @@ class PyAnnoteDiarizationStage(ProcessingStage[AudioTask, AudioTask]):
         else:
             segments.append({"speaker": speaker_id, "start": start, "end": end})
 
-    def process(self, task: AudioTask) -> AudioTask:
+    def process(self, task: AudioTask) -> AudioTask | list[AudioTask]:
         """Process a single entry for diarization and overlap detection."""
         t0 = time.perf_counter()
         data_entry = task.data
-        file_path = data_entry.get(self.audio_filepath_key)
-        if not file_path:
-            msg = f"[{self.name}] Missing key '{self.audio_filepath_key}' in entry: {data_entry.get('audio_item_id', 'unknown')}"
+        temp_paths: list[str] = []
+        file_path = resolve_audio_path(
+            data_entry,
+            residency=self.input_residency,  # type: ignore[arg-type]
+            audio_filepath_key=self.audio_filepath_key,
+            waveform_key=self.waveform_key,
+            sample_rate_key=self.sample_rate_key,
+            register_temp=temp_paths,
+        )
+        if file_path is None and self.audio_filepath_key == "resampled_audio_filepath":
+            # Composability fallback: pipelines that did not run ResampleAudioStage
+            # only have the original audio_filepath.
+            file_path = resolve_audio_path(
+                data_entry,
+                residency=self.input_residency,  # type: ignore[arg-type]
+                audio_filepath_key="audio_filepath",
+                waveform_key=self.waveform_key,
+                sample_rate_key=self.sample_rate_key,
+                register_temp=temp_paths,
+            )
+        if file_path is None:
+            entry_id = data_entry.get("audio_item_id", "unknown")
+            msg = f"[{self.name}] Missing key '{self.audio_filepath_key}' in entry: {entry_id}"
             raise ValueError(msg)
+        try:
+            return self._diarize_file(task, data_entry, file_path, t0)
+        finally:
+            cleanup_temp_files(temp_paths)
 
+    def _diarize_file(  # noqa: C901 (complexity accepted: single diarize->filter->fanout flow; no refactor pre-PR)
+        self,
+        task: AudioTask,
+        data_entry: dict[str, Any],
+        file_path: str,
+        t0: float,
+    ) -> AudioTask | list[AudioTask]:
         # Load audio using soundfile (avoids torchcodec/FFmpeg dependency)
         data, fs = sf.read(file_path, dtype="float32")
         s = torch.from_numpy(data).unsqueeze(0) if data.ndim == 1 else torch.from_numpy(data.T)
@@ -239,11 +383,12 @@ class PyAnnoteDiarizationStage(ProcessingStage[AudioTask, AudioTask]):
         diarization = diarization.crop(Segment(0, len(s[0]) / fs))
 
         # Write RTTM file (cloud-aware via fsspec)
-        logger.info(f"Writing {len(diarization._tracks)} turns to RTTM file")
-        rttm_filepath = os.path.splitext(file_path)[0] + ".rttm"
-        rttm_fs, rttm_path = url_to_fs(rttm_filepath)
-        with rttm_fs.open(rttm_path, "w") as rttm_file:
-            diarization.write_rttm(rttm_file)
+        if self.write_rttm:
+            logger.info(f"Writing {len(diarization._tracks)} turns to RTTM file")
+            rttm_filepath = os.path.splitext(file_path)[0] + ".rttm"
+            rttm_fs, rttm_path = url_to_fs(rttm_filepath)
+            with rttm_fs.open(rttm_path, "w") as rttm_file:
+                diarization.write_rttm(rttm_file)
 
         segments = []
         overlap_segments = []
@@ -256,6 +401,14 @@ class PyAnnoteDiarizationStage(ProcessingStage[AudioTask, AudioTask]):
                 speaker_id = data_entry["speaker_id"] + "_" + speaker
             elif self.audio_filepath_key in data_entry:
                 speaker_id = Path(data_entry[self.audio_filepath_key]).stem + "_" + speaker
+            elif "audio_filepath" in data_entry:
+                # the composability fallback resolves canonical audio_filepath
+                # when the configured (resampled) key is absent — derive the
+                # identifier from the same source instead of raising after a
+                # full diarization pass.
+                speaker_id = Path(data_entry["audio_filepath"]).stem + "_" + speaker
+            elif file_path:
+                speaker_id = Path(file_path).stem + "_" + speaker
             else:
                 msg = f"No speaker identifier in {file_path}"
                 raise ValueError(msg)
@@ -298,4 +451,6 @@ class PyAnnoteDiarizationStage(ProcessingStage[AudioTask, AudioTask]):
                 "audio_duration": audio_duration,
             }
         )
+        if self.fanout:
+            return self._fanout_segments(task, segments)
         return task

--- a/nemo_curator/stages/audio/inference/speaker_diarization/sortformer.py
+++ b/nemo_curator/stages/audio/inference/speaker_diarization/sortformer.py
@@ -22,6 +22,9 @@ from huggingface_hub import snapshot_download
 from loguru import logger
 from nemo.collections.asr.models import SortformerEncLabelModel
 
+from nemo_curator.backends.utils import RayStageSpecKeys
+from nemo_curator.stages.audio._agent_ready import AgentReady, Gates, IOSpec, StageContract
+from nemo_curator.stages.audio._residency import cleanup_temp_files, resolve_audio_path
 from nemo_curator.stages.base import ProcessingStage
 
 if TYPE_CHECKING:
@@ -82,7 +85,7 @@ def _write_rttm(segments: list[dict[str, Any]], sess_name: str, rttm_out_dir: st
 
 
 @dataclass
-class InferenceSortformerStage(ProcessingStage[AudioTask, AudioTask]):
+class InferenceSortformerStage(AgentReady, ProcessingStage[AudioTask, AudioTask]):
     """Speaker diarization inference using Streaming Sortformer (NeMo).
 
     Uses the NeMo SortformerEncLabelModel for end-to-end neural speaker
@@ -112,7 +115,19 @@ class InferenceSortformerStage(ProcessingStage[AudioTask, AudioTask]):
     cache_dir: str | None = None
     diar_model: Any | None = None
     filepath_key: str = "audio_filepath"
+    waveform_key: str = "waveform"
+    sample_rate_key: str = "sample_rate"
     diar_segments_key: str = "diar_segments"
+    input_residency: str = "file"
+    fanout: bool = False
+    start_key: str = "start"
+    end_key: str = "end"
+    start_ms_key: str = "start_ms"
+    end_ms_key: str = "end_ms"
+    duration_key: str = "duration"
+    segment_num_key: str = "segment_num"
+    speaker_key: str = "speaker"
+    original_file_key: str = "original_file"
     rttm_out_dir: str | None = None
     chunk_len: int = 340
     chunk_left_context: int = 1
@@ -194,10 +209,111 @@ class InferenceSortformerStage(ProcessingStage[AudioTask, AudioTask]):
         sm.spkcache_len = self.spkcache_len
 
     def inputs(self) -> tuple[list[str], list[str]]:
-        return ["data"], []
+        return [], [self.filepath_key]
 
     def outputs(self) -> tuple[list[str], list[str]]:
+        if self.fanout:
+            return ["data"], [
+                self.filepath_key,
+                self.start_key,
+                self.end_key,
+                self.start_ms_key,
+                self.end_ms_key,
+                self.duration_key,
+                self.segment_num_key,
+                self.speaker_key,
+                self.original_file_key,
+            ]
         return ["data"], [self.filepath_key, self.diar_segments_key]
+
+    def describe(self) -> StageContract:
+        if self.fanout:
+            writes = [
+                self.filepath_key,
+                self.start_key,
+                self.end_key,
+                self.start_ms_key,
+                self.end_ms_key,
+                self.duration_key,
+                self.segment_num_key,
+                self.speaker_key,
+                self.original_file_key,
+            ]
+            cardinality = "1:N fan-out"
+        else:
+            writes = [self.filepath_key, self.diar_segments_key]
+            cardinality = "1:1"
+        return StageContract(
+            reads=IOSpec(data_keys=[self.filepath_key], accepts=["file", "waveform"]),
+            writes=IOSpec(data_keys=writes),
+            cardinality=cardinality,
+            cardinality_options=["passthrough", "fan_out"],
+            iteration_key=self.diar_segments_key if self.fanout else None,
+            gates=Gates(
+                requires_gpu=True,
+                writes_to_disk=self.rttm_out_dir is not None,
+                requires_internet_first_run=self.model_path is None,
+            ),
+        )
+
+    def ray_stage_spec(self) -> dict[str, Any]:
+        if self.fanout:
+            return {RayStageSpecKeys.IS_FANOUT_STAGE: True}
+        return {}
+
+    def _segment_child_data(
+        self,
+        item: dict[str, Any],
+        segment: dict[str, Any],
+        segment_num: int,
+        file_path: str,
+        file_path_is_temp: bool = False,
+    ) -> dict[str, Any]:
+        child = {k: v for k, v in item.items() if k != self.diar_segments_key}
+        child.update({k: v for k, v in segment.items() if k not in {"start", "end", "speaker"}})
+        start = float(segment.get("start", 0.0))
+        end = float(segment.get("end", start))
+        child[self.start_key] = start
+        child[self.end_key] = end
+        child[self.start_ms_key] = int(round(start * 1000))
+        child[self.end_ms_key] = int(round(end * 1000))
+        child[self.duration_key] = max(0.0, end - start)
+        child[self.segment_num_key] = segment_num
+        if "speaker" in segment:
+            child[self.speaker_key] = segment["speaker"]
+        # Never pin a fan-out child to a materialized temp WAV: process()'s
+        # `finally` deletes it, which would leave every child referencing a
+        # missing file. Only carry a real (non-temp) source path forward; when
+        # only an in-memory waveform exists, children rely on the copied waveform.
+        if not file_path_is_temp:
+            child.setdefault(self.filepath_key, file_path)
+        original_file = (
+            item.get(self.original_file_key)
+            or item.get(self.filepath_key)
+            or item.get("audio_filepath")
+            or (None if file_path_is_temp else file_path)
+        )
+        if original_file is not None:
+            child.setdefault(self.original_file_key, original_file)
+        return child
+
+    def _fanout_segments(
+        self,
+        task: AudioTask,
+        segments: list[dict[str, Any]],
+        file_path: str,
+        file_path_is_temp: bool = False,
+    ) -> list[AudioTask]:
+        return [
+            AudioTask(
+                dataset_name=task.dataset_name,
+                filepath_key=task.filepath_key or self.filepath_key,
+                data=self._segment_child_data(task.data, segment, index, file_path, file_path_is_temp),
+                _metadata=dict(task._metadata or {}),
+                _stage_perf=list(task._stage_perf),
+            )
+            for index, segment in enumerate(segments)
+        ]
 
     def diarize(self, audio_paths: list[str]) -> list[list[dict[str, Any]]]:
         """Run Sortformer on a list of audio files.
@@ -210,29 +326,50 @@ class InferenceSortformerStage(ProcessingStage[AudioTask, AudioTask]):
         )
         return [_parse_sortformer_segments(segs) for segs in predicted_segments]
 
-    def process(self, task: AudioTask) -> AudioTask:
+    def process(self, task: AudioTask) -> AudioTask | list[AudioTask]:
         """Run speaker diarization on the audio file in the task."""
-        if not self.validate_input(task):
+        has_file = self.filepath_key in task.data
+        has_waveform = self.waveform_key in task.data and self.sample_rate_key in task.data
+        if not (has_file or has_waveform):
             msg = f"Task {task!s} failed validation for stage {self}"
             raise ValueError(msg)
 
-        file_path = task.data[self.filepath_key]
-        sess_name = task.data.get("session_name")
-        resolved_sess_name = sess_name if sess_name is not None else os.path.splitext(os.path.basename(file_path))[0]
-
-        all_segments = self.diarize([file_path])
-        segments = all_segments[0]
-
-        if self.rttm_out_dir is not None:
-            _write_rttm(segments, resolved_sess_name, self.rttm_out_dir)
-
-        output_data = dict(task.data)
-        output_data[self.diar_segments_key] = segments
-
-        return AudioTask(
-            dataset_name=task.dataset_name,
-            filepath_key=task.filepath_key or self.filepath_key,
-            data=output_data,
-            _metadata=task._metadata,
-            _stage_perf=task._stage_perf,
+        temp_paths: list[str] = []
+        file_path = resolve_audio_path(
+            task.data,
+            residency=self.input_residency,  # type: ignore[arg-type]
+            audio_filepath_key=self.filepath_key,
+            waveform_key=self.waveform_key,
+            sample_rate_key=self.sample_rate_key,
+            register_temp=temp_paths,
         )
+        if file_path is None:
+            msg = f"Task {task!s} missing audio input for {self.filepath_key}"
+            raise ValueError(msg)
+        try:
+            sess_name = task.data.get("session_name")
+            resolved_sess_name = (
+                sess_name if sess_name is not None else os.path.splitext(os.path.basename(file_path))[0]
+            )
+
+            all_segments = self.diarize([file_path])
+            segments = all_segments[0]
+
+            if self.rttm_out_dir is not None:
+                _write_rttm(segments, resolved_sess_name, self.rttm_out_dir)
+
+            if self.fanout:
+                return self._fanout_segments(task, segments, file_path, file_path in temp_paths)
+
+            output_data = dict(task.data)
+            output_data[self.diar_segments_key] = segments
+
+            return AudioTask(
+                dataset_name=task.dataset_name,
+                filepath_key=task.filepath_key or self.filepath_key,
+                data=output_data,
+                _metadata=dict(task._metadata or {}),
+                _stage_perf=list(task._stage_perf),
+            )
+        finally:
+            cleanup_temp_files(temp_paths)

--- a/nemo_curator/stages/audio/inference/speaker_diarization/sortformer.py
+++ b/nemo_curator/stages/audio/inference/speaker_diarization/sortformer.py
@@ -24,7 +24,7 @@ from nemo.collections.asr.models import SortformerEncLabelModel
 
 from nemo_curator.backends.utils import RayStageSpecKeys
 from nemo_curator.stages.audio._agent_ready import AgentReady, Gates, IOSpec, StageContract
-from nemo_curator.stages.audio._residency import cleanup_temp_files, resolve_audio_path
+from nemo_curator.stages.audio._residency import InputResidency, cleanup_temp_files, residency_read_specs, resolve_audio_path
 from nemo_curator.stages.base import ProcessingStage
 
 if TYPE_CHECKING:
@@ -118,7 +118,7 @@ class InferenceSortformerStage(AgentReady, ProcessingStage[AudioTask, AudioTask]
     waveform_key: str = "waveform"
     sample_rate_key: str = "sample_rate"
     diar_segments_key: str = "diar_segments"
-    input_residency: str = "file"
+    input_residency: InputResidency = "file"
     fanout: bool = False
     start_key: str = "start"
     end_key: str = "end"
@@ -244,7 +244,12 @@ class InferenceSortformerStage(AgentReady, ProcessingStage[AudioTask, AudioTask]
             writes = [self.filepath_key, self.diar_segments_key]
             cardinality = "1:1"
         return StageContract(
-            reads=IOSpec(data_keys=[self.filepath_key], accepts=["file", "waveform"]),
+            reads_one_of=residency_read_specs(
+                self.input_residency,
+                audio_filepath_key=self.filepath_key,
+                waveform_key=self.waveform_key,
+                sample_rate_key=self.sample_rate_key,
+            ),
             writes=IOSpec(data_keys=writes),
             cardinality=cardinality,
             cardinality_options=["passthrough", "fan_out"],

--- a/nemo_curator/stages/audio/inference/vad/whisperx_vad.py
+++ b/nemo_curator/stages/audio/inference/vad/whisperx_vad.py
@@ -34,7 +34,7 @@ from whisperx.vads.pyannote import Pyannote, load_vad_model
 from nemo_curator.backends.base import NodeInfo, WorkerMetadata
 from nemo_curator.backends.utils import RayStageSpecKeys
 from nemo_curator.stages.audio._agent_ready import AgentReady, Gates, IOSpec, StageContract
-from nemo_curator.stages.audio._residency import cleanup_temp_files, resolve_audio_path
+from nemo_curator.stages.audio._residency import InputResidency, cleanup_temp_files, residency_read_specs, resolve_audio_path
 from nemo_curator.stages.audio.common import get_audio_duration
 from nemo_curator.stages.base import ProcessingStage
 from nemo_curator.stages.resources import Resources
@@ -122,7 +122,7 @@ class WhisperXVADStage(AgentReady, ProcessingStage[AudioTask, AudioTask]):
     audio_filepath_key: str = "resampled_audio_filepath"
     waveform_key: str = "waveform"
     sample_rate_key: str = "sample_rate"
-    input_residency: str = "file"
+    input_residency: InputResidency = "file"
     fanout: bool = False
     start_key: str = "start"
     end_key: str = "end"
@@ -171,7 +171,12 @@ class WhisperXVADStage(AgentReady, ProcessingStage[AudioTask, AudioTask]):
             writes = [self.segments_key]
             cardinality = "1:1"
         return StageContract(
-            reads=IOSpec(data_keys=[self.audio_filepath_key], accepts=["file", "waveform"]),
+            reads_one_of=residency_read_specs(
+                self.input_residency,
+                audio_filepath_key=self.audio_filepath_key,
+                waveform_key=self.waveform_key,
+                sample_rate_key=self.sample_rate_key,
+            ),
             writes=IOSpec(data_keys=writes),
             cardinality=cardinality,
             cardinality_options=["passthrough", "fan_out"],

--- a/nemo_curator/stages/audio/inference/vad/whisperx_vad.py
+++ b/nemo_curator/stages/audio/inference/vad/whisperx_vad.py
@@ -32,6 +32,9 @@ from whisperx.audio import SAMPLE_RATE
 from whisperx.vads.pyannote import Pyannote, load_vad_model
 
 from nemo_curator.backends.base import NodeInfo, WorkerMetadata
+from nemo_curator.backends.utils import RayStageSpecKeys
+from nemo_curator.stages.audio._agent_ready import AgentReady, Gates, IOSpec, StageContract
+from nemo_curator.stages.audio._residency import cleanup_temp_files, resolve_audio_path
 from nemo_curator.stages.audio.common import get_audio_duration
 from nemo_curator.stages.base import ProcessingStage
 from nemo_curator.stages.resources import Resources
@@ -103,7 +106,7 @@ class WhisperXVADModel:
 
 
 @dataclass
-class WhisperXVADStage(ProcessingStage[AudioTask, AudioTask]):
+class WhisperXVADStage(AgentReady, ProcessingStage[AudioTask, AudioTask]):
     """
     Stage that performs Voice Activity Detection (VAD) using WhisperX's VAD model.
 
@@ -117,6 +120,17 @@ class WhisperXVADStage(ProcessingStage[AudioTask, AudioTask]):
     vad_offset: float = 0.363
     segments_key: str = "vad_segments"
     audio_filepath_key: str = "resampled_audio_filepath"
+    waveform_key: str = "waveform"
+    sample_rate_key: str = "sample_rate"
+    input_residency: str = "file"
+    fanout: bool = False
+    start_key: str = "start"
+    end_key: str = "end"
+    start_ms_key: str = "start_ms"
+    end_ms_key: str = "end_ms"
+    duration_key: str = "duration"
+    segment_num_key: str = "segment_num"
+    original_file_key: str = "original_file"
 
     name: str = "WhisperXVAD"
     resources: Resources = field(default_factory=lambda: Resources(gpus=1))
@@ -127,7 +141,95 @@ class WhisperXVADStage(ProcessingStage[AudioTask, AudioTask]):
         return [], [self.audio_filepath_key]
 
     def outputs(self) -> tuple[list[str], list[str]]:
+        if self.fanout:
+            return [], [
+                self.audio_filepath_key,
+                self.start_key,
+                self.end_key,
+                self.start_ms_key,
+                self.end_ms_key,
+                self.duration_key,
+                self.segment_num_key,
+                self.original_file_key,
+            ]
         return [], [self.audio_filepath_key, self.segments_key]
+
+    def describe(self) -> StageContract:
+        if self.fanout:
+            writes = [
+                self.audio_filepath_key,
+                self.start_key,
+                self.end_key,
+                self.start_ms_key,
+                self.end_ms_key,
+                self.duration_key,
+                self.segment_num_key,
+                self.original_file_key,
+            ]
+            cardinality = "1:N fan-out"
+        else:
+            writes = [self.segments_key]
+            cardinality = "1:1"
+        return StageContract(
+            reads=IOSpec(data_keys=[self.audio_filepath_key], accepts=["file", "waveform"]),
+            writes=IOSpec(data_keys=writes),
+            cardinality=cardinality,
+            cardinality_options=["passthrough", "fan_out"],
+            iteration_key=self.segments_key if self.fanout else None,
+            gates=Gates(requires_gpu=self.resources.gpus > 0),
+        )
+
+    def ray_stage_spec(self) -> dict[str, Any]:
+        if self.fanout:
+            return {RayStageSpecKeys.IS_FANOUT_STAGE: True}
+        return {}
+
+    def _segment_child_data(
+        self,
+        item: dict[str, Any],
+        segment: dict[str, Any],
+        segment_num: int,
+    ) -> dict[str, Any]:
+        child = {k: v for k, v in item.items() if k != self.segments_key}
+        start = float(segment.get("start", 0.0))
+        end = float(segment.get("end", start))
+        # copy segment extras but never whisperx's raw internal keys: 'segments'
+        # (a list of (start, end) tuples) collides with the semantic segments
+        # role and crashes dict-shaped consumers; raw start/end are re-emitted
+        # under the configured keys below.
+        child.update({k: v for k, v in segment.items() if k not in {"start", "end", "segments"}})
+        child[self.start_key] = start
+        child[self.end_key] = end
+        child[self.start_ms_key] = round(start * 1000)
+        child[self.end_ms_key] = round(end * 1000)
+        child[self.duration_key] = max(0.0, end - start)
+        child[self.segment_num_key] = segment_num
+        # Resolve source provenance from the configured key, then fall back to the
+        # canonical ``audio_filepath`` (mirrors the composability fallback in
+        # ``process()``) before the legacy resampled path. This keeps fan-out
+        # children's ``original_file`` correct when audio came in under the
+        # canonical key rather than ``resampled_audio_filepath``.
+        original_file = item.get(
+            self.original_file_key,
+            item.get(
+                self.audio_filepath_key,
+                item.get("audio_filepath", item.get("resampled_audio_filepath", "unknown")),
+            ),
+        )
+        child.setdefault(self.original_file_key, original_file)
+        return child
+
+    def _fanout_segments(self, task: AudioTask, segments: list[dict[str, Any]]) -> list[AudioTask]:
+        return [
+            AudioTask(
+                dataset_name=task.dataset_name,
+                filepath_key=task.filepath_key or self.audio_filepath_key,
+                data=self._segment_child_data(task.data, segment, index),
+                _metadata=dict(task._metadata or {}),
+                _stage_perf=list(task._stage_perf),
+            )
+            for index, segment in enumerate(segments)
+        ]
 
     @property
     def _device(self) -> str:
@@ -155,34 +257,61 @@ class WhisperXVADStage(ProcessingStage[AudioTask, AudioTask]):
         self._vad_model.to(self._device)
         logger.info(f"[{self.name}] Initialized WhisperX VAD on {self._device}")
 
-    def process(self, task: AudioTask) -> AudioTask:
+    def process(self, task: AudioTask) -> AudioTask | list[AudioTask]:
         t0 = time.perf_counter()
         data_entry = task.data
-        file_path = data_entry[self.audio_filepath_key]
-        duration = data_entry.get("duration", get_audio_duration(file_path))
-        if duration < self.min_length:
-            logger.warning(f"Skipping {file_path} because it is less than {self.min_length} seconds")
-            data_entry[self.segments_key] = []
+        temp_paths: list[str] = []
+        file_path = resolve_audio_path(
+            data_entry,
+            residency=self.input_residency,  # type: ignore[arg-type]
+            audio_filepath_key=self.audio_filepath_key,
+            waveform_key=self.waveform_key,
+            sample_rate_key=self.sample_rate_key,
+            register_temp=temp_paths,
+        )
+        if file_path is None and self.audio_filepath_key == "resampled_audio_filepath":
+            # Composability fallback: pipelines that did not run ResampleAudioStage
+            # only have the original audio_filepath.
+            file_path = resolve_audio_path(
+                data_entry,
+                residency=self.input_residency,  # type: ignore[arg-type]
+                audio_filepath_key="audio_filepath",
+                waveform_key=self.waveform_key,
+                sample_rate_key=self.sample_rate_key,
+                register_temp=temp_paths,
+            )
+        if file_path is None:
+            msg = f"[{self.name}] Missing audio input for key '{self.audio_filepath_key}'"
+            raise ValueError(msg)
+        try:
+            duration = data_entry.get("duration", get_audio_duration(file_path))
+            if duration < self.min_length:
+                logger.warning(f"Skipping {file_path} because it is less than {self.min_length} seconds")
+                data_entry[self.segments_key] = []
+                self._log_metrics(
+                    {
+                        "process_time": time.perf_counter() - t0,
+                        "audio_duration": duration,
+                        "vad_segments_detected": 0,
+                        "skipped_short": 1.0,
+                    }
+                )
+                return [] if self.fanout else task
+
+            data, sr = sf.read(file_path, dtype="float32")
+            audio = np.expand_dims(data, axis=0) if data.ndim == 1 else data.T
+            vad_segments = self._vad_model.get_vad_segments(audio, self.max_length, sample_rate=sr)
+            data_entry[self.segments_key] = vad_segments
             self._log_metrics(
                 {
                     "process_time": time.perf_counter() - t0,
                     "audio_duration": duration,
-                    "vad_segments_detected": 0,
-                    "skipped_short": 1.0,
+                    "vad_segments_detected": len(vad_segments),
+                    "skipped_short": 0.0,
                 }
             )
+            if self.fanout:
+                return self._fanout_segments(task, vad_segments)
             return task
-
-        data, sr = sf.read(file_path, dtype="float32")
-        audio = np.expand_dims(data, axis=0) if data.ndim == 1 else data.T
-        vad_segments = self._vad_model.get_vad_segments(audio, self.max_length, sample_rate=sr)
-        data_entry[self.segments_key] = vad_segments
-        self._log_metrics(
-            {
-                "process_time": time.perf_counter() - t0,
-                "audio_duration": duration,
-                "vad_segments_detected": len(vad_segments),
-                "skipped_short": 0.0,
-            }
-        )
-        return task
+        finally:
+            cleanup_temp_files(temp_paths)


### PR DESCRIPTION
## Summary
Makes the ASR/VAD/diarization stages agent-ready, routes their audio loading through the residency resolver, and fixes fan-out provenance.

### Common changes
- Each stage loads its input path via `resolve_audio_path` (accepts a file, or an in-memory waveform materialized to a temp WAV) and cleans up temp files in a `finally` block. `input_residency="file"` by default → same behavior as before. Each adds `describe()`; batched stages (e.g. ASR) are `BATCH_ONLY`.

### Fan-out provenance fix (pyannote, sortformer, whisperx_vad)
- These emit one child record per detected segment/speaker. Each child now resolves `original_file` through a fallback chain — configured `original_file_key` → `audio_filepath_key` → canonical `audio_filepath` → legacy `resampled_audio_filepath` → `"unknown"` — instead of collapsing to `"unknown"` when audio arrived under the canonical key. Children also get a distinct `segment_num` and per-segment timing (`start`/`end`, `start_ms`/`end_ms`, `duration`).
- WhisperX specifically drops its raw internal `segments` key from children (a list of tuples) so it doesn't collide with the semantic `segments` role and break dict-shaped consumers.
- sortformer additionally avoids pinning a materialized temp path onto its children.

## Notes for reviewers
- Worth a look: the `_segment_child_data` / `_fanout_segments` helpers in `pyannote.py`, `sortformer.py`, `whisperx_vad.py` (provenance fallback + temp handling) — these are near-identical across the three.

## Test plan
- [ ] `pytest tests/stages/audio/inference -q`