### PR TITLE
feat(audio-alm): agent-ready ALM data-builder and pretrain stages

### DIFF
--- a/nemo_curator/stages/audio/_agent_ready.py
+++ b/nemo_curator/stages/audio/_agent_ready.py
@@ -1,0 +1,318 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field, is_dataclass
+from enum import Enum
+from typing import TYPE_CHECKING, Any, ClassVar, Literal
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+AudioForm = Literal["file", "waveform"]
+ProducedForm = Literal["tensor", "disk"]
+Cardinality = Literal["1:1", "1:1 nested-list", "1:N fan-out", "N:1", "filter"]
+Dispatch = Literal["process", "process_batch", "auto"]
+# How a stage handles per-item failures at runtime. "unknown" means the stage
+# has not declared a uniform policy (the default for most stages today).
+ErrorPolicy = Literal["skip", "fail", "annotate", "unknown"]
+
+# Semantic role vocabulary. Because key *names* are agent-configurable
+# (config-knobs-only standardization: every read/written key is a ``*_key``
+# constructor field that an agent may rename), two stages can only be chained
+# reliably by matching the *role* a key plays, not its literal string. Roles are
+# resolved from the invariant ``*_key`` field name (see ``_roles.py``), so they
+# survive an agent renaming a key's value. ``"unknown"`` is the safe default and
+# never blocks composition.
+Role = Literal[
+    "audio_filepath",
+    "waveform",
+    "sample_rate",
+    "duration",
+    "num_samples",
+    "segments",
+    "diar_segments",
+    "vad_segments",
+    "overlap_segments",
+    "timestamps",
+    "start",
+    "end",
+    "start_ms",
+    "end_ms",
+    "text",
+    "pred_text",
+    "reference_text",
+    "words",
+    "alignment",
+    "speaker_id",
+    "num_speakers",
+    "score",
+    "metrics",
+    "prediction",
+    "segment_num",
+    "original_file",
+    "item_id",
+    "windows",
+    "manifest_path",
+    "output_path",
+    "unknown",
+]
+
+
+@dataclass(frozen=True)
+class ParamSpec:
+    """A single constructor parameter an agent can set on a stage.
+
+    Usually derived automatically from the stage's dataclass fields (or
+    ``__init__`` signature) via
+    :func:`nemo_curator.stages.audio._agent_registry.stage_params`, but a stage
+    may also override/augment entries in ``StageContract.params``.
+    """
+
+    name: str
+    type: str = "Any"
+    default: Any = None
+    required: bool = False
+    choices: list[Any] | None = None  # populated for Literal[...] params
+    description: str | None = None
+    role: Role | None = None  # semantic role of the key this param configures
+
+
+@dataclass(frozen=True)
+class IOSpec:
+    """Task data keys and audio forms read or written by a stage."""
+
+    data_keys: list[str] = field(default_factory=list)
+    segment_data_keys: list[str] = field(default_factory=list)
+    accepts: list[AudioForm] = field(default_factory=list)
+    produces: list[ProducedForm] = field(default_factory=list)
+
+
+@dataclass(frozen=True)
+class Gates:
+    """Execution gates or side effects an agent should know before wrapping a stage."""
+
+    writes_to_disk: bool = False
+    requires_gpu: bool = False
+    requires_internet_first_run: bool = False
+    requires_ffmpeg: bool = False
+    lifecycle_side_effects: bool = False
+    runtime_secrets: list[str] = field(default_factory=list)
+    # Serializability contract for sinks (distinguishes the two JSON sinks):
+    #   requires_serializable_input — this stage serializes task.data as-is (e.g.
+    #     raw json.dumps) and will fail on a resident tensor/audio blob.
+    #   sanitizes_output — this stage strips tensors/audio blobs, so anything
+    #     downstream of it is serialization-safe.
+    requires_serializable_input: bool = False
+    sanitizes_output: bool = False
+
+
+@dataclass(frozen=True)
+class SizeEnvelope:
+    """Coarse size and memory hints for agent planning."""
+
+    max_input_sec: float | None = None
+    allowed_sample_rates: list[int] | None = None
+    channels: Literal["mono", "stereo", "any"] = "any"
+    memory_hint: str | None = None
+
+
+@dataclass(frozen=True)
+class StaticHints:
+    """Instance-independent hints a stage may declare for discovery/planning.
+
+    Lets a stage expose ``cardinality_options``, ``gates``, ``dispatch``,
+    ``error_policy``, ``description`` and ``stage_id`` *without* being
+    instantiated (see :meth:`AgentReady.describe_static`). Declared on a class
+    via the ``AGENT_STATIC`` ClassVar; every field defaults so declaring it is
+    fully optional and additive.
+    """
+
+    cardinality_options: list[str] = field(default_factory=list)
+    gates: Gates = field(default_factory=Gates)
+    dispatch: Dispatch = "auto"
+    error_policy: ErrorPolicy = "unknown"
+    description: str | None = None
+    stage_id: str | None = None
+
+
+@dataclass(frozen=True)
+class StageContract:
+    """Read-only discovery contract for an agent-ready processing stage."""
+
+    reads: IOSpec = field(default_factory=IOSpec)
+    writes: IOSpec = field(default_factory=IOSpec)
+    reads_one_of: list[IOSpec] = field(default_factory=list)
+    metadata_reads: list[str] = field(default_factory=list)
+    metadata_writes: list[str] = field(default_factory=list)
+    cardinality: Cardinality = "1:1"
+    cardinality_options: list[str] = field(default_factory=list)
+    iteration_key: str | None = None
+    preserves_upstream_keys: bool = True
+    wrappable: bool = True
+    size_envelope: SizeEnvelope = field(default_factory=SizeEnvelope)
+    gates: Gates = field(default_factory=Gates)
+    # Agent-facing metadata (advisory; defaults keep older describe() calls valid).
+    stage_id: str | None = None  # stable semantic id; defaults to the class name when None
+    description: str | None = None  # one-line human summary for planners/UIs
+    params: list[ParamSpec] = field(default_factory=list)  # usually auto-derived at discovery time
+    dispatch: Dispatch = "auto"  # "auto" => infer from the stage at runtime
+    error_policy: ErrorPolicy = "unknown"
+    # Resolved-key-value -> semantic role. Populated at discovery time by
+    # ``_agent_registry.build_contract``; empty when a contract is built by hand.
+    key_roles: dict[str, Role] = field(default_factory=dict)
+    # True when the stage only implements ``process_batch`` (``process`` raises).
+    # Auto-derived at discovery time; agents must not call ``process`` on these.
+    batch_only: bool = False
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a JSON-safe dict of this contract (``json.dumps`` never raises)."""
+        return {
+            "reads": asdict(self.reads),
+            "writes": asdict(self.writes),
+            "reads_one_of": [asdict(spec) for spec in self.reads_one_of],
+            "metadata_reads": list(self.metadata_reads),
+            "metadata_writes": list(self.metadata_writes),
+            "cardinality": self.cardinality,
+            "cardinality_options": list(self.cardinality_options),
+            "iteration_key": self.iteration_key,
+            "preserves_upstream_keys": self.preserves_upstream_keys,
+            "wrappable": self.wrappable,
+            "size_envelope": asdict(self.size_envelope),
+            "gates": asdict(self.gates),
+            "stage_id": self.stage_id,
+            "description": self.description,
+            "params": [_paramspec_to_dict(p) for p in self.params],
+            "dispatch": self.dispatch,
+            "error_policy": self.error_policy,
+            "key_roles": dict(self.key_roles),
+            "batch_only": self.batch_only,
+        }
+
+
+def _jsonable_default(value: Any) -> Any:  # noqa: ANN401, PLR0911 (complexity accepted: one early return per JSON type family)
+    """Coerce an arbitrary param default to a JSON-serializable value.
+
+    Non-serializable objects (tensors, models, callables) become a short
+    ``"<non-serializable: Type>"`` sentinel rather than raising.
+    """
+    if value is None or isinstance(value, (str, int, float, bool)):
+        return value
+    if isinstance(value, (list, tuple, set)):
+        return [_jsonable_default(v) for v in value]
+    if isinstance(value, dict):
+        return {str(k): _jsonable_default(v) for k, v in value.items()}
+    if isinstance(value, Enum):
+        return value.value
+    if is_dataclass(value) and not isinstance(value, type):
+        try:
+            return {k: _jsonable_default(v) for k, v in asdict(value).items()}
+        except Exception:  # noqa: BLE001
+            return f"<non-serializable: {type(value).__name__}>"
+    return f"<non-serializable: {type(value).__name__}>"
+
+
+def _paramspec_to_dict(p: ParamSpec) -> dict[str, Any]:
+    return {
+        "name": p.name,
+        "type": p.type,
+        "default": _jsonable_default(p.default),
+        "required": p.required,
+        "choices": None if p.choices is None else [_jsonable_default(c) for c in p.choices],
+        "description": p.description,
+        "role": p.role,
+    }
+
+
+def _json_type(type_str: str | None) -> str | None:
+    """Map a rendered ParamSpec.type string to a JSON-Schema type (or None to omit)."""
+    if not type_str:
+        return None
+    t = type_str.replace(" ", "").replace("|None", "")
+    if t.startswith("Optional["):
+        t = t[len("Optional[") : -1] if t.endswith("]") else t
+    scalar = {"str": "string", "int": "integer", "float": "number", "bool": "boolean"}
+    if t in scalar:
+        return scalar[t]
+    lowered = t.lower()
+    if lowered.startswith(("list", "sequence", "tuple")):
+        return "array"
+    if lowered.startswith(("dict", "mapping")):
+        return "object"
+    return None
+
+
+def to_json_schema(params: list[ParamSpec]) -> dict[str, Any]:
+    """Build a JSON-Schema ``object`` describing a stage's configurable params.
+
+    Suitable as the argument schema for an agent's stage-configuration form.
+    """
+    properties: dict[str, Any] = {}
+    required: list[str] = []
+    for p in params:
+        schema: dict[str, Any] = {}
+        json_type = _json_type(p.type)
+        if json_type is not None:
+            schema["type"] = json_type
+        if p.choices is not None:
+            schema["enum"] = [_jsonable_default(c) for c in p.choices]
+        if p.default is not None:
+            schema["default"] = _jsonable_default(p.default)
+        if p.description:
+            schema["description"] = p.description
+        if p.role:
+            schema["x-role"] = p.role
+        properties[p.name] = schema
+        if p.required:
+            required.append(p.name)
+    out: dict[str, Any] = {"type": "object", "properties": properties}
+    if required:
+        out["required"] = required
+    return out
+
+
+class AgentReady:
+    """Mixin for stages that expose a read-only agent discovery contract."""
+
+    # Opt-in, instance-independent discovery hints. Annotated as ClassVar so
+    # dataclass stages do NOT treat these as fields. All optional/additive.
+    AGENT_STATIC: ClassVar[StaticHints | None] = None
+    # Set True on stages whose ``process`` raises (only ``process_batch`` works).
+    BATCH_ONLY: ClassVar[bool] = False
+    # Rare per-field role overrides keyed by ``*_key`` field name. Consulted
+    # before the shared ``_roles.KEY_ROLES`` table.
+    KEY_ROLE_OVERRIDES: ClassVar[Mapping[str, Role]] = {}
+
+    def describe(self) -> StageContract:
+        raise NotImplementedError
+
+    @classmethod
+    def describe_static(cls) -> StageContract:
+        """Instance-free contract for discovery/planning.
+
+        Uses class defaults + ``AGENT_STATIC`` and never runs ``__init__`` side
+        effects, so it is safe for stages with required constructor args. Prefer
+        the instance-level :meth:`describe` (or
+        ``_agent_registry.build_contract``) when resolved key *values* are
+        needed.
+        """
+        from nemo_curator.stages.audio._agent_registry import static_contract
+
+        return static_contract(cls)
+
+
+# (resolve_contract was removed: dead code whose signature promised class
+# acceptance the body rejected. Instances: use stage.describe() / build_contract;
+# classes: use describe_static() / static_contract.)

--- a/nemo_curator/stages/audio/_residency.py
+++ b/nemo_curator/stages/audio/_residency.py
@@ -21,12 +21,52 @@ from typing import TYPE_CHECKING, Any, Literal
 
 import soundfile as sf
 
+from nemo_curator.stages.audio._agent_ready import AudioForm, IOSpec
 from nemo_curator.stages.audio.common import ensure_waveform_2d, load_audio_file
 
 if TYPE_CHECKING:
     from collections.abc import Callable
 
 InputResidency = Literal["file", "waveform", "auto"]
+
+
+def accepts_for_residency(residency: str) -> list[AudioForm]:
+    """Audio forms an instance actually consumes, given its ``input_residency``.
+
+    The single source of truth a stage's ``describe()`` derives ``accepts`` from,
+    so a ``file``-mode instance can never advertise ``waveform`` (the drift /
+    "lying accepts" bug). ``auto`` accepts either; ``file``/``waveform`` accept
+    only that form.
+    """
+    if residency == "waveform":
+        return ["waveform"]
+    if residency == "file":
+        return ["file"]
+    return ["file", "waveform"]  # "auto"
+
+
+def residency_read_specs(
+    input_residency: str,
+    *,
+    audio_filepath_key: str,
+    waveform_key: str = "waveform",
+    sample_rate_key: str = "sample_rate",
+) -> list[IOSpec]:
+    """The residency-filtered audio read options for a stage's ``reads_one_of``.
+
+    ``file`` -> ``[file spec]``; ``waveform`` -> ``[waveform spec]``; ``auto`` ->
+    ``[waveform spec, file spec]``. Keeps ``accepts`` **and** ``data_keys`` in
+    lockstep with ``input_residency`` so a stage can never advertise (or require)
+    a form it won't consume for its current setting — which lets the deterministic
+    role check enforce residency compatibility with no extra check.
+    """
+    forms = accepts_for_residency(input_residency)
+    specs: list[IOSpec] = []
+    if "waveform" in forms:
+        specs.append(IOSpec(data_keys=[waveform_key, sample_rate_key], accepts=["waveform"]))
+    if "file" in forms:
+        specs.append(IOSpec(data_keys=[audio_filepath_key], accepts=["file"]))
+    return specs
 
 
 def resolve_audio(  # noqa: PLR0913 (complexity accepted: keyword-only residency/key knobs mirror the stage fields)

--- a/nemo_curator/stages/audio/_residency.py
+++ b/nemo_curator/stages/audio/_residency.py
@@ -1,0 +1,157 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import contextlib
+import os
+import tempfile
+from typing import TYPE_CHECKING, Any, Literal
+
+import soundfile as sf
+
+from nemo_curator.stages.audio.common import ensure_waveform_2d, load_audio_file
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+InputResidency = Literal["file", "waveform", "auto"]
+
+
+def resolve_audio(  # noqa: PLR0913 (complexity accepted: keyword-only residency/key knobs mirror the stage fields)
+    item: dict[str, Any],
+    *,
+    residency: InputResidency = "auto",
+    audio_filepath_key: str = "audio_filepath",
+    waveform_key: str = "waveform",
+    sample_rate_key: str = "sample_rate",
+    mono: bool = True,
+    loader: Callable[..., tuple[Any, int]] | None = None,
+) -> tuple[Any, int] | None:
+    """Return ``(waveform_2d, sample_rate)`` from tensor keys or a file path.
+
+    ``auto`` prefers an existing waveform, then falls back to file loading.
+    ``waveform`` never falls back to disk. ``file`` always loads from the
+    configured path key.
+
+    ``loader`` overrides the file-loading callable (default
+    :func:`~nemo_curator.stages.audio.common.load_audio_file`); stages pass
+    their own module-level symbol so callers can patch it at the stage module.
+    """
+    waveform = item.get(waveform_key)
+    sample_rate = item.get(sample_rate_key)
+    if residency != "file" and waveform is not None and sample_rate is not None:
+        return ensure_waveform_2d(waveform), int(sample_rate)
+
+    if residency == "waveform":
+        return None
+
+    path = item.get(audio_filepath_key)
+    if path:
+        expanded = os.path.expanduser(str(path))
+        if os.path.exists(expanded):
+            return (loader or load_audio_file)(expanded, mono=mono)
+    return None
+
+
+def _as_soundfile_array(waveform: Any) -> Any:  # noqa: ANN401
+    waveform = ensure_waveform_2d(waveform)
+    if hasattr(waveform, "detach"):
+        waveform = waveform.detach()
+    if hasattr(waveform, "cpu"):
+        waveform = waveform.cpu()
+    if hasattr(waveform, "numpy"):
+        waveform = waveform.numpy()
+    if getattr(waveform, "ndim", 0) == 2:  # noqa: PLR2004 - 2 == a (channels, samples) 2-D array
+        channels, samples = waveform.shape
+        if channels == 1:
+            return waveform[0]
+        if channels < samples:
+            return waveform.T
+    return waveform
+
+
+def resolve_audio_path(  # noqa: PLR0913 (complexity accepted: keyword-only residency/key knobs mirror the stage fields)
+    item: dict[str, Any],
+    *,
+    residency: InputResidency = "auto",
+    audio_filepath_key: str = "audio_filepath",
+    waveform_key: str = "waveform",
+    sample_rate_key: str = "sample_rate",
+    temp_dir: str | None = None,
+    register_temp: list[str] | None = None,
+) -> str | None:
+    """Return an audio path, writing a temp WAV when only a waveform exists.
+
+    When a temp WAV is materialized from an in-memory waveform and
+    ``register_temp`` is provided, the temp path is appended to that list so the
+    caller can delete it after use (see :func:`cleanup_temp_files`). Without
+    ``register_temp`` the caller is responsible for cleanup itself.
+    """
+    path = item.get(audio_filepath_key)
+    local_path: str | None = None
+    if residency != "waveform" and path:
+        local_path = os.path.expanduser(str(path))
+        if os.path.exists(local_path):
+            return local_path
+        # Protocol-prefixed paths (file://, http(s)://, s3://, ...) were handled
+        # by the stages' own fsspec machinery before the residency layer existed;
+        # keep accepting them when the target exists remotely.
+        if "://" in str(path):
+            try:
+                from fsspec.core import url_to_fs
+
+                fs, fspath = url_to_fs(str(path))
+                if fs.exists(fspath):
+                    return path
+            except Exception:  # noqa: BLE001, S110 - unknown protocol/creds -> deliberate fall-through
+                pass
+
+    if residency == "file":
+        # Pre-residency stages handed unverified paths straight to their own
+        # downstream machinery (ffmpeg/NeMo/fsspec) and let it report the
+        # failure; keep that contract instead of gating on os.path.exists.
+        return local_path
+
+    waveform = item.get(waveform_key)
+    sample_rate = item.get(sample_rate_key)
+    if waveform is None or sample_rate is None:
+        return local_path
+
+    fd, tmp = tempfile.mkstemp(suffix=".wav", dir=temp_dir)
+    os.close(fd)
+    sf.write(tmp, _as_soundfile_array(waveform), int(sample_rate))
+    if register_temp is not None:
+        register_temp.append(tmp)
+    return tmp
+
+
+def cleanup_temp_files(paths: list[str] | None) -> None:
+    """Best-effort removal of temp files created by :func:`resolve_audio_path`."""
+    for path in paths or ():
+        with contextlib.suppress(OSError):
+            os.remove(path)
+
+
+def produce_audio_filepath(
+    item: dict[str, Any],
+    new_path: str,
+    *,
+    key: str = "audio_filepath",
+    original_key: str = "original_audio_filepath",
+) -> None:
+    """Update a canonical audio path while preserving the first prior value."""
+    if key in item and original_key not in item:
+        item[original_key] = item[key]
+    item[key] = new_path

--- a/nemo_curator/stages/audio/alm/alm_data_builder.py
+++ b/nemo_curator/stages/audio/alm/alm_data_builder.py
@@ -26,6 +26,7 @@ import time
 from dataclasses import asdict, dataclass, field
 from typing import Any
 
+from nemo_curator.stages.audio._agent_ready import AgentReady, IOSpec, StageContract
 from nemo_curator.stages.base import ProcessingStage
 from nemo_curator.tasks import AudioTask
 
@@ -124,7 +125,7 @@ def _record_window_loss(  # noqa: PLR0913
 
 
 @dataclass
-class ALMDataBuilderStage(ProcessingStage[AudioTask, AudioTask]):
+class ALMDataBuilderStage(AgentReady, ProcessingStage[AudioTask, AudioTask]):
     """Build ALM training windows from audio segments.
 
     Filters segments by sample rate, bandwidth, speaker count, and duration
@@ -148,6 +149,13 @@ class ALMDataBuilderStage(ProcessingStage[AudioTask, AudioTask]):
 
     # Top-level fields to drop from output entry (comma-separated)
     drop_fields_top_level: str = "words,segments"
+    audio_filepath_key: str = "audio_filepath"
+    segments_key: str = "segments"
+    audio_sample_rate_key: str = "audio_sample_rate"
+    windows_key: str = "windows"
+    stats_key: str = "stats"
+    truncation_events_key: str = "truncation_events"
+    swift_audio_filepath_key: str = "swift_audio_filepath"
 
     def __post_init__(self) -> None:
         """Compute derived parameters - EXACT match to SDP."""
@@ -159,17 +167,29 @@ class ALMDataBuilderStage(ProcessingStage[AudioTask, AudioTask]):
         self._drop_fields_top_level_set = {f.strip() for f in self.drop_fields_top_level.split(",") if f.strip()}
 
     def inputs(self) -> tuple[list[str], list[str]]:
-        return [], ["audio_filepath", "segments", "audio_sample_rate"]
+        return [], [self.audio_filepath_key, self.segments_key, self.audio_sample_rate_key]
+
+    def outputs(self) -> tuple[list[str], list[str]]:
+        return [], [self.windows_key, self.stats_key, self.truncation_events_key]
+
+    def describe(self) -> StageContract:
+        return StageContract(
+            reads=IOSpec(data_keys=[self.audio_filepath_key, self.segments_key, self.audio_sample_rate_key]),
+            writes=IOSpec(data_keys=[self.windows_key, self.stats_key, self.truncation_events_key]),
+            # process() rebuilds task.data selectively (words/segments stripped;
+            # the min_sample_rate branch keeps only a four-key subset).
+            preserves_upstream_keys=False,
+        )
 
     def process(self, task: AudioTask) -> AudioTask:
         t0 = time.perf_counter()
-        num_segments = len(task.data.get("segments", []))
+        num_segments = len(task.data.get(self.segments_key, []))
         result = self._process_single_entry(task.data)
         task.data.clear()
         task.data.update(result)
         process_time = time.perf_counter() - t0
 
-        num_windows = len(task.data.get("windows", []))
+        num_windows = len(task.data.get(self.windows_key, []))
         self._log_metrics(
             {
                 "process_time": process_time,
@@ -184,25 +204,25 @@ class ALMDataBuilderStage(ProcessingStage[AudioTask, AudioTask]):
         """Process a single entry and extract valid training windows."""
         total_truncation_events = 0
 
-        audio_file = entry_data.get("audio_filepath")
-        segments = entry_data.get("segments", [])
+        audio_file = entry_data.get(self.audio_filepath_key)
+        segments = entry_data.get(self.segments_key, [])
         total_dur = sum(seg["end"] - seg["start"] for seg in segments)
 
         stat = BuilderStats(
             total_segments=len(segments),
             total_dur=total_dur,
-            swift_path=entry_data.get("swift_audio_filepath", ""),
-            audio_sample_rate=entry_data.get("audio_sample_rate", 0),
+            swift_path=entry_data.get(self.swift_audio_filepath_key, ""),
+            audio_sample_rate=entry_data.get(self.audio_sample_rate_key, 0),
         )
 
-        if entry_data.get("audio_sample_rate", 0) < self.min_sample_rate:
+        if entry_data.get(self.audio_sample_rate_key, 0) < self.min_sample_rate:
             stat.lost_sr = len(segments)
             stat.dur_lost_sr = total_dur
             return {
-                "audio_filepath": audio_file,
-                "windows": [],
-                "stats": stat.to_dict(),
-                "truncation_events": total_truncation_events,
+                self.audio_filepath_key: audio_file,
+                self.windows_key: [],
+                self.stats_key: stat.to_dict(),
+                self.truncation_events_key: total_truncation_events,
             }
 
         valid_windows: list[dict[str, Any]] = []
@@ -284,8 +304,8 @@ class ALMDataBuilderStage(ProcessingStage[AudioTask, AudioTask]):
             )
 
         result = {k: v for k, v in entry_data.items() if k not in self._drop_fields_top_level_set}
-        result["windows"] = valid_windows
-        result["stats"] = stat.to_dict()
-        result["truncation_events"] = total_truncation_events
+        result[self.windows_key] = valid_windows
+        result[self.stats_key] = stat.to_dict()
+        result[self.truncation_events_key] = total_truncation_events
 
         return result

--- a/nemo_curator/stages/audio/alm/alm_data_overlap.py
+++ b/nemo_curator/stages/audio/alm/alm_data_overlap.py
@@ -26,6 +26,7 @@ import time
 from dataclasses import dataclass
 from typing import Any
 
+from nemo_curator.stages.audio._agent_ready import AgentReady, IOSpec, StageContract
 from nemo_curator.stages.base import ProcessingStage
 from nemo_curator.tasks import AudioTask
 
@@ -149,7 +150,7 @@ def _get_filepath_from_stats(stats: dict[str, Any] | None, key: str) -> str | No
 
 
 @dataclass
-class ALMDataOverlapStage(ProcessingStage[AudioTask, AudioTask]):
+class ALMDataOverlapStage(AgentReady, ProcessingStage[AudioTask, AudioTask]):
     """Filter overlapping ALM windows.
 
     Removes windows with overlap exceeding the threshold, keeping
@@ -161,6 +162,8 @@ class ALMDataOverlapStage(ProcessingStage[AudioTask, AudioTask]):
     # Processing parameters (EXACT match to SDP)
     overlap_percentage: int = 0
     target_duration: float = 120.0
+    windows_key: str = "windows"
+    filtered_windows_key: str = "filtered_windows"
 
     def __post_init__(self) -> None:
         """Validate parameters."""
@@ -172,17 +175,26 @@ class ALMDataOverlapStage(ProcessingStage[AudioTask, AudioTask]):
             raise ValueError(msg)
 
     def inputs(self) -> tuple[list[str], list[str]]:
-        return [], ["windows"]
+        return [], [self.windows_key]
+
+    def outputs(self) -> tuple[list[str], list[str]]:
+        return [], [self.filtered_windows_key]
+
+    def describe(self) -> StageContract:
+        return StageContract(
+            reads=IOSpec(data_keys=[self.windows_key]),
+            writes=IOSpec(data_keys=[self.filtered_windows_key]),
+        )
 
     def process(self, task: AudioTask) -> AudioTask:
         t0 = time.perf_counter()
-        input_windows = len(task.data.get("windows", []))
+        input_windows = len(task.data.get(self.windows_key, []))
         result = self._filter_overlaps(task.data)
         task.data.clear()
         task.data.update(result)
         filter_time = time.perf_counter() - t0
 
-        output_windows = len(task.data.get("filtered_windows", []))
+        output_windows = len(task.data.get(self.filtered_windows_key, []))
         filtered_dur = task.data.get("filtered_dur", 0.0)
         self._log_metrics(
             {
@@ -199,10 +211,10 @@ class ALMDataOverlapStage(ProcessingStage[AudioTask, AudioTask]):
         """Filter overlapping windows from entry."""
         threshold = self.overlap_percentage / MAX_OVERLAP_PERCENTAGE
 
-        windows = entry.get("windows", [])
+        windows = entry.get(self.windows_key, [])
         if not windows:
             result = entry.copy()
-            result.setdefault("filtered_windows", [])
+            result.setdefault(self.filtered_windows_key, [])
             result.setdefault("filtered_dur", 0.0)
             result.setdefault("filtered_dur_list", [])
             result.setdefault("total_dur_window", 0.0)
@@ -234,7 +246,7 @@ class ALMDataOverlapStage(ProcessingStage[AudioTask, AudioTask]):
         result["total_dur_list_window"] = total_dur_list_window
         result["total_dur_list_window_timestamps"] = total_dur_list_window_timestamps
         result["filtered"] = filtered_timestamps
-        result["filtered_windows"] = filtered_windows
+        result[self.filtered_windows_key] = filtered_windows
         result["filtered_dur"] = filtered_dur
         result["filtered_dur_list"] = filtered_dur_list
         result["manifest_filepath"] = manifest_filepath

--- a/nemo_curator/stages/audio/alm/pretrain/extraction.py
+++ b/nemo_curator/stages/audio/alm/pretrain/extraction.py
@@ -32,6 +32,7 @@ import torchaudio.functional as taf
 from loguru import logger
 
 from nemo_curator.backends.utils import RayStageSpecKeys
+from nemo_curator.stages.audio._agent_ready import AgentReady, Gates, IOSpec, StageContract
 from nemo_curator.stages.audio.alm.pretrain.planning import relativize_segments
 from nemo_curator.stages.audio.alm.pretrain.utils import (
     _PLAN_DATA_KEY,
@@ -51,7 +52,7 @@ if TYPE_CHECKING:
 
 
 @dataclass
-class SnippetExtractionStage(ProcessingStage[AudioTask, AudioTask]):
+class SnippetExtractionStage(AgentReady, ProcessingStage[AudioTask, AudioTask]):
     """Slice the source audio per snippet plan, mono-resample, and write into a tar.
 
     For each planned snippet:
@@ -115,6 +116,20 @@ class SnippetExtractionStage(ProcessingStage[AudioTask, AudioTask]):
 
     def outputs(self) -> tuple[list[str], list[str]]:
         return [], [self.audio_filepath_key, "snippet_id", "duration", "segments"]
+
+    def describe(self) -> StageContract:
+        return StageContract(
+            reads=IOSpec(data_keys=[self.audio_filepath_key, _PLAN_DATA_KEY], accepts=["file"]),
+            writes=IOSpec(
+                data_keys=[self.audio_filepath_key, "snippet_id", "duration", "segments"],
+                # Disk output only happens when not dry-running; keep this consistent
+                # with the writes_to_disk gate below.
+                produces=[] if self.dry_run else ["disk"],
+            ),
+            cardinality="1:N fan-out",
+            iteration_key=_PLAN_DATA_KEY,
+            gates=Gates(writes_to_disk=not self.dry_run, lifecycle_side_effects=not self.dry_run),
+        )
 
     def ray_stage_spec(self) -> dict[str, Any]:
         return {RayStageSpecKeys.IS_FANOUT_STAGE: True}

--- a/nemo_curator/stages/audio/alm/pretrain/io.py
+++ b/nemo_curator/stages/audio/alm/pretrain/io.py
@@ -34,6 +34,7 @@ from typing import TYPE_CHECKING, Any
 from loguru import logger
 
 from nemo_curator.backends.utils import RayStageSpecKeys
+from nemo_curator.stages.audio._agent_ready import AgentReady, Gates, IOSpec, StageContract
 from nemo_curator.stages.audio.alm.pretrain.utils import (
     _AUDIO_PATH_RESOLUTION_MODES,
     _MANIFEST_SHARD_EXT,
@@ -100,7 +101,7 @@ def _check_duplicate_audio_basename(
 
 
 @dataclass
-class ReadLongFormManifestStage(ProcessingStage[EmptyTask, AudioTask]):
+class ReadLongFormManifestStage(AgentReady, ProcessingStage[EmptyTask, AudioTask]):
     """Read a JSONL manifest of long-form audios; emit one AudioTask per row.
 
     Each line in ``input_manifest`` is parsed as JSON and re-emitted as
@@ -154,6 +155,12 @@ class ReadLongFormManifestStage(ProcessingStage[EmptyTask, AudioTask]):
 
     def outputs(self) -> tuple[list[str], list[str]]:
         return [], [self.audio_filepath_key, "id", "segments"]
+
+    def describe(self) -> StageContract:
+        return StageContract(
+            writes=IOSpec(data_keys=[self.audio_filepath_key, "id", "segments"]),
+            cardinality="1:N fan-out",
+        )
 
     def ray_stage_spec(self) -> dict[str, Any]:
         return {RayStageSpecKeys.IS_FANOUT_STAGE: True}
@@ -229,7 +236,7 @@ class ReadLongFormManifestStage(ProcessingStage[EmptyTask, AudioTask]):
 
 
 @dataclass
-class SnippetManifestWriterStage(ProcessingStage[AudioTask, AudioTask]):
+class SnippetManifestWriterStage(AgentReady, ProcessingStage[AudioTask, AudioTask]):
     """Append each (non-stub) snippet's ``data`` as a JSONL line.
 
     Single-replica writer; the file is truncated once on driver setup
@@ -252,6 +259,9 @@ class SnippetManifestWriterStage(ProcessingStage[AudioTask, AudioTask]):
 
     def outputs(self) -> tuple[list[str], list[str]]:
         return [], []
+
+    def describe(self) -> StageContract:
+        return StageContract(gates=Gates(writes_to_disk=True, lifecycle_side_effects=True))
 
     def setup_on_node(
         self,
@@ -284,7 +294,7 @@ class SnippetManifestWriterStage(ProcessingStage[AudioTask, AudioTask]):
 
 
 @dataclass
-class PretrainMetricsAggregatorStage(ProcessingStage[AudioTask, AudioTask]):
+class PretrainMetricsAggregatorStage(AgentReady, ProcessingStage[AudioTask, AudioTask]):
     """Per-replica metrics aggregator.
 
     Each ``process()`` call appends one JSONL record to a per-replica
@@ -330,6 +340,12 @@ class PretrainMetricsAggregatorStage(ProcessingStage[AudioTask, AudioTask]):
 
     def outputs(self) -> tuple[list[str], list[str]]:
         return [], []
+
+    def describe(self) -> StageContract:
+        return StageContract(
+            metadata_reads=[_PRETRAIN_META_KEY],
+            gates=Gates(writes_to_disk=True, lifecycle_side_effects=True),
+        )
 
     def setup_on_node(
         self,

--- a/nemo_curator/stages/audio/alm/pretrain/planning.py
+++ b/nemo_curator/stages/audio/alm/pretrain/planning.py
@@ -34,6 +34,7 @@ from huggingface_hub import snapshot_download
 from loguru import logger
 from transformers import AutoTokenizer
 
+from nemo_curator.stages.audio._agent_ready import AgentReady, Gates, IOSpec, StageContract
 from nemo_curator.stages.audio.alm.pretrain.utils import (
     _MAX_FILTERED_TEXT_EXAMPLES,
     _PLAN_DATA_KEY,
@@ -328,7 +329,7 @@ def _format_red(text: str, ranges: list[tuple[int, int]]) -> str:
 
 
 @dataclass
-class OverlapFilterStage(ProcessingStage[AudioTask, AudioTask]):
+class OverlapFilterStage(AgentReady, ProcessingStage[AudioTask, AudioTask]):
     """Drop empty segments and overlapping segment pairs.
 
     First filters segments that have neither text nor words.  Then drops
@@ -353,6 +354,13 @@ class OverlapFilterStage(ProcessingStage[AudioTask, AudioTask]):
 
     def outputs(self) -> tuple[list[str], list[str]]:
         return [], ["segments"]
+
+    def describe(self) -> StageContract:
+        return StageContract(
+            reads=IOSpec(data_keys=["segments"]),
+            writes=IOSpec(data_keys=["segments"]),
+            metadata_writes=[_PRETRAIN_META_KEY],
+        )
 
     def process(self, task: AudioTask) -> AudioTask:
         t0 = time.perf_counter()
@@ -400,7 +408,7 @@ class OverlapFilterStage(ProcessingStage[AudioTask, AudioTask]):
 
 
 @dataclass
-class SnippetCutPlannerStage(ProcessingStage[AudioTask, AudioTask]):
+class SnippetCutPlannerStage(AgentReady, ProcessingStage[AudioTask, AudioTask]):
     """Compute snippet cut boundaries for one input audio.
 
     Pure planning -- no audio I/O.  Produces a list of snippet specs
@@ -442,6 +450,13 @@ class SnippetCutPlannerStage(ProcessingStage[AudioTask, AudioTask]):
     def outputs(self) -> tuple[list[str], list[str]]:
         return [], [_PLAN_DATA_KEY]
 
+    def describe(self) -> StageContract:
+        return StageContract(
+            reads=IOSpec(data_keys=["segments"]),
+            writes=IOSpec(data_keys=[_PLAN_DATA_KEY]),
+            metadata_writes=[_PRETRAIN_META_KEY],
+        )
+
     def process(self, task: AudioTask) -> AudioTask:
         t0 = time.perf_counter()
         segments = list(task.data.get("segments") or [])
@@ -479,7 +494,7 @@ class SnippetCutPlannerStage(ProcessingStage[AudioTask, AudioTask]):
 
 
 @dataclass
-class SnippetRepetitionFilterStage(ProcessingStage[AudioTask, AudioTask]):
+class SnippetRepetitionFilterStage(AgentReady, ProcessingStage[AudioTask, AudioTask]):
     """Drop planned snippets whose text shows suspicious n-gram repetition.
 
     Whisper-style ASR sometimes degenerates into repeating the same
@@ -534,6 +549,14 @@ class SnippetRepetitionFilterStage(ProcessingStage[AudioTask, AudioTask]):
 
     def outputs(self) -> tuple[list[str], list[str]]:
         return [], [_PLAN_DATA_KEY]
+
+    def describe(self) -> StageContract:
+        return StageContract(
+            reads=IOSpec(data_keys=[_PLAN_DATA_KEY]),
+            writes=IOSpec(data_keys=[_PLAN_DATA_KEY]),
+            metadata_writes=[_PRETRAIN_META_KEY],
+            gates=Gates(requires_internet_first_run=not os.path.isdir(self.tokenizer_path)),
+        )
 
     def setup_on_node(
         self,

--- a/nemo_curator/stages/audio/common.py
+++ b/nemo_curator/stages/audio/common.py
@@ -25,6 +25,7 @@ from fsspec.core import url_to_fs
 from loguru import logger
 
 from nemo_curator.backends.base import NodeInfo, WorkerMetadata
+from nemo_curator.stages.audio._agent_ready import AgentReady, Gates, IOSpec, StageContract
 from nemo_curator.stages.base import CompositeStage, ProcessingStage
 from nemo_curator.stages.file_partitioning import FilePartitioningStage
 from nemo_curator.tasks import AudioTask, EmptyTask, FileGroupTask
@@ -41,7 +42,7 @@ def get_audio_duration(audio_filepath: str) -> float:
 
 
 @dataclass
-class GetAudioDurationStage(ProcessingStage[AudioTask, AudioTask]):
+class GetAudioDurationStage(AgentReady, ProcessingStage[AudioTask, AudioTask]):
     """Compute audio duration from the file at *audio_filepath_key* and
     store the result under *duration_key*.
 
@@ -65,6 +66,12 @@ class GetAudioDurationStage(ProcessingStage[AudioTask, AudioTask]):
     def outputs(self) -> tuple[list[str], list[str]]:
         return [], [self.duration_key]
 
+    def describe(self) -> StageContract:
+        return StageContract(
+            reads=IOSpec(data_keys=[self.audio_filepath_key], accepts=["file"]),
+            writes=IOSpec(data_keys=[self.duration_key]),
+        )
+
     def process(self, task: AudioTask) -> AudioTask:
         t0 = time.perf_counter()
         audio_filepath = task.data[self.audio_filepath_key]
@@ -74,7 +81,7 @@ class GetAudioDurationStage(ProcessingStage[AudioTask, AudioTask]):
         return task
 
 
-class PreserveByValueStage(ProcessingStage[AudioTask, AudioTask]):
+class PreserveByValueStage(AgentReady, ProcessingStage[AudioTask, AudioTask]):
     """Filter entries by comparing *input_value_key* against *target_value*.
 
     Returns ``None`` from ``process()`` to drop entries that fail the
@@ -87,6 +94,7 @@ class PreserveByValueStage(ProcessingStage[AudioTask, AudioTask]):
     """
 
     name: str = "PreserveByValueStage"
+    BATCH_ONLY = True  # process() raises; only process_batch is implemented (agent-discovery hint)
 
     def __init__(
         self,
@@ -107,6 +115,13 @@ class PreserveByValueStage(ProcessingStage[AudioTask, AudioTask]):
 
     def outputs(self) -> tuple[list[str], list[str]]:
         return [], [self.input_value_key]
+
+    def describe(self) -> StageContract:
+        return StageContract(
+            reads=IOSpec(data_keys=[self.input_value_key]),
+            writes=IOSpec(data_keys=[self.input_value_key]),
+            cardinality="filter",
+        )
 
     def process(self, task: AudioTask) -> AudioTask | None:
         msg = "PreserveByValueStage only supports process_batch"
@@ -133,7 +148,7 @@ class PreserveByValueStage(ProcessingStage[AudioTask, AudioTask]):
 
 
 @dataclass
-class ManifestReaderStage(ProcessingStage[FileGroupTask, AudioTask]):
+class ManifestReaderStage(AgentReady, ProcessingStage[FileGroupTask, AudioTask]):
     """Read JSONL manifest files from a FileGroupTask and emit one AudioTask per line.
 
     Uses line-by-line streaming via fsspec (no Pandas) to keep memory at ~1x file size.
@@ -177,9 +192,16 @@ class ManifestReaderStage(ProcessingStage[FileGroupTask, AudioTask]):
     def num_workers(self) -> int | None:
         return 1
 
+    def describe(self) -> StageContract:
+        return StageContract(
+            writes=IOSpec(data_keys=["audio_filepath"]),
+            cardinality="1:N fan-out",
+            gates=Gates(lifecycle_side_effects=True),
+        )
+
 
 @dataclass
-class ManifestReader(CompositeStage[EmptyTask, AudioTask]):
+class ManifestReader(AgentReady, CompositeStage[EmptyTask, AudioTask]):
     """Composite stage for reading JSONL manifests.
 
     Decomposes into:
@@ -227,9 +249,12 @@ class ManifestReader(CompositeStage[EmptyTask, AudioTask]):
             parts.append(f"with target blocksize {self.blocksize}")
         return ", ".join(parts)
 
+    def describe(self) -> StageContract:
+        return StageContract(cardinality="1:N fan-out", wrappable=False)
+
 
 @dataclass
-class ManifestWriterStage(ProcessingStage[AudioTask, AudioTask]):
+class ManifestWriterStage(AgentReady, ProcessingStage[AudioTask, AudioTask]):
     """Append a single AudioTask to a JSONL manifest file.
 
     The output file is truncated once in ``setup()`` (called on the driver)
@@ -290,6 +315,18 @@ class ManifestWriterStage(ProcessingStage[AudioTask, AudioTask]):
     def num_workers(self) -> int | None:
         return 1
 
+    def describe(self) -> StageContract:
+        return StageContract(
+            gates=Gates(
+                writes_to_disk=True,
+                lifecycle_side_effects=True,
+                # Serializes task.data as-is via json.dumps; a resident tensor
+                # (e.g. a waveform) will crash it. Route through
+                # AudioToDocumentStage (which sanitizes) if one may be present.
+                requires_serializable_input=True,
+            ),
+        )
+
 
 def load_audio_file(audio_path: str, mono: bool = True) -> tuple[torch.Tensor, int]:
     """Load audio file and return waveform tensor (channels, samples) and sample rate."""
@@ -327,6 +364,13 @@ def resolve_waveform_from_item(
     item['audio_filepath'], resolves missing sample_rate from file header.
     Updates item in-place when loading from file.
     Returns None if resolution fails.
+
+    .. note::
+       The canonical resolver is :func:`nemo_curator.stages.audio._residency.resolve_audio`.
+       This helper is retained for its unique behavior — reading ``sample_rate`` from the
+       file header *without* reloading an already-present waveform, and writing the loaded
+       waveform/sample_rate back into ``item`` — which ``resolve_audio`` does not replicate.
+       Prefer ``resolve_audio`` in new code.
     """
     waveform = item.get("waveform")
     sample_rate = item.get("sample_rate")


### PR DESCRIPTION
## Summary
Makes the ALM (audio-language-model) data-pipeline stages agent-ready. Additive only.

- `alm/alm_data_builder.py`, `alm/alm_data_overlap.py`, `alm/pretrain/extraction.py`, `alm/pretrain/io.py`, `alm/pretrain/planning.py` — subclass `AgentReady` and add `describe()` / `StageContract` declaring each stage's reads/writes; some hardcoded keys made configurable. Core data-building / planning / IO logic is unchanged.

## Notes for reviewers
- Additive, backward compatible; no runtime behavior change expected.
- Worth a look: that each new `describe()` matches what the stage actually reads/writes.

## Test plan
- [ ] `pytest tests/stages/audio/alm -q`