### PR TITLE
Add num_workers_per_node() as a method for stages + Per-node worker sizing for download stages

### DIFF
--- a/nemo_curator/backends/ray_actor_pool/utils.py
+++ b/nemo_curator/backends/ray_actor_pool/utils.py
@@ -61,12 +61,6 @@ def calculate_optimal_actors_for_stage(
 
     num_workers = stage.num_workers()
     num_workers_per_node = get_stage_num_workers_per_node(stage)
-    if num_workers is not None and num_workers_per_node is not None:
-        msg = (
-            f"Stage {stage.name} defines both num_workers()={num_workers} and "
-            f"num_workers_per_node()={num_workers_per_node}. Use only one worker sizing option."
-        )
-        raise ValueError(msg)
 
     if num_workers is not None and num_workers > 0:
         if num_workers > max_actors_resources:

--- a/nemo_curator/backends/ray_actor_pool/utils.py
+++ b/nemo_curator/backends/ray_actor_pool/utils.py
@@ -18,7 +18,8 @@ from typing import TYPE_CHECKING
 import ray
 from loguru import logger
 
-from nemo_curator.backends.utils import get_available_cpu_gpu_resources
+from nemo_curator.backends.utils import get_available_cpu_gpu_resources, get_stage_num_workers_per_node
+from nemo_curator.utils.ray_utils import get_alive_ray_node_count
 
 if TYPE_CHECKING:
     from ray.actor import ActorClass
@@ -59,6 +60,14 @@ def calculate_optimal_actors_for_stage(
         raise ValueError(msg)
 
     num_workers = stage.num_workers()
+    num_workers_per_node = get_stage_num_workers_per_node(stage)
+    if num_workers is not None and num_workers_per_node is not None:
+        msg = (
+            f"Stage {stage.name} defines both num_workers()={num_workers} and "
+            f"num_workers_per_node()={num_workers_per_node}. Use only one worker sizing option."
+        )
+        raise ValueError(msg)
+
     if num_workers is not None and num_workers > 0:
         if num_workers > max_actors_resources:
             msg = (
@@ -69,6 +78,19 @@ def calculate_optimal_actors_for_stage(
             logger.warning(msg)
             return max_actors_resources
         return num_workers
+
+    if num_workers_per_node is not None:
+        num_nodes = get_alive_ray_node_count(ignore_head_node=ignore_head_node)
+        requested_actors = max(1, math.ceil(num_workers_per_node * num_nodes))
+        if requested_actors > max_actors_resources:
+            msg = (
+                f"Stage {stage.name} requires {requested_actors} actors from num_workers_per_node(), "
+                f"but only {max_actors_resources} fit with available resources. "
+                f"Capping actor count to {max_actors_resources}."
+            )
+            logger.warning(msg)
+            return max_actors_resources
+        return requested_actors
 
     number_of_batches = (
         math.ceil(num_tasks / stage.batch_size) if stage.batch_size is not None and stage.batch_size > 0 else num_tasks

--- a/nemo_curator/backends/ray_data/adapter.py
+++ b/nemo_curator/backends/ray_data/adapter.py
@@ -13,15 +13,21 @@
 # limitations under the License.
 
 import copy
+import math
 from collections.abc import Callable
 from typing import Any
 
 from loguru import logger
-from ray.data import Dataset, TaskPoolStrategy
+from ray.data import ActorPoolStrategy, Dataset, TaskPoolStrategy
 
 from nemo_curator.backends.base import BaseStageAdapter
-from nemo_curator.backends.utils import RayStageSpecKeys, get_worker_metadata_and_node_id
+from nemo_curator.backends.utils import (
+    RayStageSpecKeys,
+    get_stage_num_workers_per_node,
+    get_worker_metadata_and_node_id,
+)
 from nemo_curator.stages.base import ProcessingStage
+from nemo_curator.utils.ray_utils import get_alive_ray_node_count
 
 from .utils import get_actor_compute_strategy_for_stage, get_configured_actor_pool_sizing_keys, is_actor_stage
 
@@ -39,8 +45,9 @@ class RayDataStageAdapter(BaseStageAdapter):
         c. Else we use tasks
     """
 
-    def __init__(self, stage: ProcessingStage):
+    def __init__(self, stage: ProcessingStage, ignore_head_node: bool = False):
         super().__init__(stage)
+        self.ignore_head_node = ignore_head_node
 
         self._batch_size = self.stage.batch_size
         if self._batch_size is None and self.stage.resources.gpus > 0:
@@ -90,6 +97,59 @@ class RayDataStageAdapter(BaseStageAdapter):
             kwargs["num_gpus"] = self.stage.resources.gpus  # type: ignore[reportArgumentType]
         return kwargs
 
+    def _get_per_node_pool_size(self, ray_stage_spec: dict, num_workers: int | None) -> int | None:
+        num_workers_per_node = get_stage_num_workers_per_node(self.stage)
+        if num_workers_per_node is None:
+            return None
+
+        if num_workers is not None:
+            msg = (
+                f"Stage {self.stage.name} defines both num_workers()={num_workers} and "
+                f"num_workers_per_node()={num_workers_per_node}. "
+                "Use only one worker sizing option."
+            )
+            raise ValueError(msg)
+
+        actor_pool_sizing_keys = get_configured_actor_pool_sizing_keys(ray_stage_spec)
+        if actor_pool_sizing_keys:
+            msg = (
+                f"Stage {self.stage.name} defines num_workers_per_node() "
+                f"and actor-pool sizing keys {actor_pool_sizing_keys}. Use only one worker sizing option."
+            )
+            raise ValueError(msg)
+
+        node_count = get_alive_ray_node_count(ignore_head_node=self.ignore_head_node)
+        if node_count <= 0:
+            msg = f"No alive Ray nodes available for num_workers_per_node sizing on stage {self.stage.name}."
+            raise ValueError(msg)
+        return max(1, math.ceil(num_workers_per_node * node_count))
+
+    def _build_actor_compute_kwargs(self, per_node_pool_size: int | None) -> dict[str, object]:
+        if per_node_pool_size is not None:
+            return {"compute": ActorPoolStrategy(size=per_node_pool_size)}
+        return {"compute": get_actor_compute_strategy_for_stage(self.stage)}
+
+    def _build_task_compute_kwargs(
+        self, ray_stage_spec: dict, per_node_pool_size: int | None, num_workers: int | None
+    ) -> dict[str, object]:
+        actor_pool_sizing_keys = get_configured_actor_pool_sizing_keys(ray_stage_spec)
+        if actor_pool_sizing_keys:
+            logger.warning(
+                f"Ignoring ray_stage_spec worker sizing keys {actor_pool_sizing_keys} "
+                f"for Ray Data task stage {self.stage.name}; these keys only apply to actor stages."
+            )
+
+        map_batches_kwargs: dict[str, object] = {}
+        if per_node_pool_size is not None:
+            map_batches_kwargs["compute"] = TaskPoolStrategy(size=per_node_pool_size)
+        elif num_workers is not None and num_workers > 0:
+            map_batches_kwargs["compute"] = TaskPoolStrategy(size=num_workers)
+
+        max_calls = ray_stage_spec.get(RayStageSpecKeys.MAX_CALLS_PER_WORKER)
+        if max_calls is not None:
+            map_batches_kwargs["max_calls"] = max_calls
+        return map_batches_kwargs
+
     def process_dataset(self, dataset: Dataset) -> Dataset:
         """Process a Ray Data dataset through this stage.
 
@@ -101,28 +161,15 @@ class RayDataStageAdapter(BaseStageAdapter):
         """
         ray_stage_spec = self.stage.ray_stage_spec()
         stage_is_actor = ray_stage_spec.get(RayStageSpecKeys.IS_ACTOR_STAGE, is_actor_stage(self.stage))
+        num_workers = self.stage.num_workers()
+        per_node_pool_size = self._get_per_node_pool_size(ray_stage_spec, num_workers)
 
         if stage_is_actor:
-            map_batches_fn = create_actor_from_stage(self.stage)
-            map_batches_kwargs = {"compute": get_actor_compute_strategy_for_stage(self.stage)}
+            map_batches_fn = create_actor_from_stage(self.stage, ignore_head_node=self.ignore_head_node)
+            map_batches_kwargs = self._build_actor_compute_kwargs(per_node_pool_size)
         else:
-            map_batches_fn = create_task_from_stage(self.stage)
-            map_batches_kwargs = {}
-
-            actor_pool_sizing_keys = get_configured_actor_pool_sizing_keys(ray_stage_spec)
-            if actor_pool_sizing_keys:
-                logger.warning(
-                    f"Ignoring ray_stage_spec worker sizing keys {actor_pool_sizing_keys} "
-                    f"for Ray Data task stage {self.stage.name}; these keys only apply to actor stages."
-                )
-
-            num_workers = self.stage.num_workers()
-            if num_workers is not None and num_workers > 0:
-                map_batches_kwargs["compute"] = TaskPoolStrategy(size=num_workers)
-
-            max_calls = ray_stage_spec.get(RayStageSpecKeys.MAX_CALLS_PER_WORKER)
-            if max_calls is not None:
-                map_batches_kwargs["max_calls"] = max_calls
+            map_batches_fn = create_task_from_stage(self.stage, ignore_head_node=self.ignore_head_node)
+            map_batches_kwargs = self._build_task_compute_kwargs(ray_stage_spec, per_node_pool_size, num_workers)
 
         map_batches_kwargs.update(self._build_resource_kwargs(ray_stage_spec))
 
@@ -141,6 +188,9 @@ class RayDataStageAdapter(BaseStageAdapter):
             )
             raise ValueError(msg)
 
+        if per_node_pool_size is not None:
+            map_batches_kwargs.setdefault("scheduling_strategy", "SPREAD")
+
         map_batches_kwargs.update(ray_remote_args)
 
         # Let Ray Data apply the selected compute strategy and resource requirements.
@@ -154,7 +204,7 @@ class RayDataStageAdapter(BaseStageAdapter):
         return processed_dataset
 
 
-def create_actor_from_stage(stage: ProcessingStage) -> type[RayDataStageAdapter]:
+def create_actor_from_stage(stage: ProcessingStage, ignore_head_node: bool = False) -> type[RayDataStageAdapter]:
     """Create a StageProcessor class with the proper stage name for display."""
 
     class RayDataStageActorAdapter(RayDataStageAdapter):
@@ -162,7 +212,7 @@ def create_actor_from_stage(stage: ProcessingStage) -> type[RayDataStageAdapter]
 
         def __init__(self):
             """Initialize the stage processor."""
-            super().__init__(stage)
+            super().__init__(stage, ignore_head_node=ignore_head_node)
             self.setup_done = False
             node_info, worker_metadata = get_worker_metadata_and_node_id()
             self.setup_on_node(node_info, worker_metadata)
@@ -179,7 +229,9 @@ def create_actor_from_stage(stage: ProcessingStage) -> type[RayDataStageAdapter]
     return RayDataStageActorAdapter
 
 
-def create_task_from_stage(stage: ProcessingStage) -> Callable[[dict[str, Any]], dict[str, Any]]:
+def create_task_from_stage(
+    stage: ProcessingStage, ignore_head_node: bool = False
+) -> Callable[[dict[str, Any]], dict[str, Any]]:
     """Create a named Ray Data stage adapter function.
 
     This creates a standalone function that wraps the stage processing logic
@@ -192,7 +244,7 @@ def create_task_from_stage(stage: ProcessingStage) -> Callable[[dict[str, Any]],
         Callable: A function that can be used directly with Ray Data's map_batches
     """
     # Create the adapter instance
-    adapter = RayDataStageAdapter(stage)
+    adapter = RayDataStageAdapter(stage, ignore_head_node=ignore_head_node)
 
     # Create a standalone function that wraps the adapter's processing logic
     def stage_map_fn(batch: dict[str, Any]) -> dict[str, Any]:

--- a/nemo_curator/backends/ray_data/adapter.py
+++ b/nemo_curator/backends/ray_data/adapter.py
@@ -97,49 +97,41 @@ class RayDataStageAdapter(BaseStageAdapter):
             kwargs["num_gpus"] = self.stage.resources.gpus  # type: ignore[reportArgumentType]
         return kwargs
 
-    def _get_per_node_pool_size(self, ray_stage_spec: dict, num_workers: int | None) -> int | None:
+    def _per_node_pool_size(self) -> int | None:
+        """Actor/task pool size derived from ``num_workers_per_node()``, or None if unset.
+
+        Mutual exclusion with ``num_workers()`` and actor-pool sizing keys is enforced at
+        stage construction (``ProcessingStage._validate_worker_sizing``).
+        """
         num_workers_per_node = get_stage_num_workers_per_node(self.stage)
         if num_workers_per_node is None:
             return None
-
-        if num_workers is not None:
-            msg = (
-                f"Stage {self.stage.name} defines both num_workers()={num_workers} and "
-                f"num_workers_per_node()={num_workers_per_node}. "
-                "Use only one worker sizing option."
-            )
-            raise ValueError(msg)
-
-        actor_pool_sizing_keys = get_configured_actor_pool_sizing_keys(ray_stage_spec)
-        if actor_pool_sizing_keys:
-            msg = (
-                f"Stage {self.stage.name} defines num_workers_per_node() "
-                f"and actor-pool sizing keys {actor_pool_sizing_keys}. Use only one worker sizing option."
-            )
-            raise ValueError(msg)
-
         node_count = get_alive_ray_node_count(ignore_head_node=self.ignore_head_node)
         if node_count <= 0:
             msg = f"No alive Ray nodes available for num_workers_per_node sizing on stage {self.stage.name}."
             raise ValueError(msg)
         return max(1, math.ceil(num_workers_per_node * node_count))
 
-    def _build_actor_compute_kwargs(self, per_node_pool_size: int | None) -> dict[str, object]:
-        if per_node_pool_size is not None:
-            return {"compute": ActorPoolStrategy(size=per_node_pool_size)}
-        return {"compute": get_actor_compute_strategy_for_stage(self.stage)}
+    def _compute_kwargs(self, ray_stage_spec: dict, stage_is_actor: bool, per_node_pool_size: int | None) -> dict:
+        """Select the Ray Data compute strategy (actor pool vs task pool) and its sizing."""
+        if stage_is_actor:
+            compute = (
+                ActorPoolStrategy(size=per_node_pool_size)
+                if per_node_pool_size is not None
+                else get_actor_compute_strategy_for_stage(self.stage)
+            )
+            return {"compute": compute}
 
-    def _build_task_compute_kwargs(
-        self, ray_stage_spec: dict, per_node_pool_size: int | None, num_workers: int | None
-    ) -> dict[str, object]:
-        actor_pool_sizing_keys = get_configured_actor_pool_sizing_keys(ray_stage_spec)
-        if actor_pool_sizing_keys:
+        # Task stages: actor-pool sizing keys don't apply, so surface them if present.
+        sizing_keys = get_configured_actor_pool_sizing_keys(ray_stage_spec)
+        if sizing_keys:
             logger.warning(
-                f"Ignoring ray_stage_spec worker sizing keys {actor_pool_sizing_keys} "
+                f"Ignoring ray_stage_spec worker sizing keys {sizing_keys} "
                 f"for Ray Data task stage {self.stage.name}; these keys only apply to actor stages."
             )
 
         map_batches_kwargs: dict[str, object] = {}
+        num_workers = self.stage.num_workers()
         if per_node_pool_size is not None:
             map_batches_kwargs["compute"] = TaskPoolStrategy(size=per_node_pool_size)
         elif num_workers is not None and num_workers > 0:
@@ -161,15 +153,11 @@ class RayDataStageAdapter(BaseStageAdapter):
         """
         ray_stage_spec = self.stage.ray_stage_spec()
         stage_is_actor = ray_stage_spec.get(RayStageSpecKeys.IS_ACTOR_STAGE, is_actor_stage(self.stage))
-        num_workers = self.stage.num_workers()
-        per_node_pool_size = self._get_per_node_pool_size(ray_stage_spec, num_workers)
+        per_node_pool_size = self._per_node_pool_size()
 
-        if stage_is_actor:
-            map_batches_fn = create_actor_from_stage(self.stage, ignore_head_node=self.ignore_head_node)
-            map_batches_kwargs = self._build_actor_compute_kwargs(per_node_pool_size)
-        else:
-            map_batches_fn = create_task_from_stage(self.stage, ignore_head_node=self.ignore_head_node)
-            map_batches_kwargs = self._build_task_compute_kwargs(ray_stage_spec, per_node_pool_size, num_workers)
+        stage_factory = create_actor_from_stage if stage_is_actor else create_task_from_stage
+        map_batches_fn = stage_factory(self.stage, ignore_head_node=self.ignore_head_node)
+        map_batches_kwargs = self._compute_kwargs(ray_stage_spec, stage_is_actor, per_node_pool_size)
 
         map_batches_kwargs.update(self._build_resource_kwargs(ray_stage_spec))
 

--- a/nemo_curator/backends/ray_data/adapter.py
+++ b/nemo_curator/backends/ray_data/adapter.py
@@ -80,11 +80,14 @@ class RayDataStageAdapter(BaseStageAdapter):
         # For Task objects, we return them in the 'item' column
         return {"item": results}
 
-    def _per_node_pool_size(self) -> int | None:
-        """Actor/task pool size derived from ``num_workers_per_node()``, or None if unset.
+    def _total_pool_size(self) -> int | None:
+        """Total (cluster-wide) pool size implied by ``num_workers_per_node()``, or None if unset.
 
-        Mutual exclusion with ``num_workers()`` and actor-pool sizing keys is enforced at
-        stage construction (``ProcessingStage._validate_worker_sizing``).
+        A Ray Data pool ``size`` is the total replica count, so we scale the per-node request by
+        the node count (``num_workers_per_node * num_nodes``) and pair it with SPREAD scheduling
+        in ``process_dataset`` to land ~``num_workers_per_node`` replicas on each node. Mutual
+        exclusion with ``num_workers()`` and actor-pool sizing keys is enforced at stage
+        construction (``ProcessingStage._validate_worker_sizing``).
         """
         num_workers_per_node = get_stage_num_workers_per_node(self.stage)
         if num_workers_per_node is None:
@@ -96,7 +99,7 @@ class RayDataStageAdapter(BaseStageAdapter):
         return max(1, math.ceil(num_workers_per_node * node_count))
 
     def _managed_map_batches_kwargs(
-        self, ray_stage_spec: dict, stage_is_actor: bool, per_node_pool_size: int | None
+        self, ray_stage_spec: dict, stage_is_actor: bool, total_pool_size: int | None
     ) -> dict:
         """Build the Curator-managed map_batches kwargs: compute strategy plus CPU/GPU reservations.
 
@@ -109,14 +112,14 @@ class RayDataStageAdapter(BaseStageAdapter):
 
         if stage_is_actor:
             kwargs["compute"] = (
-                ActorPoolStrategy(size=per_node_pool_size)
-                if per_node_pool_size is not None
+                ActorPoolStrategy(size=total_pool_size)
+                if total_pool_size is not None
                 else get_actor_compute_strategy_for_stage(self.stage)
             )
         else:
             num_workers = self.stage.num_workers()
-            if per_node_pool_size is not None:
-                kwargs["compute"] = TaskPoolStrategy(size=per_node_pool_size)
+            if total_pool_size is not None:
+                kwargs["compute"] = TaskPoolStrategy(size=total_pool_size)
             elif num_workers is not None and num_workers > 0:
                 kwargs["compute"] = TaskPoolStrategy(size=num_workers)
 
@@ -152,11 +155,11 @@ class RayDataStageAdapter(BaseStageAdapter):
         """
         ray_stage_spec = self.stage.ray_stage_spec()
         stage_is_actor = ray_stage_spec.get(RayStageSpecKeys.IS_ACTOR_STAGE, is_actor_stage(self.stage))
-        per_node_pool_size = self._per_node_pool_size()
+        total_pool_size = self._total_pool_size()
 
         stage_factory = create_actor_from_stage if stage_is_actor else create_task_from_stage
         map_batches_fn = stage_factory(self.stage, ignore_head_node=self.ignore_head_node)
-        map_batches_kwargs = self._managed_map_batches_kwargs(ray_stage_spec, stage_is_actor, per_node_pool_size)
+        map_batches_kwargs = self._managed_map_batches_kwargs(ray_stage_spec, stage_is_actor, total_pool_size)
 
         # Per-stage ray_remote_args (e.g. runtime_env with different pip versions per stage).
         ray_remote_args = copy.deepcopy(ray_stage_spec.get(RayStageSpecKeys.RAY_REMOTE_ARGS) or {})
@@ -173,7 +176,8 @@ class RayDataStageAdapter(BaseStageAdapter):
             )
             raise ValueError(msg)
 
-        if per_node_pool_size is not None:
+        # When sizing by num_workers_per_node, SPREAD spreads the total pool evenly across nodes.
+        if total_pool_size is not None:
             map_batches_kwargs.setdefault("scheduling_strategy", "SPREAD")
 
         map_batches_kwargs.update(ray_remote_args)

--- a/nemo_curator/backends/ray_data/adapter.py
+++ b/nemo_curator/backends/ray_data/adapter.py
@@ -80,23 +80,6 @@ class RayDataStageAdapter(BaseStageAdapter):
         # For Task objects, we return them in the 'item' column
         return {"item": results}
 
-    def _build_resource_kwargs(self, ray_stage_spec: dict) -> dict[str, float]:
-        """Build num_cpus/num_gpus kwargs for map_batches.
-
-        Checks ray_stage_spec for RAY_NUM_CPUS first so stages can request a
-        different CPU reservation for Ray Data (e.g. cpus=1.0 to enable stage
-        fusion) without changing resources.cpus used by other executors.
-        """
-        kwargs: dict[str, float] = {}
-        ray_num_cpus = ray_stage_spec.get(RayStageSpecKeys.RAY_NUM_CPUS)
-        if ray_num_cpus is not None:
-            kwargs["num_cpus"] = ray_num_cpus  # type: ignore[reportArgumentType]
-        elif self.stage.resources.cpus > 0:
-            kwargs["num_cpus"] = self.stage.resources.cpus  # type: ignore[reportArgumentType]
-        if self.stage.resources.gpus > 0:
-            kwargs["num_gpus"] = self.stage.resources.gpus  # type: ignore[reportArgumentType]
-        return kwargs
-
     def _per_node_pool_size(self) -> int | None:
         """Actor/task pool size derived from ``num_workers_per_node()``, or None if unset.
 
@@ -112,35 +95,51 @@ class RayDataStageAdapter(BaseStageAdapter):
             raise ValueError(msg)
         return max(1, math.ceil(num_workers_per_node * node_count))
 
-    def _compute_kwargs(self, ray_stage_spec: dict, stage_is_actor: bool, per_node_pool_size: int | None) -> dict:
-        """Select the Ray Data compute strategy (actor pool vs task pool) and its sizing."""
+    def _managed_map_batches_kwargs(
+        self, ray_stage_spec: dict, stage_is_actor: bool, per_node_pool_size: int | None
+    ) -> dict:
+        """Build the Curator-managed map_batches kwargs: compute strategy plus CPU/GPU reservations.
+
+        Actor stages always use an actor pool; task stages use a task pool only when sized
+        explicitly (per-node or num_workers), otherwise Ray Data's default. ``RAY_NUM_CPUS``
+        in ``ray_stage_spec`` overrides ``resources.cpus`` for Ray Data only (e.g. cpus=1.0 to
+        enable stage fusion) without affecting other executors.
+        """
+        kwargs: dict[str, object] = {}
+
         if stage_is_actor:
-            compute = (
+            kwargs["compute"] = (
                 ActorPoolStrategy(size=per_node_pool_size)
                 if per_node_pool_size is not None
                 else get_actor_compute_strategy_for_stage(self.stage)
             )
-            return {"compute": compute}
+        else:
+            num_workers = self.stage.num_workers()
+            if per_node_pool_size is not None:
+                kwargs["compute"] = TaskPoolStrategy(size=per_node_pool_size)
+            elif num_workers is not None and num_workers > 0:
+                kwargs["compute"] = TaskPoolStrategy(size=num_workers)
 
-        # Task stages: actor-pool sizing keys don't apply, so surface them if present.
-        sizing_keys = get_configured_actor_pool_sizing_keys(ray_stage_spec)
-        if sizing_keys:
-            logger.warning(
-                f"Ignoring ray_stage_spec worker sizing keys {sizing_keys} "
-                f"for Ray Data task stage {self.stage.name}; these keys only apply to actor stages."
-            )
+            # Actor-pool sizing keys don't apply to task stages, so surface them if present.
+            sizing_keys = get_configured_actor_pool_sizing_keys(ray_stage_spec)
+            if sizing_keys:
+                logger.warning(
+                    f"Ignoring ray_stage_spec worker sizing keys {sizing_keys} "
+                    f"for Ray Data task stage {self.stage.name}; these keys only apply to actor stages."
+                )
+            max_calls = ray_stage_spec.get(RayStageSpecKeys.MAX_CALLS_PER_WORKER)
+            if max_calls is not None:
+                kwargs["max_calls"] = max_calls
 
-        map_batches_kwargs: dict[str, object] = {}
-        num_workers = self.stage.num_workers()
-        if per_node_pool_size is not None:
-            map_batches_kwargs["compute"] = TaskPoolStrategy(size=per_node_pool_size)
-        elif num_workers is not None and num_workers > 0:
-            map_batches_kwargs["compute"] = TaskPoolStrategy(size=num_workers)
+        ray_num_cpus = ray_stage_spec.get(RayStageSpecKeys.RAY_NUM_CPUS)
+        if ray_num_cpus is not None:
+            kwargs["num_cpus"] = ray_num_cpus
+        elif self.stage.resources.cpus > 0:
+            kwargs["num_cpus"] = self.stage.resources.cpus
+        if self.stage.resources.gpus > 0:
+            kwargs["num_gpus"] = self.stage.resources.gpus
 
-        max_calls = ray_stage_spec.get(RayStageSpecKeys.MAX_CALLS_PER_WORKER)
-        if max_calls is not None:
-            map_batches_kwargs["max_calls"] = max_calls
-        return map_batches_kwargs
+        return kwargs
 
     def process_dataset(self, dataset: Dataset) -> Dataset:
         """Process a Ray Data dataset through this stage.
@@ -157,9 +156,7 @@ class RayDataStageAdapter(BaseStageAdapter):
 
         stage_factory = create_actor_from_stage if stage_is_actor else create_task_from_stage
         map_batches_fn = stage_factory(self.stage, ignore_head_node=self.ignore_head_node)
-        map_batches_kwargs = self._compute_kwargs(ray_stage_spec, stage_is_actor, per_node_pool_size)
-
-        map_batches_kwargs.update(self._build_resource_kwargs(ray_stage_spec))
+        map_batches_kwargs = self._managed_map_batches_kwargs(ray_stage_spec, stage_is_actor, per_node_pool_size)
 
         # Per-stage ray_remote_args (e.g. runtime_env with different pip versions per stage).
         ray_remote_args = copy.deepcopy(ray_stage_spec.get(RayStageSpecKeys.RAY_REMOTE_ARGS) or {})

--- a/nemo_curator/backends/ray_data/executor.py
+++ b/nemo_curator/backends/ray_data/executor.py
@@ -93,7 +93,7 @@ class RayDataExecutor(BaseExecutor):
                 logger.info(f"  CPU cores: {stage.resources.cpus}, GPU ratio: {stage.resources.gpus}")
 
                 # Create adapter for this stage
-                adapter = RayDataStageAdapter(stage)
+                adapter = RayDataStageAdapter(stage, ignore_head_node=self.ignore_head_node)
 
                 # Apply stage transformation
                 current_dataset = adapter.process_dataset(current_dataset)

--- a/nemo_curator/backends/ray_data/utils.py
+++ b/nemo_curator/backends/ray_data/utils.py
@@ -14,7 +14,6 @@
 
 from collections.abc import Mapping
 
-from loguru import logger
 from ray.data import ActorPoolStrategy
 
 from nemo_curator.backends.utils import RayStageSpecKeys
@@ -42,12 +41,6 @@ def get_actor_compute_strategy_for_stage(stage: ProcessingStage) -> ActorPoolStr
     """
     num_workers = stage.num_workers()
     if num_workers is not None and num_workers > 0:
-        actor_pool_sizing_keys = get_configured_actor_pool_sizing_keys(stage.ray_stage_spec())
-        if actor_pool_sizing_keys:
-            logger.warning(
-                f"Stage {stage.name} uses num_workers={num_workers}; ignoring ray_stage_spec "
-                f"actor-pool sizing keys {actor_pool_sizing_keys}."
-            )
         return ActorPoolStrategy(size=num_workers)
 
     ray_stage_spec = stage.ray_stage_spec()

--- a/nemo_curator/backends/utils.py
+++ b/nemo_curator/backends/utils.py
@@ -16,14 +16,14 @@ import os
 import time
 from copy import deepcopy
 from enum import Enum
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import ray
 from loguru import logger
 
 from nemo_curator.backends.base import NodeInfo, WorkerMetadata
 from nemo_curator.stages.base import ProcessingStage
-from nemo_curator.utils.ray_utils import get_head_node_id, submit_on_each_node
+from nemo_curator.utils.ray_utils import get_alive_ray_nodes, get_head_node_id, submit_on_each_node
 
 if TYPE_CHECKING:
     import loguru
@@ -137,6 +137,26 @@ class RayStageSpecKeys(str, Enum):
     RAY_NUM_CPUS = "ray_num_cpus"
 
 
+def get_stage_num_workers_per_node(stage: ProcessingStage) -> int | float | None:
+    """Return a stage's generic per-node worker request.
+
+    Prefer ``ProcessingStage.num_workers_per_node()``. For older stages that still expose
+    a plain ``num_workers_per_node`` field, accept the field value so backend sizing stays
+    compatible while stages migrate to the method form.
+    """
+    value_or_method: Any = getattr(stage, "num_workers_per_node", None)
+    value = value_or_method() if callable(value_or_method) else value_or_method
+    if value is None:
+        return None
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        msg = f"num_workers_per_node() for stage {stage.name} must be a positive number."
+        raise TypeError(msg)
+    if value <= 0:
+        msg = f"num_workers_per_node() for stage {stage.name} must be > 0."
+        raise ValueError(msg)
+    return value
+
+
 def get_worker_metadata_and_node_id() -> tuple[NodeInfo, WorkerMetadata]:
     """Get the worker metadata and node id from the runtime context."""
     ray_context = ray.get_runtime_context()
@@ -212,13 +232,8 @@ def execute_setup_on_node(stages: list[ProcessingStage], ignore_head_node: bool 
     the sum of per-stage times — important when setup is heavy (model downloads, weight
     loads) and stages don't contend for the same resources.
     """
-    head_node_id = get_head_node_id() if ignore_head_node else None
-    for node in ray.nodes():
-        if not node.get("Alive"):
-            continue
+    for node in get_alive_ray_nodes(ignore_head_node=ignore_head_node):
         node_id = node["NodeID"]
-        if ignore_head_node and node_id == head_node_id:
-            continue
         logger.info(f"Executing setup on node {node_id} for {len(stages)} stages")
 
     refs: list = []

--- a/nemo_curator/backends/utils.py
+++ b/nemo_curator/backends/utils.py
@@ -16,7 +16,7 @@ import os
 import time
 from copy import deepcopy
 from enum import Enum
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 import ray
 from loguru import logger
@@ -138,14 +138,8 @@ class RayStageSpecKeys(str, Enum):
 
 
 def get_stage_num_workers_per_node(stage: ProcessingStage) -> int | float | None:
-    """Return a stage's generic per-node worker request.
-
-    Prefer ``ProcessingStage.num_workers_per_node()``. For older stages that still expose
-    a plain ``num_workers_per_node`` field, accept the field value so backend sizing stays
-    compatible while stages migrate to the method form.
-    """
-    value_or_method: Any = getattr(stage, "num_workers_per_node", None)
-    value = value_or_method() if callable(value_or_method) else value_or_method
+    """Return a stage's validated per-node worker request from ``num_workers_per_node()``."""
+    value = stage.num_workers_per_node()
     if value is None:
         return None
     if isinstance(value, bool) or not isinstance(value, (int, float)):

--- a/nemo_curator/backends/xenna/executor.py
+++ b/nemo_curator/backends/xenna/executor.py
@@ -20,7 +20,7 @@ from cosmos_xenna.utils.verbosity import VerbosityLevel
 from loguru import logger
 
 from nemo_curator.backends.base import BaseExecutor
-from nemo_curator.backends.utils import register_loguru_serializer
+from nemo_curator.backends.utils import get_stage_num_workers_per_node, register_loguru_serializer
 from nemo_curator.backends.xenna.adapter import create_named_xenna_stage_adapter
 from nemo_curator.stages.base import ProcessingStage
 from nemo_curator.tasks import EmptyTask, Task
@@ -83,11 +83,21 @@ class XennaExecutor(BaseExecutor):
                 raise ValueError(msg)
 
             num_workers = stage.num_workers()
-            num_workers_per_node = stage_config.get("num_workers_per_node")
+            stage_num_workers_per_node = get_stage_num_workers_per_node(stage)
+            spec_num_workers_per_node = stage_config.get("num_workers_per_node")
+            if stage_num_workers_per_node is not None and spec_num_workers_per_node is not None:
+                msg = (
+                    f"Stage {stage.name} sets both num_workers_per_node() and "
+                    "xenna_stage_spec()['num_workers_per_node']. Use only one worker sizing option."
+                )
+                raise ValueError(msg)
+            num_workers_per_node = (
+                stage_num_workers_per_node if stage_num_workers_per_node is not None else spec_num_workers_per_node
+            )
             if num_workers is not None and num_workers_per_node is not None:
                 msg = (
                     f"Stage {stage.name} sets both num_workers() and "
-                    "xenna_stage_spec()['num_workers_per_node']. Use only one worker sizing option."
+                    "num_workers_per_node(). Use only one worker sizing option."
                 )
                 raise ValueError(msg)
 

--- a/nemo_curator/backends/xenna/executor.py
+++ b/nemo_curator/backends/xenna/executor.py
@@ -78,28 +78,15 @@ class XennaExecutor(BaseExecutor):
         for stage in stages:
             # Get stage configuration
             stage_config = stage.xenna_stage_spec()
-            if "num_workers" in stage_config:
-                msg = f"Stage {stage.name} sets num_workers in xenna_stage_spec(). Use num_workers() instead."
-                raise ValueError(msg)
+            for reserved in ("num_workers", "num_workers_per_node"):
+                if reserved in stage_config:
+                    msg = f"Stage {stage.name} sets {reserved} in xenna_stage_spec(). Use {reserved}() instead."
+                    raise ValueError(msg)
 
+            # Mutual exclusion of num_workers() vs num_workers_per_node() is enforced at
+            # stage construction (ProcessingStage._validate_worker_sizing).
             num_workers = stage.num_workers()
-            stage_num_workers_per_node = get_stage_num_workers_per_node(stage)
-            spec_num_workers_per_node = stage_config.get("num_workers_per_node")
-            if stage_num_workers_per_node is not None and spec_num_workers_per_node is not None:
-                msg = (
-                    f"Stage {stage.name} sets both num_workers_per_node() and "
-                    "xenna_stage_spec()['num_workers_per_node']. Use only one worker sizing option."
-                )
-                raise ValueError(msg)
-            num_workers_per_node = (
-                stage_num_workers_per_node if stage_num_workers_per_node is not None else spec_num_workers_per_node
-            )
-            if num_workers is not None and num_workers_per_node is not None:
-                msg = (
-                    f"Stage {stage.name} sets both num_workers() and "
-                    "num_workers_per_node(). Use only one worker sizing option."
-                )
-                raise ValueError(msg)
+            num_workers_per_node = get_stage_num_workers_per_node(stage)
 
             # Create Xenna stage adapter with the original stage's name
             xenna_stage = create_named_xenna_stage_adapter(

--- a/nemo_curator/stages/base.py
+++ b/nemo_curator/stages/base.py
@@ -65,29 +65,6 @@ def _num_workers_per_node_method(num_workers_per_node: float | None) -> Callable
     return get_num_workers_per_node
 
 
-def _get_num_workers_per_node_value(stage: ProcessingStage) -> float | None:
-    value_or_method = stage.num_workers_per_node
-    return value_or_method() if callable(value_or_method) else value_or_method
-
-
-def _set_num_workers_per_node_override(stage: ProcessingStage, num_workers_per_node: float | None) -> None:
-    if callable(stage.num_workers_per_node):
-        stage.num_workers_per_node = _num_workers_per_node_method(num_workers_per_node)
-    else:
-        stage.num_workers_per_node = num_workers_per_node
-
-
-def _check_worker_sizing_options(stage: ProcessingStage) -> None:
-    effective_num_workers = stage.num_workers()
-    effective_num_workers_per_node = _get_num_workers_per_node_value(stage)
-    if effective_num_workers is not None and effective_num_workers_per_node is not None:
-        msg = (
-            "Use only one worker sizing option: num_workers or num_workers_per_node. "
-            "Set one of them to None before configuring the other."
-        )
-        raise ValueError(msg)
-
-
 class StageMeta(ABCMeta):
     """Metaclass that automatically registers concrete Stage subclasses.
     A class is considered *concrete* if it directly inherits from
@@ -110,6 +87,12 @@ class StageMeta(ABCMeta):
             _STAGE_REGISTRY[cls.__name__] = cls  # type: ignore[assignment]
 
         return cls
+
+    def __call__(cls, *args, **kwargs):
+        """Validate worker sizing once every stage instance is fully constructed."""
+        instance = super().__call__(*args, **kwargs)
+        instance._validate_worker_sizing()
+        return instance
 
 
 def get_stage_class(name: str) -> type[ProcessingStage]:
@@ -179,16 +162,17 @@ class ProcessingStage(ABC, Generic[X, Y], metaclass=StageMeta):
                 msg = f"{cls.__name__} must not override '{attr}'"
                 raise TypeError(msg)
 
-        num_workers = cls.__dict__.get("num_workers")
-        if (num_workers is not None and not callable(num_workers)) or (
-            num_workers is None and "num_workers" in cls.__dict__.get("__annotations__", {})
-        ):
-            msg = (
-                f"{cls.__name__} must not define 'num_workers' as a stage attribute. "
-                "Override num_workers() for backend worker sizing, or use a different field name "
-                "for stage-specific worker counts."
-            )
-            raise TypeError(msg)
+        for worker_attr in ("num_workers", "num_workers_per_node"):
+            value = cls.__dict__.get(worker_attr)
+            if (value is not None and not callable(value)) or (
+                value is None and worker_attr in cls.__dict__.get("__annotations__", {})
+            ):
+                msg = (
+                    f"{cls.__name__} must not define '{worker_attr}' as a stage attribute. "
+                    f"Override {worker_attr}() for backend worker sizing, or use a different field name "
+                    "for stage-specific worker counts."
+                )
+                raise TypeError(msg)
 
         for attr in ("name", "resources", "batch_size", "runtime_env"):
             if isinstance(cls.__dict__.get(attr), property):
@@ -206,6 +190,38 @@ class ProcessingStage(ABC, Generic[X, Y], metaclass=StageMeta):
     def num_workers_per_node(self) -> float | None:
         """Number of workers required per Ray node. If None, executor default sizing is used."""
         return None
+
+    def _validate_worker_sizing(self) -> None:
+        """Enforce that at most one worker-sizing mechanism is configured.
+
+        A stage may size its worker pool with exactly one of ``num_workers()``,
+        ``num_workers_per_node()``, or the Ray Data actor-pool sizing keys
+        (``min_workers``/``max_workers``/``initial_workers``) in ``ray_stage_spec()``.
+        Combining them is ambiguous, so we reject it once here — at construction and in
+        ``with_()`` — rather than defensively re-checking in every backend.
+        """
+        configured = [
+            name
+            for name, value in (
+                ("num_workers()", self.num_workers()),
+                ("num_workers_per_node()", self.num_workers_per_node()),
+            )
+            if value is not None
+        ]
+        ray_stage_spec = self.ray_stage_spec()
+        if ray_stage_spec:
+            # Lazy import: only stages that populate ray_stage_spec touch the Ray Data backend.
+            from nemo_curator.backends.ray_data.utils import get_configured_actor_pool_sizing_keys
+
+            if get_configured_actor_pool_sizing_keys(ray_stage_spec):
+                configured.append("actor-pool sizing keys (min/max/initial_workers)")
+
+        if len(configured) > 1:
+            msg = (
+                f"Stage {self.name} sets multiple worker-sizing options ({', '.join(configured)}); "
+                "use only one of num_workers, num_workers_per_node, or actor-pool sizing keys."
+            )
+            raise ValueError(msg)
 
     def validate_input(self, task: Task) -> bool:
         """Validate input task meets requirements.
@@ -408,9 +424,11 @@ class ProcessingStage(ABC, Generic[X, Y], metaclass=StageMeta):
         if num_workers is not _UNSET:
             new_instance.num_workers = _num_workers_method(cast("int | None", num_workers))
         if num_workers_per_node is not _UNSET:
-            _set_num_workers_per_node_override(new_instance, cast("float | None", num_workers_per_node))
+            new_instance.num_workers_per_node = _num_workers_per_node_method(
+                cast("float | None", num_workers_per_node)
+            )
 
-        _check_worker_sizing_options(new_instance)
+        new_instance._validate_worker_sizing()
 
         return new_instance
 

--- a/nemo_curator/stages/base.py
+++ b/nemo_curator/stages/base.py
@@ -58,6 +58,36 @@ def _num_workers_method(num_workers: int | None) -> Callable[[], int | None]:
     return get_num_workers
 
 
+def _num_workers_per_node_method(num_workers_per_node: float | None) -> Callable[[], float | None]:
+    def get_num_workers_per_node() -> float | None:
+        return num_workers_per_node
+
+    return get_num_workers_per_node
+
+
+def _get_num_workers_per_node_value(stage: ProcessingStage) -> float | None:
+    value_or_method = stage.num_workers_per_node
+    return value_or_method() if callable(value_or_method) else value_or_method
+
+
+def _set_num_workers_per_node_override(stage: ProcessingStage, num_workers_per_node: float | None) -> None:
+    if callable(stage.num_workers_per_node):
+        stage.num_workers_per_node = _num_workers_per_node_method(num_workers_per_node)
+    else:
+        stage.num_workers_per_node = num_workers_per_node
+
+
+def _check_worker_sizing_options(stage: ProcessingStage) -> None:
+    effective_num_workers = stage.num_workers()
+    effective_num_workers_per_node = _get_num_workers_per_node_value(stage)
+    if effective_num_workers is not None and effective_num_workers_per_node is not None:
+        msg = (
+            "Use only one worker sizing option: num_workers or num_workers_per_node. "
+            "Set one of them to None before configuring the other."
+        )
+        raise ValueError(msg)
+
+
 class StageMeta(ABCMeta):
     """Metaclass that automatically registers concrete Stage subclasses.
     A class is considered *concrete* if it directly inherits from
@@ -171,6 +201,10 @@ class ProcessingStage(ABC, Generic[X, Y], metaclass=StageMeta):
 
     def num_workers(self) -> int | None:
         """Number of workers required. If None, then executor will determine the number of workers."""
+        return None
+
+    def num_workers_per_node(self) -> float | None:
+        """Number of workers required per Ray node. If None, executor default sizing is used."""
         return None
 
     def validate_input(self, task: Task) -> bool:
@@ -321,6 +355,7 @@ class ProcessingStage(ABC, Generic[X, Y], metaclass=StageMeta):
         ray_stage_spec: dict[str, Any] | None = None,
         xenna_stage_spec: dict[str, Any] | None = None,
         num_workers: int | None | _UnsetType = _UNSET,
+        num_workers_per_node: float | None | _UnsetType = _UNSET,
     ) -> ProcessingStage:
         """Apply configuration changes to this stage with overridden properties.
 
@@ -335,6 +370,8 @@ class ProcessingStage(ABC, Generic[X, Y], metaclass=StageMeta):
             xenna_stage_spec: Merge overrides into the Xenna stage spec. User-provided keys win.
                 Use num_workers instead of setting num_workers in xenna_stage_spec.
             num_workers: Override the num_workers() result. Passing None explicitly resets to executor default behavior.
+            num_workers_per_node: Override the num_workers_per_node() result. Passing None explicitly resets to
+                executor default behavior.
         """
         new_instance = copy.deepcopy(self)
 
@@ -370,6 +407,10 @@ class ProcessingStage(ABC, Generic[X, Y], metaclass=StageMeta):
 
         if num_workers is not _UNSET:
             new_instance.num_workers = _num_workers_method(cast("int | None", num_workers))
+        if num_workers_per_node is not _UNSET:
+            _set_num_workers_per_node_override(new_instance, cast("float | None", num_workers_per_node))
+
+        _check_worker_sizing_options(new_instance)
 
         return new_instance
 

--- a/nemo_curator/stages/image/deduplication/removal.py
+++ b/nemo_curator/stages/image/deduplication/removal.py
@@ -14,7 +14,6 @@
 
 import os
 from dataclasses import dataclass, field
-from typing import Any
 
 import pyarrow as pa
 import pyarrow.dataset as ds
@@ -36,15 +35,14 @@ class ImageDuplicatesRemovalStage(ProcessingStage[ImageBatch, ImageBatch]):
         removal_parquets_dir: Directory containing Parquet files with image IDs to remove
         duplicate_id_field: Name of the column containing image IDs to remove
         verbose: Whether to log verbose output
-        num_workers_per_node: Number of workers per node for the stage. This is sometimes needed
-            to avoid OOM when concurrently running actors on one node loading the same removal
-            parquet files into memory.
+
+    To cap concurrent actors per node (e.g. to avoid OOM when each actor loads the same
+    removal parquet files into memory), configure ``.with_(num_workers_per_node=...)``.
     """
 
     removal_parquets_dir: str
     duplicate_id_field: str = "id"
     verbose: bool = False
-    num_workers_per_node: int | None = None
 
     name: str = "image_dedup_filter"
 
@@ -96,9 +94,3 @@ class ImageDuplicatesRemovalStage(ProcessingStage[ImageBatch, ImageBatch]):
             _metadata=task._metadata,
             _stage_perf=task._stage_perf,
         )
-
-    def xenna_stage_spec(self) -> dict[str, Any]:
-        spec: dict[str, Any] = {}
-        if self.num_workers_per_node is not None:
-            spec["num_workers_per_node"] = self.num_workers_per_node
-        return spec

--- a/nemo_curator/stages/text/download/arxiv/download.py
+++ b/nemo_curator/stages/text/download/arxiv/download.py
@@ -30,6 +30,9 @@ class ArxivDownloader(DocumentDownloader):
             msg = "s5cmd is not installed. Please install it from https://github.com/peak/s5cmd"
             raise RuntimeError(msg)
 
+    def num_workers_per_node(self) -> int | None:
+        return 2
+
     def _get_output_filename(self, url: str) -> str:
         # Use tarfile name as output filename
         return url

--- a/nemo_curator/stages/text/download/base/download.py
+++ b/nemo_curator/stages/text/download/base/download.py
@@ -15,7 +15,6 @@
 import os
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import Any
 
 from loguru import logger
 
@@ -159,7 +158,5 @@ class DocumentDownloadStage(ProcessingStage[FileGroupTask, FileGroupTask]):
             _stage_perf=task._stage_perf,
         )
 
-    def xenna_stage_spec(self) -> dict[str, Any]:
-        return {
-            "num_workers_per_node": self.downloader.num_workers_per_node(),
-        }
+    def num_workers_per_node(self) -> int | float | None:
+        return self.downloader.num_workers_per_node()

--- a/nemo_curator/stages/text/download/common_crawl/download.py
+++ b/nemo_curator/stages/text/download/common_crawl/download.py
@@ -59,6 +59,9 @@ class CommonCrawlWARCDownloader(DocumentDownloader):
             msg = "s5cmd is not installed. Please install it from https://github.com/peak/s5cmd"
             raise RuntimeError(msg)
 
+    def num_workers_per_node(self) -> int | None:
+        return 2
+
     def _get_output_filename(self, url: str) -> str:
         """Generate output filename from URL."""
         return urlparse(url).path[1:].replace("/", "-")

--- a/nemo_curator/stages/video/io/video_reader.py
+++ b/nemo_curator/stages/video/io/video_reader.py
@@ -70,6 +70,9 @@ class VideoReaderStage(ProcessingStage[FileGroupTask, VideoTask]):
         """
         return ["data"], ["source_bytes", "metadata"]
 
+    def num_workers_per_node(self) -> int | None:
+        return 2
+
     def process(self, task: FileGroupTask) -> VideoTask:
         """Process a video task by reading file bytes and extracting metadata.
 

--- a/nemo_curator/utils/ray_utils.py
+++ b/nemo_curator/utils/ray_utils.py
@@ -19,7 +19,6 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any
 
 import ray
-from loguru import logger
 from ray.util.scheduling_strategies import NodeAffinitySchedulingStrategy
 
 if TYPE_CHECKING:
@@ -52,6 +51,25 @@ def get_head_node_id() -> str | None:
     return None
 
 
+def get_alive_ray_nodes(ignore_head_node: bool = False) -> list[dict[str, Any]]:
+    """Return alive Ray nodes, optionally excluding the cluster head."""
+    head_node_id = get_head_node_id() if ignore_head_node else None
+    nodes = []
+    for node in ray.nodes():
+        if not node.get("Alive"):
+            continue
+        node_id = node["NodeID"]
+        if ignore_head_node and node_id == head_node_id:
+            continue
+        nodes.append(node)
+    return nodes
+
+
+def get_alive_ray_node_count(ignore_head_node: bool = False) -> int:
+    """Return the number of alive Ray nodes available for per-node work."""
+    return len(get_alive_ray_nodes(ignore_head_node=ignore_head_node))
+
+
 def submit_on_each_node(
     remote_fn: RemoteFunction,
     *args,
@@ -67,15 +85,9 @@ def submit_on_each_node(
     for awaiting the returned refs (typically via ``ray.get``); use this when batching
     multiple fan-outs into a single await preserves parallelism.
     """
-    head_node_id = get_head_node_id() if ignore_head_node else None
     refs = []
-    for node in ray.nodes():
-        if not node.get("Alive"):
-            continue
+    for node in get_alive_ray_nodes(ignore_head_node=ignore_head_node):
         node_id = node["NodeID"]
-        if ignore_head_node and node_id == head_node_id:
-            logger.info(f"Skipping head node {node_id}")
-            continue
         refs.append(
             remote_fn.options(
                 num_cpus=num_cpus,

--- a/tests/backends/ray_actor_pool/test_executor.py
+++ b/tests/backends/ray_actor_pool/test_executor.py
@@ -46,7 +46,7 @@ class TestRayActorPoolExecutor:
     def test_calculate_optimal_actors_respects_explicit_num_workers(
         self, available_cpus: float, expected_actors: int, expected_warning: str | None
     ) -> None:
-        stage = _stage_with_num_workers(num_workers=4, cpus=1.0, batch_size=10)
+        stage = _stage_with_worker_sizing(num_workers=4, num_workers_per_node=None, cpus=1.0, batch_size=10)
 
         with (
             mock.patch(
@@ -63,11 +63,59 @@ class TestRayActorPoolExecutor:
             mock_warning.assert_called_once()
             assert expected_warning in mock_warning.call_args.args[0]
 
+    @pytest.mark.parametrize(
+        ("available_cpus", "expected_actors", "expected_warning"),
+        [
+            (8.0, 6, None),
+            (4.0, 4, "requires 6 actors from num_workers_per_node()"),
+        ],
+    )
+    def test_calculate_optimal_actors_respects_num_workers_per_node(
+        self, available_cpus: float, expected_actors: int, expected_warning: str | None
+    ) -> None:
+        stage = _stage_with_worker_sizing(num_workers=None, num_workers_per_node=2, cpus=1.0, batch_size=10)
 
-def _stage_with_num_workers(*, num_workers: int, cpus: float, batch_size: int) -> mock.Mock:
+        with (
+            mock.patch(
+                "nemo_curator.backends.ray_actor_pool.utils.get_available_cpu_gpu_resources",
+                return_value=(available_cpus, 0.0),
+            ),
+            mock.patch(
+                "nemo_curator.backends.ray_actor_pool.utils.get_alive_ray_node_count",
+                return_value=3,
+            ) as mock_node_count,
+            mock.patch("nemo_curator.backends.ray_actor_pool.utils.logger.warning") as mock_warning,
+        ):
+            assert calculate_optimal_actors_for_stage(stage, num_tasks=1, ignore_head_node=True) == expected_actors
+
+        mock_node_count.assert_called_once_with(ignore_head_node=True)
+        if expected_warning is None:
+            mock_warning.assert_not_called()
+        else:
+            mock_warning.assert_called_once()
+            assert expected_warning in mock_warning.call_args.args[0]
+
+    @pytest.mark.parametrize("num_workers", [0, 4])
+    def test_calculate_optimal_actors_rejects_num_workers_with_num_workers_per_node(self, num_workers: int) -> None:
+        stage = _stage_with_worker_sizing(num_workers=num_workers, num_workers_per_node=2, cpus=1.0, batch_size=10)
+
+        with (
+            mock.patch(
+                "nemo_curator.backends.ray_actor_pool.utils.get_available_cpu_gpu_resources",
+                return_value=(8.0, 0.0),
+            ),
+            pytest.raises(ValueError, match=r"num_workers\(\).*num_workers_per_node\(\)"),
+        ):
+            calculate_optimal_actors_for_stage(stage, num_tasks=1)
+
+
+def _stage_with_worker_sizing(
+    *, num_workers: int | None, num_workers_per_node: float | None, cpus: float, batch_size: int
+) -> mock.Mock:
     stage = mock.Mock()
     stage.name = "stage"
     stage.resources = Resources(cpus=cpus, gpus=0.0)
     stage.batch_size = batch_size
     stage.num_workers.return_value = num_workers
+    stage.num_workers_per_node.return_value = num_workers_per_node
     return stage

--- a/tests/backends/ray_actor_pool/test_executor.py
+++ b/tests/backends/ray_actor_pool/test_executor.py
@@ -95,20 +95,9 @@ class TestRayActorPoolExecutor:
             mock_warning.assert_called_once()
             assert expected_warning in mock_warning.call_args.args[0]
 
-    @pytest.mark.parametrize("num_workers", [0, 4])
-    def test_calculate_optimal_actors_rejects_num_workers_with_num_workers_per_node(self, num_workers: int) -> None:
-        stage = _stage_with_worker_sizing(num_workers=num_workers, num_workers_per_node=2, cpus=1.0, batch_size=10)
 
-        with (
-            mock.patch(
-                "nemo_curator.backends.ray_actor_pool.utils.get_available_cpu_gpu_resources",
-                return_value=(8.0, 0.0),
-            ),
-            pytest.raises(ValueError, match=r"num_workers\(\).*num_workers_per_node\(\)"),
-        ):
-            calculate_optimal_actors_for_stage(stage, num_tasks=1)
-
-
+# Mutual exclusion of num_workers() and num_workers_per_node() is enforced at stage
+# construction (ProcessingStage._validate_worker_sizing); see tests/stages/common/test_base.py.
 def _stage_with_worker_sizing(
     *, num_workers: int | None, num_workers_per_node: float | None, cpus: float, batch_size: int
 ) -> mock.Mock:

--- a/tests/backends/ray_data/test_adapter.py
+++ b/tests/backends/ray_data/test_adapter.py
@@ -96,22 +96,27 @@ class TestRayDataStageAdapter:
             assert "concurrency" not in kwargs
 
     def test_task_stage_uses_task_pool_strategy_for_num_workers(self):
+        stage = ConfigurableTaskStage(num_workers=3)
+
+        task_kwargs = _map_batches_kwargs(stage)
+
+        assert task_kwargs["compute"] == TaskPoolStrategy(size=3)
+
+    def test_task_stage_warns_on_actor_pool_sizing_keys(self):
         stage = ConfigurableTaskStage(
             ray_stage_spec={
                 RayStageSpecKeys.MIN_WORKERS: 2,
                 RayStageSpecKeys.MAX_WORKERS: 8,
                 RayStageSpecKeys.INITIAL_WORKERS: 4,
             },
-            num_workers=3,
         )
 
         with mock.patch("nemo_curator.backends.ray_data.adapter.logger.warning") as mock_warning:
             task_kwargs = _map_batches_kwargs(stage)
 
-        assert task_kwargs["compute"] == TaskPoolStrategy(size=3)
+        assert "compute" not in task_kwargs
         assert mock_warning.call_count == 1
-        warning_messages = [call.args[0] for call in mock_warning.call_args_list]
-        assert "Ignoring ray_stage_spec worker sizing keys" in warning_messages[0]
+        assert "Ignoring ray_stage_spec worker sizing keys" in mock_warning.call_args_list[0].args[0]
 
     def test_task_stage_uses_task_pool_strategy_for_num_workers_per_node(self):
         stage = ConfigurableTaskStage().with_(num_workers_per_node=2)
@@ -158,10 +163,9 @@ class TestRayDataStageAdapter:
 
     @pytest.mark.parametrize("num_workers", [0, 3])
     def test_num_workers_per_node_rejects_explicit_stage_num_workers(self, num_workers: int):
-        stage = ConflictingWorkerSizingTaskStage(num_workers=num_workers)
-
+        # Mutual exclusion is enforced at stage construction, not in the adapter.
         with pytest.raises(ValueError, match=r"num_workers.*num_workers_per_node"):
-            _map_batches_kwargs(stage)
+            ConflictingWorkerSizingTaskStage(num_workers=num_workers)
 
     def test_source_fanout_task_stage_uses_task_pool_strategy_for_single_worker_default(self):
         stage = ConfigurableTaskStage(

--- a/tests/backends/ray_data/test_adapter.py
+++ b/tests/backends/ray_data/test_adapter.py
@@ -70,6 +70,11 @@ class ConfigurableTaskStage(ConfigurableActorStage):
         return self._ray_stage_spec
 
 
+class ConflictingWorkerSizingTaskStage(ConfigurableTaskStage):
+    def num_workers_per_node(self) -> int:
+        return 2
+
+
 class TestRayDataStageAdapter:
     def test_process_dataset_uses_compute_for_actor_stages_and_ray_default_for_task_stages(self):
         fixed_actor_kwargs = _map_batches_kwargs(ConfigurableActorStage(num_workers=3))
@@ -108,6 +113,56 @@ class TestRayDataStageAdapter:
         warning_messages = [call.args[0] for call in mock_warning.call_args_list]
         assert "Ignoring ray_stage_spec worker sizing keys" in warning_messages[0]
 
+    def test_task_stage_uses_task_pool_strategy_for_num_workers_per_node(self):
+        stage = ConfigurableTaskStage().with_(num_workers_per_node=2)
+
+        with mock.patch("nemo_curator.backends.ray_data.adapter.get_alive_ray_node_count", return_value=3):
+            task_kwargs = _map_batches_kwargs(stage)
+
+        assert task_kwargs["compute"] == TaskPoolStrategy(size=6)
+        assert task_kwargs["scheduling_strategy"] == "SPREAD"
+
+    def test_actor_stage_uses_actor_pool_strategy_for_num_workers_per_node(self):
+        stage = ConfigurableActorStage().with_(num_workers_per_node=2)
+
+        with mock.patch("nemo_curator.backends.ray_data.adapter.get_alive_ray_node_count", return_value=3):
+            actor_kwargs = _map_batches_kwargs(stage)
+
+        assert actor_kwargs["compute"] == ActorPoolStrategy(size=6)
+        assert actor_kwargs["scheduling_strategy"] == "SPREAD"
+
+    def test_num_workers_per_node_passes_ignore_head_node_to_alive_node_count(self):
+        stage = ConfigurableTaskStage().with_(num_workers_per_node=2)
+
+        with mock.patch(
+            "nemo_curator.backends.ray_data.adapter.get_alive_ray_node_count", return_value=2
+        ) as mock_count:
+            task_kwargs = _map_batches_kwargs(stage, ignore_head_node=True)
+
+        mock_count.assert_called_once_with(ignore_head_node=True)
+        assert task_kwargs["compute"] == TaskPoolStrategy(size=4)
+
+    def test_num_workers_per_node_preserves_user_scheduling_strategy_override(self):
+        stage = ConfigurableTaskStage().with_(
+            ray_stage_spec={
+                RayStageSpecKeys.RAY_REMOTE_ARGS: {"scheduling_strategy": "DEFAULT"},
+            },
+            num_workers_per_node=2,
+        )
+
+        with mock.patch("nemo_curator.backends.ray_data.adapter.get_alive_ray_node_count", return_value=3):
+            task_kwargs = _map_batches_kwargs(stage)
+
+        assert task_kwargs["compute"] == TaskPoolStrategy(size=6)
+        assert task_kwargs["scheduling_strategy"] == "DEFAULT"
+
+    @pytest.mark.parametrize("num_workers", [0, 3])
+    def test_num_workers_per_node_rejects_explicit_stage_num_workers(self, num_workers: int):
+        stage = ConflictingWorkerSizingTaskStage(num_workers=num_workers)
+
+        with pytest.raises(ValueError, match=r"num_workers.*num_workers_per_node"):
+            _map_batches_kwargs(stage)
+
     def test_source_fanout_task_stage_uses_task_pool_strategy_for_single_worker_default(self):
         stage = ConfigurableTaskStage(
             ray_stage_spec={RayStageSpecKeys.IS_FANOUT_STAGE: True},
@@ -141,9 +196,9 @@ class TestRayDataStageAdapter:
         assert kwargs["num_cpus"] == stage.resources.cpus
 
 
-def _map_batches_kwargs(stage: ProcessingStage) -> dict[str, object]:
+def _map_batches_kwargs(stage: ProcessingStage, ignore_head_node: bool = False) -> dict[str, object]:
     dataset = RecordingDataset()
-    RayDataStageAdapter(stage).process_dataset(dataset)  # type: ignore[arg-type]
+    RayDataStageAdapter(stage, ignore_head_node=ignore_head_node).process_dataset(dataset)  # type: ignore[arg-type]
     assert dataset.map_batches_kwargs is not None
     assert dataset.batch_size == stage.batch_size
     return dataset.map_batches_kwargs

--- a/tests/backends/ray_data/test_utils.py
+++ b/tests/backends/ray_data/test_utils.py
@@ -64,12 +64,12 @@ class TestGetActorComputeStrategyForStage:
     """Test class for Ray Data compute strategy construction."""
 
     @pytest.mark.parametrize(
-        ("num_workers", "ray_stage_spec", "expected", "expected_warning"),
+        ("num_workers", "ray_stage_spec", "expected"),
         [
-            (4, {}, ActorPoolStrategy(size=4), None),
-            (0, {}, ActorPoolStrategy(min_size=1, max_size=None), None),
-            (-1, {}, ActorPoolStrategy(min_size=1, max_size=None), None),
-            (None, {}, ActorPoolStrategy(min_size=1, max_size=None), None),
+            (4, {}, ActorPoolStrategy(size=4)),
+            (0, {}, ActorPoolStrategy(min_size=1, max_size=None)),
+            (-1, {}, ActorPoolStrategy(min_size=1, max_size=None)),
+            (None, {}, ActorPoolStrategy(min_size=1, max_size=None)),
             (
                 None,
                 {
@@ -78,17 +78,6 @@ class TestGetActorComputeStrategyForStage:
                     RayStageSpecKeys.INITIAL_WORKERS: 4,
                 },
                 ActorPoolStrategy(min_size=2, max_size=8, initial_size=4),
-                None,
-            ),
-            (
-                3,
-                {
-                    RayStageSpecKeys.MIN_WORKERS: 1,
-                    RayStageSpecKeys.MAX_WORKERS: 8,
-                    RayStageSpecKeys.INITIAL_WORKERS: 2,
-                },
-                ActorPoolStrategy(size=3),
-                "uses num_workers=3",
             ),
         ],
     )
@@ -97,19 +86,11 @@ class TestGetActorComputeStrategyForStage:
         num_workers: int | None,
         ray_stage_spec: dict[str, object],
         expected: ActorPoolStrategy,
-        expected_warning: str | None,
     ):
         mock_stage = Mock(num_workers=lambda: num_workers, ray_stage_spec=lambda: ray_stage_spec)
         mock_stage.name = "stage"
 
-        with patch("nemo_curator.backends.ray_data.utils.logger.warning") as mock_warning:
-            assert get_actor_compute_strategy_for_stage(mock_stage) == expected
-
-        if expected_warning is None:
-            mock_warning.assert_not_called()
-        else:
-            mock_warning.assert_called_once()
-            assert expected_warning in mock_warning.call_args.args[0]
+        assert get_actor_compute_strategy_for_stage(mock_stage) == expected
 
     def test_actor_compute_strategy_rejects_invalid_sizing(self):
         mock_stage = Mock(

--- a/tests/backends/test_xenna_executor.py
+++ b/tests/backends/test_xenna_executor.py
@@ -28,13 +28,18 @@ class ConfigurableStage(ProcessingStage[EmptyTask, EmptyTask]):
         self,
         *,
         num_workers: int | None = None,
+        num_workers_per_node: float | None = None,
         xenna_stage_spec: dict[str, object] | None = None,
     ) -> None:
         self._num_workers = num_workers
+        self._num_workers_per_node = num_workers_per_node
         self._xenna_stage_spec = xenna_stage_spec or {}
 
     def num_workers(self) -> int | None:
         return self._num_workers
+
+    def num_workers_per_node(self) -> float | None:
+        return self._num_workers_per_node
 
     def xenna_stage_spec(self) -> dict[str, object]:
         return self._xenna_stage_spec
@@ -58,6 +63,17 @@ def test_xenna_executor_uses_stage_num_workers_when_xenna_spec_has_no_worker_siz
 def test_xenna_executor_accepts_num_workers_per_node_when_stage_num_workers_is_unset(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    stage = ConfigurableStage(num_workers_per_node=0.5)
+
+    captured = _execute_and_capture_stage_spec(monkeypatch, stage)
+
+    assert captured["num_workers"] is None
+    assert captured["num_workers_per_node"] == 0.5
+
+
+def test_xenna_executor_accepts_legacy_spec_num_workers_per_node_when_stage_method_is_unset(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     stage = ConfigurableStage(xenna_stage_spec={"num_workers_per_node": 0.5})
 
     captured = _execute_and_capture_stage_spec(monkeypatch, stage)
@@ -67,9 +83,18 @@ def test_xenna_executor_accepts_num_workers_per_node_when_stage_num_workers_is_u
 
 
 def test_xenna_executor_rejects_num_workers_with_num_workers_per_node(monkeypatch: pytest.MonkeyPatch) -> None:
-    stage = ConfigurableStage(num_workers=3, xenna_stage_spec={"num_workers_per_node": 0.5})
+    stage = ConfigurableStage(num_workers=3, num_workers_per_node=0.5)
 
     with pytest.raises(ValueError, match=r"num_workers\(\).*num_workers_per_node"):
+        _execute_and_capture_stage_spec(monkeypatch, stage)
+
+
+def test_xenna_executor_rejects_conflicting_num_workers_per_node_sources(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    stage = ConfigurableStage(num_workers_per_node=0.5, xenna_stage_spec={"num_workers_per_node": 1.0})
+
+    with pytest.raises(ValueError, match=r"num_workers_per_node\(\).*xenna_stage_spec"):
         _execute_and_capture_stage_spec(monkeypatch, stage)
 
 

--- a/tests/backends/test_xenna_executor.py
+++ b/tests/backends/test_xenna_executor.py
@@ -71,37 +71,23 @@ def test_xenna_executor_accepts_num_workers_per_node_when_stage_num_workers_is_u
     assert captured["num_workers_per_node"] == 0.5
 
 
-def test_xenna_executor_accepts_legacy_spec_num_workers_per_node_when_stage_method_is_unset(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    stage = ConfigurableStage(xenna_stage_spec={"num_workers_per_node": 0.5})
-
-    captured = _execute_and_capture_stage_spec(monkeypatch, stage)
-
-    assert captured["num_workers"] is None
-    assert captured["num_workers_per_node"] == 0.5
-
-
-def test_xenna_executor_rejects_num_workers_with_num_workers_per_node(monkeypatch: pytest.MonkeyPatch) -> None:
-    stage = ConfigurableStage(num_workers=3, num_workers_per_node=0.5)
-
-    with pytest.raises(ValueError, match=r"num_workers\(\).*num_workers_per_node"):
-        _execute_and_capture_stage_spec(monkeypatch, stage)
-
-
-def test_xenna_executor_rejects_conflicting_num_workers_per_node_sources(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    stage = ConfigurableStage(num_workers_per_node=0.5, xenna_stage_spec={"num_workers_per_node": 1.0})
-
-    with pytest.raises(ValueError, match=r"num_workers_per_node\(\).*xenna_stage_spec"):
-        _execute_and_capture_stage_spec(monkeypatch, stage)
+def test_xenna_executor_rejects_num_workers_with_num_workers_per_node() -> None:
+    # Mutual exclusion is enforced at stage construction (ProcessingStage._validate_worker_sizing).
+    with pytest.raises(ValueError, match=r"num_workers.*num_workers_per_node"):
+        ConfigurableStage(num_workers=3, num_workers_per_node=0.5)
 
 
 def test_xenna_executor_rejects_num_workers_in_xenna_stage_spec(monkeypatch: pytest.MonkeyPatch) -> None:
     stage = ConfigurableStage(xenna_stage_spec={"num_workers": 3})
 
     with pytest.raises(ValueError, match="Use num_workers\\(\\) instead"):
+        _execute_and_capture_stage_spec(monkeypatch, stage)
+
+
+def test_xenna_executor_rejects_num_workers_per_node_in_xenna_stage_spec(monkeypatch: pytest.MonkeyPatch) -> None:
+    stage = ConfigurableStage(xenna_stage_spec={"num_workers_per_node": 0.5})
+
+    with pytest.raises(ValueError, match="Use num_workers_per_node\\(\\) instead"):
         _execute_and_capture_stage_spec(monkeypatch, stage)
 
 

--- a/tests/stages/common/test_base.py
+++ b/tests/stages/common/test_base.py
@@ -327,6 +327,38 @@ class TestProcessingStageWith:
         assert stage.num_workers() == 2
         assert stage_new.num_workers() is None
 
+    def test_num_workers_per_node_override_accepts_none_as_explicit_override(self):
+        """Test num_workers_per_node can be overridden with the generic with_ helper."""
+        stage = ConcreteProcessingStage()
+
+        stage_new = stage.with_(num_workers_per_node=2)
+        stage_reset = stage_new.with_(num_workers_per_node=None)
+
+        assert stage.num_workers_per_node() is None
+        assert stage_new.num_workers_per_node() == 2
+        assert stage_reset.num_workers_per_node() is None
+
+    def test_worker_sizing_rejects_num_workers_with_num_workers_per_node(self):
+        """Test generic worker sizing rejects fixed and per-node worker counts together."""
+        stage = ConcreteProcessingStage()
+
+        with pytest.raises(ValueError, match=r"num_workers.*num_workers_per_node"):
+            stage.with_(num_workers=2, num_workers_per_node=2)
+
+    def test_worker_sizing_rejects_zero_num_workers_with_num_workers_per_node(self):
+        """Test generic worker sizing rejects any explicit fixed worker count with per-node sizing."""
+        stage = ConcreteProcessingStage()
+
+        with pytest.raises(ValueError, match=r"num_workers.*num_workers_per_node"):
+            stage.with_(num_workers=0, num_workers_per_node=2)
+
+    def test_worker_sizing_rejects_existing_num_workers_with_num_workers_per_node(self):
+        """Test with_ rejects per-node sizing when the stage already declares fixed workers."""
+        stage = BackendConfiguredStage()
+
+        with pytest.raises(ValueError, match=r"num_workers.*num_workers_per_node"):
+            stage.with_(num_workers_per_node=2)
+
 
 class TestProcessingStageOverriddenProperties:
     """Test that ProcessingStage raises an error if a derived class overrides the _name, _resources, or _batch_size property."""

--- a/tests/stages/text/download/arxiv/test_download.py
+++ b/tests/stages/text/download/arxiv/test_download.py
@@ -36,6 +36,10 @@ class TestArxivDownloader:
     """Test suite for ArxivDownloader."""
 
     @mock.patch("nemo_curator.stages.text.download.arxiv.download.check_s5cmd_installed", return_value=True)
+    def test_num_workers_per_node_default(self, mock_s5cmd_check: mock.Mock, tmp_path: Path) -> None:
+        assert ArxivDownloader(str(tmp_path)).num_workers_per_node() == 2
+
+    @mock.patch("nemo_curator.stages.text.download.arxiv.download.check_s5cmd_installed", return_value=True)
     @mock.patch("subprocess.run", return_value=mock.Mock(returncode=0))
     @pytest.mark.parametrize("verbose", [True, False])
     def test_download_to_path(

--- a/tests/stages/text/download/base/test_download.py
+++ b/tests/stages/text/download/base/test_download.py
@@ -42,6 +42,11 @@ class MockDocumentDownloader(DocumentDownloader):
 class TestBaseDocumentDownloader:
     """Base test class for DocumentDownloader temporary file logic."""
 
+    def test_num_workers_per_node_defaults_to_unbounded(self, tmp_path: Path) -> None:
+        downloader = MockDocumentDownloader(str(tmp_path))
+
+        assert downloader.num_workers_per_node() is None
+
     @mock.patch.object(MockDocumentDownloader, "_download_to_path")
     @pytest.mark.parametrize("verbose", [True, False])
     def test_download_existing_file(
@@ -185,6 +190,20 @@ class TestBaseDocumentDownloader:
 
 class TestDocumentDownloadStage:
     """Test class for DocumentDownloadStage functionality."""
+
+    def test_num_workers_per_node_delegates_to_downloader(self, tmp_path: Path) -> None:
+        class PerNodeMockDownloader(MockDocumentDownloader):
+            def num_workers_per_node(self) -> int | None:
+                return 4
+
+        stage = DocumentDownloadStage(PerNodeMockDownloader(str(tmp_path)))
+
+        assert stage.num_workers_per_node() == 4
+
+    def test_num_workers_per_node_can_be_overridden_with_stage_with(self, tmp_path: Path) -> None:
+        stage = DocumentDownloadStage(MockDocumentDownloader(str(tmp_path))).with_(num_workers_per_node=4)
+
+        assert stage.num_workers_per_node() == 4
 
     def test_stage_properties(self, tmp_path: Path) -> None:
         """Test that stage properties are correctly defined."""

--- a/tests/stages/text/download/common_crawl/test_download.py
+++ b/tests/stages/text/download/common_crawl/test_download.py
@@ -25,6 +25,9 @@ from nemo_curator.stages.text.download.utils import check_s5cmd_installed
 class TestCommonCrawlWARCDownloader:
     """Test suite for CommonCrawlWARCDownloader."""
 
+    def test_num_workers_per_node_default(self, tmp_path: Path) -> None:
+        assert CommonCrawlWARCDownloader(str(tmp_path), use_aws_to_download=False).num_workers_per_node() == 2
+
     @mock.patch("subprocess.run", return_value=mock.Mock(returncode=0))
     def test_download_to_path_wget(self, mock_run: mock.Mock, tmp_path: Path) -> None:
         """Test _download_to_path with wget (use_aws_to_download=False)."""

--- a/tests/stages/text/download/wikipedia/test_download.py
+++ b/tests/stages/text/download/wikipedia/test_download.py
@@ -27,6 +27,9 @@ def _wget_command(url: str, path: str) -> list[str]:
 class TestWikipediaDownloader:
     """Test suite for WikipediaDownloader."""
 
+    def test_num_workers_per_node_default(self, tmp_path: Path):
+        assert WikipediaDownloader(str(tmp_path)).num_workers_per_node() == 2
+
     def test_init_default_values(self, tmp_path: Path):
         """Test initialization with default values."""
         downloader = WikipediaDownloader(str(tmp_path))

--- a/tests/stages/video/io/test_video_reader.py
+++ b/tests/stages/video/io/test_video_reader.py
@@ -33,6 +33,7 @@ class TestVideoReaderStage:
         assert stage.name == "video_reader"
         assert stage.inputs() == (["data"], [])
         assert stage.outputs() == (["data"], ["source_bytes", "metadata"])
+        assert stage.num_workers_per_node() == 2
 
     def test_stage_initialization(self) -> None:
         """Test stage initialization with different parameters."""

--- a/tests/utils/test_ray_utils.py
+++ b/tests/utils/test_ray_utils.py
@@ -69,6 +69,22 @@ class _FakeRemoteFunction:
 
 
 class TestRunOnEachNode:
+    def test_get_alive_ray_nodes_filters_dead_nodes(self) -> None:
+        assert hasattr(ray_utils, "get_alive_ray_nodes")
+        assert hasattr(ray_utils, "get_alive_ray_node_count")
+        nodes = ray_utils.get_alive_ray_nodes()
+
+        assert [node["NodeID"] for node in nodes] == [_HEAD_NODE_ID, _WORKER_NODE_ID]
+        assert ray_utils.get_alive_ray_node_count() == 2
+
+    def test_get_alive_ray_nodes_can_ignore_head_node(self, reset_head_node_cache: None) -> None:
+        assert hasattr(ray_utils, "get_alive_ray_nodes")
+        assert hasattr(ray_utils, "get_alive_ray_node_count")
+        nodes = ray_utils.get_alive_ray_nodes(ignore_head_node=True)
+
+        assert [node["NodeID"] for node in nodes] == [_WORKER_NODE_ID]
+        assert ray_utils.get_alive_ray_node_count(ignore_head_node=True) == 1
+
     def test_returns_one_result_per_alive_node(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Default call schedules ``remote_fn`` once per alive node and returns each landing node's id."""
         remote_fn = _FakeRemoteFunction()
@@ -78,9 +94,7 @@ class TestRunOnEachNode:
 
         assert results == remote_fn.submissions
         assert [r["args"] for r in results] == [("payload",), ("payload",)]
-        scheduled_ids = [
-            r["options"]["scheduling_strategy"].node_id for r in remote_fn.submissions
-        ]
+        scheduled_ids = [r["options"]["scheduling_strategy"].node_id for r in remote_fn.submissions]
         assert scheduled_ids == [_HEAD_NODE_ID, _WORKER_NODE_ID]
         assert all(not r["options"]["scheduling_strategy"].soft for r in remote_fn.submissions)
 

--- a/tutorials/audio/callhome_diar/run.py
+++ b/tutorials/audio/callhome_diar/run.py
@@ -34,7 +34,6 @@ import time
 from collections import Counter
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
 
 from loguru import logger
 
@@ -144,8 +143,8 @@ class CallHomeReaderStage(ProcessingStage[EmptyTask, AudioTask]):
     def outputs(self) -> tuple[list[str], list[str]]:
         return ["data"], [self.filepath_key]
 
-    def xenna_stage_spec(self) -> dict[str, Any]:
-        return {"num_workers_per_node": 1}
+    def num_workers_per_node(self) -> int:
+        return 1
 
     def process(self, task: EmptyTask) -> list[AudioTask]:  # noqa: ARG002
         cha_path = Path(self.cha_dir)


### PR DESCRIPTION
## Summary
- Add `ProcessingStage.num_workers_per_node()` (method-only) and `with_(num_workers_per_node=...)`.
- Enforce at most one worker-sizing option (`num_workers` / `num_workers_per_node` / actor-pool `min`/`max`/`initial_workers`) once at stage construction, and drop the duplicated checks from the Ray Data, Ray Actor Pool, and Xenna backends.
- Translate per-node sizing across all three backends using shared alive-Ray-node helpers, and apply default per-node limits to download-like stages.
- Add matching backend/stage tests.

## Behavior/API changes
- Removed the legacy `xenna_stage_spec()["num_workers_per_node"]` path and the `ImageDuplicatesRemovalStage(num_workers_per_node=...)` constructor arg; use `.with_(num_workers_per_node=...)` instead (migrated `ImageDuplicatesRemovalStage` and the CallHome tutorial).

Fixes #2197