### PR TITLE
Audio: add Qwen3-ASR adapter

### DIFF
--- a/nemo_curator/models/asr/base.py
+++ b/nemo_curator/models/asr/base.py
@@ -42,8 +42,10 @@ class ASRResult:
             when ``skipped`` is true. Defaults to ``"empty_audio"`` in the stage.
         unsupported_language: Optional normalized language code used by the
             stage to annotate items excluded by its language allowlist.
-        extras: Adapter-specific diagnostics outside the canonical shape; the
-            stage never reads inside this dict.
+        extras: Adapter-specific, manifest-serializable diagnostics. When the
+            stage's ``extras_key`` is enabled, it writes a shallow copy of this
+            dictionary under that one nested output field without interpreting
+            individual keys.
     """
 
     text: str

--- a/nemo_curator/models/asr/qwen_asr.py
+++ b/nemo_curator/models/asr/qwen_asr.py
@@ -35,7 +35,7 @@ from huggingface_hub import snapshot_download
 from loguru import logger
 
 from nemo_curator.models.asr.base import ASRResult
-from nemo_curator.utils.vllm_utils import merge_vllm_kwargs, validate_vllm_kwargs
+from nemo_curator.utils.vllm_utils import merge_vllm_kwargs
 
 _DEFAULT_QWEN3_ASR_MODEL = "Qwen/Qwen3-ASR-0.6B"
 
@@ -129,11 +129,6 @@ class QwenASRAdapter:
             )
             raise ValueError(msg)
         self.vllm_kwargs = deepcopy(dict(self.vllm_kwargs))
-        validate_vllm_kwargs(
-            self.vllm_kwargs,
-            self._model_owned_vllm_kwargs(),
-            owner_description="adapter-owned arguments",
-        )
 
     def _model_owned_vllm_kwargs(self) -> dict[str, Any]:
         """Return the qwen-asr constructor arguments owned by this adapter."""

--- a/nemo_curator/models/asr/qwen_asr.py
+++ b/nemo_curator/models/asr/qwen_asr.py
@@ -23,14 +23,12 @@ results back to ``ASRResult`` positions.
 from __future__ import annotations
 
 import gc
-import inspect
 from copy import deepcopy
 from dataclasses import dataclass, field
 from typing import Any
 
 import numpy as np
 import torch
-import transformers
 from huggingface_hub import snapshot_download
 from loguru import logger
 
@@ -52,30 +50,6 @@ def _qwen_asr_model_cls() -> Any:  # noqa: ANN401
         msg = "QwenASRAdapter requires the audio_cuda12 and vllm extras: uv sync --extra audio_cuda12 --extra vllm"
         raise ImportError(msg) from exc
     return Qwen3ASRModel
-
-
-def _patch_transformers_compat() -> None:
-    """Accept qwen-asr's decorator-factory syntax on newer Transformers.
-
-    This matches the compatibility patch used by the nkoluguri Qwen-ASR
-    reference. Newer Transformers exposes ``check_model_inputs`` as a plain
-    decorator, while qwen-asr 0.0.6 still invokes it with parentheses.
-    """
-    try:
-        original = getattr(transformers, "check_model_inputs", None)
-        if original is None:
-            return
-        parameters = list(inspect.signature(original).parameters.values())
-        if parameters and parameters[0].name == "func":
-
-            def compat_check_model_inputs(*args: Any) -> Any:  # noqa: ANN401
-                if args and callable(args[0]):
-                    return original(args[0])
-                return original
-
-            transformers.check_model_inputs = compat_check_model_inputs
-    except Exception:  # noqa: BLE001, S110
-        pass
 
 
 @dataclass
@@ -171,7 +145,6 @@ class QwenASRAdapter:
         )
         if model_kwargs["revision"] is None:
             del model_kwargs["revision"]
-        _patch_transformers_compat()
         try:
             self._model = _qwen_asr_model_cls().LLM(**model_kwargs)
         except Exception:

--- a/nemo_curator/models/asr/qwen_asr.py
+++ b/nemo_curator/models/asr/qwen_asr.py
@@ -1,0 +1,262 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Qwen3-ASR vLLM implementation of the shared ASR adapter.
+
+This uses the same ``Qwen3ASRModel.LLM`` construction and vLLM engine settings
+as the nkoluguri reference. ``ASRStage`` owns mono conversion and resampling;
+the adapter hands one prepared batch to one ``transcribe`` call and maps
+results back to ``ASRResult`` positions.
+"""
+
+from __future__ import annotations
+
+import gc
+import inspect
+from copy import deepcopy
+from dataclasses import dataclass, field
+from typing import Any
+
+import numpy as np
+import torch
+import transformers
+from huggingface_hub import snapshot_download
+from loguru import logger
+
+from nemo_curator.models.asr.base import ASRResult
+from nemo_curator.utils.vllm_utils import validate_vllm_kwargs
+
+_DEFAULT_QWEN3_ASR_MODEL = "Qwen/Qwen3-ASR-0.6B"
+
+# Qwen's audio processor needs >=200 samples for STFT padding. 1600 samples
+# (100 ms at 16 kHz) is a conservative floor that also matches the Qwen-Omni
+# preprocessing path.
+_MIN_SAMPLES = 1600
+
+_RESERVED_VLLM_KWARGS = frozenset(
+    {
+        "model",
+        "revision",
+        "gpu_memory_utilization",
+        "max_inference_batch_size",
+        "max_new_tokens",
+        "trust_remote_code",
+        "enforce_eager",
+        "enable_prefix_caching",
+        "prefix_caching_hash_algo",
+    }
+)
+
+
+def _qwen_asr_model_cls() -> Any:  # noqa: ANN401
+    try:
+        from qwen_asr import Qwen3ASRModel
+    except ImportError as exc:
+        msg = "QwenASRAdapter requires the audio_cuda12 and vllm extras: uv sync --extra audio_cuda12 --extra vllm"
+        raise ImportError(msg) from exc
+    return Qwen3ASRModel
+
+
+def _patch_transformers_compat() -> None:
+    """Accept qwen-asr's decorator-factory syntax on newer Transformers.
+
+    This matches the compatibility patch used by the nkoluguri Qwen-ASR
+    reference. Newer Transformers exposes ``check_model_inputs`` as a plain
+    decorator, while qwen-asr 0.0.6 still invokes it with parentheses.
+    """
+    try:
+        original = getattr(transformers, "check_model_inputs", None)
+        if original is None:
+            return
+        parameters = list(inspect.signature(original).parameters.values())
+        if parameters and parameters[0].name == "func":
+
+            def compat_check_model_inputs(*args: Any) -> Any:  # noqa: ANN401
+                if args and callable(args[0]):
+                    return original(args[0])
+                return original
+
+            transformers.check_model_inputs = compat_check_model_inputs
+    except Exception:  # noqa: BLE001, S110
+        pass
+
+
+@dataclass
+class QwenASRAdapter:
+    """Run vLLM-backed Qwen3-ASR over Curator waveform items.
+
+    Every valid item in one adapter call goes to a single ``transcribe`` call,
+    so the caller's batch boundary is the model's batch boundary.
+    ``max_inference_batch_size`` is the library's own internal cap and is passed
+    through at construction.
+
+    ``revision`` is accepted to satisfy the shared adapter constructor and is
+    forwarded to both weight prefetch and the vLLM model loader.
+
+    ``vllm_kwargs`` exposes additional engine settings, following the existing
+    Qwen-Omni adapter convention. Adapter-owned settings cannot be overridden
+    through this mapping. Its default is empty, so normal construction exactly
+    matches the nkoluguri reference engine arguments.
+    """
+
+    model_id: str = _DEFAULT_QWEN3_ASR_MODEL
+    revision: str | None = None
+    gpu_memory_utilization: float = 0.7
+    max_new_tokens: int = 4096
+    max_inference_batch_size: int = 128
+    vllm_kwargs: dict[str, Any] = field(default_factory=dict)
+    _model: Any = field(default=None, init=False, repr=False)
+
+    def __post_init__(self) -> None:
+        if not self.model_id:
+            msg = "QwenASRAdapter.model_id must be non-empty"
+            raise ValueError(msg)
+        if not 0.0 < float(self.gpu_memory_utilization) <= 1.0:
+            msg = f"QwenASRAdapter.gpu_memory_utilization must be in (0, 1], got {self.gpu_memory_utilization}"
+            raise ValueError(msg)
+        if (
+            not isinstance(self.max_new_tokens, int)
+            or isinstance(self.max_new_tokens, bool)
+            or self.max_new_tokens <= 0
+        ):
+            msg = f"QwenASRAdapter.max_new_tokens must be a positive integer, got {self.max_new_tokens!r}"
+            raise ValueError(msg)
+        if (
+            not isinstance(self.max_inference_batch_size, int)
+            or isinstance(self.max_inference_batch_size, bool)
+            or self.max_inference_batch_size <= 0
+        ):
+            msg = (
+                "QwenASRAdapter.max_inference_batch_size must be a positive integer, "
+                f"got {self.max_inference_batch_size!r}"
+            )
+            raise ValueError(msg)
+        self.vllm_kwargs = deepcopy(dict(self.vllm_kwargs))
+        validate_vllm_kwargs(
+            self.vllm_kwargs,
+            _RESERVED_VLLM_KWARGS,
+            owner_description="adapter-owned arguments",
+        )
+
+    @classmethod
+    def download_weights_on_node(cls, model_id: str, revision: str | None = None) -> None:
+        """Populate the local Hugging Face cache without allocating a GPU."""
+        snapshot_download(model_id, revision=revision)
+
+    def load_model(self, *, num_gpus: int) -> None:
+        """Load one worker-local Qwen3-ASR model through its vLLM backend."""
+        if self._model is not None:
+            return
+        if not isinstance(num_gpus, int) or isinstance(num_gpus, bool) or num_gpus != 1:
+            msg = f"QwenASRAdapter requires exactly one integer GPU, got {num_gpus!r}"
+            raise ValueError(msg)
+
+        logger.info(
+            "Loading QwenASRAdapter model={} gpu_mem={} max_new_tokens={} max_batch={}",
+            self.model_id,
+            self.gpu_memory_utilization,
+            self.max_new_tokens,
+            self.max_inference_batch_size,
+        )
+        model_kwargs = deepcopy(self.vllm_kwargs)
+        model_kwargs.update(
+            {
+                "model": self.model_id,
+                "gpu_memory_utilization": self.gpu_memory_utilization,
+                "max_inference_batch_size": self.max_inference_batch_size,
+                "max_new_tokens": self.max_new_tokens,
+                "trust_remote_code": True,
+                "enforce_eager": True,
+                "enable_prefix_caching": True,
+                "prefix_caching_hash_algo": "xxhash",
+            }
+        )
+        if self.revision is not None:
+            model_kwargs["revision"] = self.revision
+        _patch_transformers_compat()
+        try:
+            self._model = _qwen_asr_model_cls().LLM(**model_kwargs)
+        except Exception:
+            self.unload_model()
+            raise
+        logger.info("QwenASRAdapter ready ({})", self.model_id)
+
+    def unload_model(self) -> None:
+        """Release the worker-local model and CUDA cache state."""
+        self._model = None
+        gc.collect()
+        try:
+            torch.cuda.empty_cache()
+            torch.cuda.synchronize()
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("CUDA cache clear skipped: {}", exc)
+
+    @staticmethod
+    def _waveform(item: dict[str, Any]) -> np.ndarray:
+        waveform = np.asarray(item.get("waveform"), dtype=np.float32)
+        if waveform.ndim != 1:
+            msg = f"ASRStage must provide a mono 1-D waveform, got shape {waveform.shape}"
+            raise ValueError(msg)
+        return waveform
+
+    def transcribe_batch(self, items: list[dict[str, Any]]) -> list[ASRResult]:
+        """Transcribe one adapter call while preserving input order."""
+        if not items:
+            return []
+
+        valid_indices: list[int] = []
+        audio_inputs: list[tuple[np.ndarray, int]] = []
+        languages: list[str | None] = []
+        for index, item in enumerate(items):
+            waveform = self._waveform(item)
+            source_rate = int(item.get("sample_rate") or 0)
+            if waveform.size < _MIN_SAMPLES or source_rate <= 0:
+                continue
+            valid_indices.append(index)
+            audio_inputs.append((waveform, source_rate))
+            languages.append(item.get("language"))
+
+        results = [ASRResult(text="", skipped=True) for _ in items]
+        if not audio_inputs:
+            logger.warning(
+                "QwenASRAdapter: all {} items were shorter than {} samples or lacked a sample rate",
+                len(items),
+                _MIN_SAMPLES,
+            )
+            return results
+        if len(audio_inputs) < len(items):
+            logger.warning(
+                "QwenASRAdapter: skipping {}/{} items shorter than {} samples",
+                len(items) - len(audio_inputs),
+                len(items),
+                _MIN_SAMPLES,
+            )
+
+        outputs = self._model.transcribe(audio=audio_inputs, language=languages)
+
+        outputs = list(outputs or [])
+        if len(outputs) != len(valid_indices):
+            msg = f"Qwen3-ASR returned {len(outputs)} transcriptions for {len(valid_indices)} valid inputs"
+            raise RuntimeError(msg)
+
+        for index, output in zip(valid_indices, outputs, strict=True):
+            text = getattr(output, "text", output)
+            text = "" if text is None else str(text)
+            detected_language = getattr(output, "language", "") or ""
+            results[index] = ASRResult(
+                text=text,
+                skipped=not text.strip(),
+                extras={"detected_language": str(detected_language)} if detected_language else {},
+            )
+        return results

--- a/nemo_curator/models/asr/qwen_asr.py
+++ b/nemo_curator/models/asr/qwen_asr.py
@@ -35,7 +35,7 @@ from huggingface_hub import snapshot_download
 from loguru import logger
 
 from nemo_curator.models.asr.base import ASRResult
-from nemo_curator.utils.vllm_utils import validate_vllm_kwargs
+from nemo_curator.utils.vllm_utils import merge_vllm_kwargs, validate_vllm_kwargs
 
 _DEFAULT_QWEN3_ASR_MODEL = "Qwen/Qwen3-ASR-0.6B"
 
@@ -43,20 +43,6 @@ _DEFAULT_QWEN3_ASR_MODEL = "Qwen/Qwen3-ASR-0.6B"
 # (100 ms at 16 kHz) is a conservative floor that also matches the Qwen-Omni
 # preprocessing path.
 _MIN_SAMPLES = 1600
-
-_RESERVED_VLLM_KWARGS = frozenset(
-    {
-        "model",
-        "revision",
-        "gpu_memory_utilization",
-        "max_inference_batch_size",
-        "max_new_tokens",
-        "trust_remote_code",
-        "enforce_eager",
-        "enable_prefix_caching",
-        "prefix_caching_hash_algo",
-    }
-)
 
 
 def _qwen_asr_model_cls() -> Any:  # noqa: ANN401
@@ -145,9 +131,23 @@ class QwenASRAdapter:
         self.vllm_kwargs = deepcopy(dict(self.vllm_kwargs))
         validate_vllm_kwargs(
             self.vllm_kwargs,
-            _RESERVED_VLLM_KWARGS,
+            self._model_owned_vllm_kwargs(),
             owner_description="adapter-owned arguments",
         )
+
+    def _model_owned_vllm_kwargs(self) -> dict[str, Any]:
+        """Return the qwen-asr constructor arguments owned by this adapter."""
+        return {
+            "model": self.model_id,
+            "revision": self.revision,
+            "gpu_memory_utilization": self.gpu_memory_utilization,
+            "max_inference_batch_size": self.max_inference_batch_size,
+            "max_new_tokens": self.max_new_tokens,
+            "trust_remote_code": True,
+            "enforce_eager": True,
+            "enable_prefix_caching": True,
+            "prefix_caching_hash_algo": "xxhash",
+        }
 
     @classmethod
     def download_weights_on_node(cls, model_id: str, revision: str | None = None) -> None:
@@ -169,21 +169,13 @@ class QwenASRAdapter:
             self.max_new_tokens,
             self.max_inference_batch_size,
         )
-        model_kwargs = deepcopy(self.vllm_kwargs)
-        model_kwargs.update(
-            {
-                "model": self.model_id,
-                "gpu_memory_utilization": self.gpu_memory_utilization,
-                "max_inference_batch_size": self.max_inference_batch_size,
-                "max_new_tokens": self.max_new_tokens,
-                "trust_remote_code": True,
-                "enforce_eager": True,
-                "enable_prefix_caching": True,
-                "prefix_caching_hash_algo": "xxhash",
-            }
+        model_kwargs = merge_vllm_kwargs(
+            self.vllm_kwargs,
+            self._model_owned_vllm_kwargs(),
+            owner_description="adapter-owned arguments",
         )
-        if self.revision is not None:
-            model_kwargs["revision"] = self.revision
+        if model_kwargs["revision"] is None:
+            del model_kwargs["revision"]
         _patch_transformers_compat()
         try:
             self._model = _qwen_asr_model_cls().LLM(**model_kwargs)

--- a/nemo_curator/models/asr/qwen_omni.py
+++ b/nemo_curator/models/asr/qwen_omni.py
@@ -27,7 +27,7 @@ from huggingface_hub import snapshot_download
 from loguru import logger
 
 from nemo_curator.models.asr.base import ASRResult
-from nemo_curator.utils.vllm_utils import create_vllm_llm, merge_vllm_kwargs, validate_vllm_kwargs
+from nemo_curator.utils.vllm_utils import create_vllm_llm, merge_vllm_kwargs
 
 if TYPE_CHECKING:
     import numpy as np
@@ -153,11 +153,6 @@ class QwenOmniASRAdapter:
             raise ValueError(msg)
         self.vllm_kwargs = deepcopy(dict(self.vllm_kwargs))
         self.sampling_kwargs = deepcopy(dict(self.sampling_kwargs))
-        validate_vllm_kwargs(
-            self.vllm_kwargs,
-            self._stage_owned_vllm_kwargs(num_gpus=None),
-            owner_description="stage-owned arguments",
-        )
         if "max_tokens" in self.sampling_kwargs:
             msg = "sampling_kwargs cannot override adapter-owned max_tokens; use max_output_tokens"
             raise ValueError(msg)

--- a/nemo_curator/models/asr/qwen_omni.py
+++ b/nemo_curator/models/asr/qwen_omni.py
@@ -27,7 +27,7 @@ from huggingface_hub import snapshot_download
 from loguru import logger
 
 from nemo_curator.models.asr.base import ASRResult
-from nemo_curator.utils.vllm_utils import create_vllm_llm
+from nemo_curator.utils.vllm_utils import create_vllm_llm, validate_vllm_kwargs
 
 if TYPE_CHECKING:
     import numpy as np
@@ -154,10 +154,11 @@ class QwenOmniASRAdapter:
             raise ValueError(msg)
         self.vllm_kwargs = deepcopy(dict(self.vllm_kwargs))
         self.sampling_kwargs = deepcopy(dict(self.sampling_kwargs))
-        reserved_vllm_kwargs = sorted(_RESERVED_VLLM_KWARGS.intersection(self.vllm_kwargs))
-        if reserved_vllm_kwargs:
-            msg = f"vllm_kwargs cannot override stage-owned arguments: {', '.join(reserved_vllm_kwargs)}"
-            raise ValueError(msg)
+        validate_vllm_kwargs(
+            self.vllm_kwargs,
+            _RESERVED_VLLM_KWARGS,
+            owner_description="stage-owned arguments",
+        )
         if "max_tokens" in self.sampling_kwargs:
             msg = "sampling_kwargs cannot override adapter-owned max_tokens; use max_output_tokens"
             raise ValueError(msg)

--- a/nemo_curator/models/asr/qwen_omni.py
+++ b/nemo_curator/models/asr/qwen_omni.py
@@ -27,7 +27,7 @@ from huggingface_hub import snapshot_download
 from loguru import logger
 
 from nemo_curator.models.asr.base import ASRResult
-from nemo_curator.utils.vllm_utils import create_vllm_llm, validate_vllm_kwargs
+from nemo_curator.utils.vllm_utils import create_vllm_llm, merge_vllm_kwargs, validate_vllm_kwargs
 
 if TYPE_CHECKING:
     import numpy as np
@@ -70,7 +70,6 @@ _QWEN3_OMNI_MODEL_ID = "Qwen/Qwen3-Omni-30B-A3B-Instruct"
 _QWEN_OMNI_SAMPLE_RATE = 16000
 _MIN_QWEN_AUDIO_SAMPLES = 1600
 _PROMPT_CONTENT_ORDERS = frozenset({"text_audio", "audio_text"})
-_RESERVED_VLLM_KWARGS = frozenset({"model", "revision", "tensor_parallel_size"})
 
 
 def _default_vllm_kwargs() -> dict[str, Any]:
@@ -156,7 +155,7 @@ class QwenOmniASRAdapter:
         self.sampling_kwargs = deepcopy(dict(self.sampling_kwargs))
         validate_vllm_kwargs(
             self.vllm_kwargs,
-            _RESERVED_VLLM_KWARGS,
+            self._stage_owned_vllm_kwargs(num_gpus=None),
             owner_description="stage-owned arguments",
         )
         if "max_tokens" in self.sampling_kwargs:
@@ -166,6 +165,14 @@ class QwenOmniASRAdapter:
         self._processor: Any = None
         self._llm: Any = None
         self._sampling_params: Any = None
+
+    def _stage_owned_vllm_kwargs(self, *, num_gpus: int | None) -> dict[str, Any]:
+        """Return vLLM constructor arguments supplied by the stage contract."""
+        return {
+            "model": self.model_id,
+            "revision": self.revision,
+            "tensor_parallel_size": num_gpus,
+        }
 
     @staticmethod
     def _load_text(text: str | None, file_path: str | None) -> str | None:
@@ -207,10 +214,14 @@ class QwenOmniASRAdapter:
             + (f"  revision={self.revision}" if self.revision is not None else "")
         )
 
-        engine_kwargs = dict(self.vllm_kwargs)
-        engine_kwargs["tensor_parallel_size"] = num_gpus
-        if self.revision is not None:
-            engine_kwargs["revision"] = self.revision
+        engine_kwargs = merge_vllm_kwargs(
+            self.vllm_kwargs,
+            self._stage_owned_vllm_kwargs(num_gpus=num_gpus),
+            owner_description="stage-owned arguments",
+        )
+        del engine_kwargs["model"]
+        if engine_kwargs["revision"] is None:
+            del engine_kwargs["revision"]
 
         try:
             proc_kwargs: dict[str, Any] = {}

--- a/nemo_curator/stages/audio/inference/asr/stage.py
+++ b/nemo_curator/stages/audio/inference/asr/stage.py
@@ -27,6 +27,7 @@ from typing import TYPE_CHECKING, Any
 
 import hydra.utils
 import numpy as np
+import soundfile
 import torch
 import torchaudio
 from loguru import logger
@@ -112,8 +113,9 @@ def _set_note(task_data: dict[str, Any], stage_name: str, value: str) -> None:
 class ASRStage(ProcessingStage[AudioTask, AudioTask]):
     """Audio speech-recognition stage with a pluggable adapter.
 
-    The stage writes only ``pred_text_key`` plus the optional control columns
-    ``_skipme`` and ``additional_notes``.
+    The stage writes ``pred_text_key`` and optional control columns ``_skipme``
+    and ``additional_notes``. When ``extras_key`` is configured, it also writes
+    non-empty adapter metadata as one nested dictionary under that key.
     """
 
     # Adapter selection.
@@ -132,6 +134,7 @@ class ASRStage(ProcessingStage[AudioTask, AudioTask]):
     default_language: str | None = None
     supported_language_codes: list[str] | None = None
     pred_text_key: str = "pred_text"
+    extras_key: str | None = None
 
     skip_if_output_exists: bool = False
 
@@ -149,6 +152,14 @@ class ASRStage(ProcessingStage[AudioTask, AudioTask]):
         if self.pred_text_key in {_SKIP_ME_KEY, _NOTES_KEY}:
             msg = f"ASRStage.pred_text_key cannot use reserved control column {self.pred_text_key!r}"
             raise ValueError(msg)
+        if self.extras_key is not None:
+            self.extras_key = self.extras_key.strip()
+            if not self.extras_key:
+                msg = "ASRStage.extras_key must be non-empty or None"
+                raise ValueError(msg)
+            if self.extras_key in {self.pred_text_key, _SKIP_ME_KEY, _NOTES_KEY}:
+                msg = f"ASRStage.extras_key cannot collide with another output column: {self.extras_key!r}"
+                raise ValueError(msg)
         if int(self.batch_size) <= 0:
             msg = f"ASRStage.batch_size must be > 0, got {self.batch_size}"
             raise ValueError(msg)
@@ -236,7 +247,10 @@ class ASRStage(ProcessingStage[AudioTask, AudioTask]):
         return [], [self.audio_filepath_key]
 
     def outputs(self) -> tuple[list[str], list[str]]:
-        return [], [self.pred_text_key, _SKIP_ME_KEY, _NOTES_KEY]
+        optional_outputs = [self.pred_text_key, _SKIP_ME_KEY, _NOTES_KEY]
+        if self.extras_key is not None:
+            optional_outputs.append(self.extras_key)
+        return [], optional_outputs
 
     def _resolve_language(self, task: AudioTask) -> str | None:
         code = self._resolve_language_code(task)
@@ -278,11 +292,15 @@ class ASRStage(ProcessingStage[AudioTask, AudioTask]):
     def _load_audio(audio_filepath: str) -> tuple[np.ndarray, int]:
         """Open one resampled file inside the ASR worker.
 
-        ``ResampleAudioStage`` guarantees mono audio, so squeezing its channel
-        dimension matches the file-backed tagging pipeline contract.
+        ``soundfile`` avoids making PCM WAV decoding depend on TorchCodec's
+        optional CUDA/FFmpeg shared libraries. SoundFile returns multichannel
+        audio as sample-major, so transpose it to the channel-first shape used
+        by ``_prepare_waveform``.
         """
-        waveform, sample_rate = torchaudio.load(audio_filepath)
-        return waveform.squeeze(0).numpy(), sample_rate
+        waveform, sample_rate = soundfile.read(audio_filepath, dtype="float32")
+        if waveform.ndim == _CHANNEL_FIRST_DIMENSIONS:
+            waveform = waveform.T
+        return np.ascontiguousarray(waveform, dtype=np.float32), sample_rate
 
     def _prepare_waveform(self, waveform: object, sample_rate: object) -> np.ndarray:
         """Return contiguous mono float32 samples at ``target_sample_rate``."""
@@ -429,6 +447,11 @@ class ASRStage(ProcessingStage[AudioTask, AudioTask]):
         skipped_count = 0
         for task, item, result in zip(tasks, items, results, strict=True):
             task.data[self.pred_text_key] = result.text
+            if self.extras_key is not None:
+                if result.extras:
+                    task.data[self.extras_key] = dict(result.extras)
+                else:
+                    task.data.pop(self.extras_key, None)
             unsupported_language = result.unsupported_language
             missing_language = self._supported_language_codes is not None and not item["language_code"]
             if missing_language:

--- a/nemo_curator/utils/vllm_utils.py
+++ b/nemo_curator/utils/vllm_utils.py
@@ -28,6 +28,7 @@ utilities into other modalities.
 
 from __future__ import annotations
 
+from copy import deepcopy
 from typing import TYPE_CHECKING
 
 from loguru import logger
@@ -68,6 +69,28 @@ def validate_vllm_kwargs(
     if conflicts:
         msg = f"vllm_kwargs cannot override {owner_description}: {', '.join(conflicts)}"
         raise ValueError(msg)
+
+
+def merge_vllm_kwargs(
+    vllm_kwargs: Mapping[str, object],
+    owned_kwargs: Mapping[str, object],
+    *,
+    owner_description: str,
+) -> dict[str, object]:
+    """Merge caller-owned vLLM arguments with user-provided engine options.
+
+    Callers describe the keyword arguments they own by passing the actual
+    ``owned_kwargs`` mapping. This keeps collision handling generic while the
+    owner-specific values remain next to the call that constructs the engine.
+    """
+    validate_vllm_kwargs(
+        vllm_kwargs,
+        owned_kwargs,
+        owner_description=owner_description,
+    )
+    merged_kwargs = deepcopy(dict(vllm_kwargs))
+    merged_kwargs.update(owned_kwargs)
+    return merged_kwargs
 
 
 def _exception_chain_text(exc: BaseException) -> str:

--- a/nemo_curator/utils/vllm_utils.py
+++ b/nemo_curator/utils/vllm_utils.py
@@ -28,7 +28,12 @@ utilities into other modalities.
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from loguru import logger
+
+if TYPE_CHECKING:
+    from collections.abc import Collection, Mapping
 
 # Errors that should not be retried. Add entries here when vLLM exposes
 # other fatal startup errors through generic EngineCore wrapper messages.
@@ -50,6 +55,19 @@ _ENGINE_STARTUP_FAILURE_MARKERS = (
     "engine core initialization failed",
     "enginecore failed to start",
 )
+
+
+def validate_vllm_kwargs(
+    vllm_kwargs: Mapping[str, object],
+    reserved_keys: Collection[str],
+    *,
+    owner_description: str,
+) -> None:
+    """Reject vLLM kwargs that override arguments owned by the caller."""
+    conflicts = sorted(set(vllm_kwargs).intersection(reserved_keys))
+    if conflicts:
+        msg = f"vllm_kwargs cannot override {owner_description}: {', '.join(conflicts)}"
+        raise ValueError(msg)
 
 
 def _exception_chain_text(exc: BaseException) -> str:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -135,6 +135,8 @@ audio_cuda12 = [
     "nemo_curator[cuda12]",
     "nvidia-cudnn-cu12",
     "onnxruntime-gpu>=1.20.1,<1.24; platform_machine == 'x86_64'",
+    # Do not use qwen-asr[vllm], whose vLLM 0.14.0 pin conflicts with Curator's shared vLLM version.
+    "qwen-asr==0.0.6; platform_machine == 'x86_64' and platform_system != 'Darwin'",
     "qwen-omni-utils>=0.0.9",
     "torchcodec; platform_machine == 'x86_64' and platform_system != 'Darwin'",
 ]

--- a/tests/config/test_run.py
+++ b/tests/config/test_run.py
@@ -438,6 +438,7 @@ def test_qwen_tutorial_yaml_matches_reference_runner_config():
     assert stage.audio_filepath_key == "resampled_audio_filepath"
     assert stage.inputs()[1] == ["resampled_audio_filepath"]
     assert stage.pred_text_key == "custom_prediction"
+    assert stage.extras_key is None
     assert stage.outputs() == ([], ["custom_prediction", "_skipme", "additional_notes"])
     assert stage.default_language is None
     assert stage.supported_language_codes == [
@@ -491,6 +492,81 @@ def test_qwen_tutorial_yaml_matches_reference_runner_config():
             "top_k": 1,
             "repetition_penalty": 1.0,
         },
+    }
+    assert executor.__class__.__name__ == "RayDataExecutor"
+    assert executor.config == {}
+
+
+def test_qwen_asr_tutorial_yaml_uses_generic_adapter_contract():
+    config_dir = Path(__file__).parents[2] / "tutorials" / "audio" / "qwen_asr"
+    with initialize_config_dir(config_dir=str(config_dir), version_base=None):
+        cfg = compose(
+            config_name="pipeline",
+            overrides=[
+                "manifest_path=tests/fixtures/audio/tagging/sample_input.jsonl",
+                "pred_text_key=custom_prediction",
+            ],
+        )
+
+    pipeline = create_pipeline_from_yaml(cfg, log_config=False)
+    resample_stage = pipeline.stages[1]
+    stage = pipeline.stages[2]
+    executor = create_executor_from_yaml(cfg)
+
+    assert resample_stage.__class__.__name__ == "ResampleAudioStage"
+    assert "sample_rate" not in cfg
+    assert Path(resample_stage.resampled_audio_dir).parts[-2:] == ("qwen_asr_workspace", "audio_resampled")
+    assert resample_stage.target_sample_rate == 16000
+    assert resample_stage.target_format == "wav"
+    assert resample_stage.target_nchannels == 1
+    assert stage.audio_filepath_key == "resampled_audio_filepath"
+    assert stage.inputs()[1] == ["resampled_audio_filepath"]
+    assert stage.pred_text_key == "custom_prediction"
+    assert stage.extras_key == "asr_extras"
+    assert stage.outputs() == (
+        [],
+        ["custom_prediction", "_skipme", "additional_notes", "asr_extras"],
+    )
+    assert stage.default_language is None
+    assert stage.supported_language_codes == [
+        "zh",
+        "en",
+        "yue",
+        "ar",
+        "de",
+        "fr",
+        "es",
+        "pt",
+        "id",
+        "it",
+        "ko",
+        "ru",
+        "th",
+        "vi",
+        "ja",
+        "tr",
+        "hi",
+        "ms",
+        "nl",
+        "sv",
+        "da",
+        "fi",
+        "pl",
+        "cs",
+        "fil",
+        "fa",
+        "el",
+        "hu",
+        "mk",
+        "ro",
+    ]
+    assert stage.batch_size == 128
+    assert stage.resources.gpus == 1
+    assert dict(stage.adapter_kwargs) == {
+        "gpu_memory_utilization": 0.7,
+        "max_new_tokens": 4096,
+        "max_inference_batch_size": 128,
+        "vllm_kwargs": {"max_model_len": 8192},
     }
     assert executor.__class__.__name__ == "RayDataExecutor"
     assert executor.config == {}

--- a/tests/gpu_test_groups.json
+++ b/tests/gpu_test_groups.json
@@ -19,6 +19,10 @@
     "extras": ["audio_cuda12"],
     "paths": ["tests/stages/audio"]
   },
+  "audio_qwen_asr": {
+    "extras": ["audio_cuda12", "vllm"],
+    "paths": ["tests/models/asr/test_qwen_asr.py"]
+  },
   "audio_qwen_vllm": {
     "extras": ["audio_cuda12", "vllm"],
     "paths": ["tests/models/asr/test_qwen_omni_gpu.py"]

--- a/tests/models/asr/test_package_lazy_import.py
+++ b/tests/models/asr/test_package_lazy_import.py
@@ -25,9 +25,13 @@ if TYPE_CHECKING:
 
 
 def test_importing_asr_subpackage_does_not_load_concrete_adapters(monkeypatch: pytest.MonkeyPatch) -> None:
-    """The package init must not pull in the concrete ASR implementation."""
+    """The package init must not pull in either concrete Qwen adapter."""
     original_import = builtins.__import__
     blocked: list[str] = []
+    concrete_modules = {
+        "nemo_curator.models.asr.qwen_asr",
+        "nemo_curator.models.asr.qwen_omni",
+    }
 
     def tracking_import(
         name: str,
@@ -36,7 +40,7 @@ def test_importing_asr_subpackage_does_not_load_concrete_adapters(monkeypatch: p
         fromlist: tuple[str, ...] = (),
         level: int = 0,
     ) -> object:
-        if name == "nemo_curator.models.asr.qwen_omni":
+        if name in concrete_modules:
             blocked.append(name)
             msg = f"blocked eager import of {name}"
             raise ImportError(msg)
@@ -47,6 +51,7 @@ def test_importing_asr_subpackage_does_not_load_concrete_adapters(monkeypatch: p
     module_names = {
         "nemo_curator.models.asr",
         "nemo_curator.models.asr.base",
+        "nemo_curator.models.asr.qwen_asr",
         "nemo_curator.models.asr.qwen_omni",
     }
     saved_modules = {name: sys.modules.get(name) for name in module_names}
@@ -57,6 +62,7 @@ def test_importing_asr_subpackage_does_not_load_concrete_adapters(monkeypatch: p
         import nemo_curator.models.asr as asr_pkg
 
         assert blocked == []
+        assert "QwenASRAdapter" not in vars(asr_pkg)
         assert "QwenOmniASRAdapter" not in vars(asr_pkg)
     finally:
         for mod_name in module_names:
@@ -66,9 +72,12 @@ def test_importing_asr_subpackage_does_not_load_concrete_adapters(monkeypatch: p
                 sys.modules[mod_name] = module
 
 
-def test_hydra_resolves_qwen_adapter_from_module_path() -> None:
+def test_hydra_resolves_both_qwen_adapters_from_module_paths() -> None:
     import hydra.utils
 
-    adapter_cls = hydra.utils.get_class("nemo_curator.models.asr.qwen_omni.QwenOmniASRAdapter")
-
-    assert adapter_cls.__name__ == "QwenOmniASRAdapter"
+    targets = {
+        "nemo_curator.models.asr.qwen_asr.QwenASRAdapter": "QwenASRAdapter",
+        "nemo_curator.models.asr.qwen_omni.QwenOmniASRAdapter": "QwenOmniASRAdapter",
+    }
+    for target, expected_name in targets.items():
+        assert hydra.utils.get_class(target).__name__ == expected_name

--- a/tests/models/asr/test_qwen_asr.py
+++ b/tests/models/asr/test_qwen_asr.py
@@ -27,7 +27,7 @@ import pytest
 import torch
 
 from nemo_curator.models.asr.base import ASRAdapter
-from nemo_curator.models.asr.qwen_asr import _MIN_SAMPLES, QwenASRAdapter, _patch_transformers_compat
+from nemo_curator.models.asr.qwen_asr import _MIN_SAMPLES, QwenASRAdapter
 from nemo_curator.stages.audio.inference.asr.stage import ASRStage
 from nemo_curator.tasks import AudioTask
 
@@ -107,17 +107,7 @@ def test_qwen_adapter_copies_nested_vllm_kwargs() -> None:
 
 @pytest.mark.parametrize(
     "reserved_key",
-    [
-        "model",
-        "revision",
-        "gpu_memory_utilization",
-        "max_inference_batch_size",
-        "max_new_tokens",
-        "trust_remote_code",
-        "enforce_eager",
-        "enable_prefix_caching",
-        "prefix_caching_hash_algo",
-    ],
+    QwenASRAdapter()._model_owned_vllm_kwargs(),
 )
 def test_qwen_adapter_rejects_adapter_owned_vllm_kwargs(reserved_key: str) -> None:
     adapter = QwenASRAdapter(vllm_kwargs={reserved_key: object()})
@@ -188,34 +178,6 @@ def test_load_model_forwards_additional_vllm_kwargs() -> None:
         adapter.load_model(num_gpus=1)
 
     assert model_cls.LLM.call_args.kwargs["max_model_len"] == 8192
-
-
-def test_load_model_applies_nkoluguri_transformers_compat_patch() -> None:
-    model_cls = MagicMock()
-    adapter = QwenASRAdapter()
-
-    with (
-        patch("nemo_curator.models.asr.qwen_asr._patch_transformers_compat") as compat,
-        patch("nemo_curator.models.asr.qwen_asr._qwen_asr_model_cls", return_value=model_cls),
-    ):
-        adapter.load_model(num_gpus=1)
-
-    compat.assert_called_once_with()
-
-
-def test_transformers_compat_wraps_plain_decorator_for_factory_syntax() -> None:
-    def plain_decorator(func):  # noqa: ANN001, ANN202
-        return func
-
-    transformers_stub = SimpleNamespace(check_model_inputs=plain_decorator)
-    with patch("nemo_curator.models.asr.qwen_asr.transformers", transformers_stub):
-        _patch_transformers_compat()
-
-    def decorated() -> str:
-        return "ok"
-
-    assert transformers_stub.check_model_inputs()(decorated)() == "ok"
-    assert transformers_stub.check_model_inputs(decorated)() == "ok"
 
 
 def test_load_model_without_qwen_asr_names_required_extras() -> None:

--- a/tests/models/asr/test_qwen_asr.py
+++ b/tests/models/asr/test_qwen_asr.py
@@ -120,8 +120,10 @@ def test_qwen_adapter_copies_nested_vllm_kwargs() -> None:
     ],
 )
 def test_qwen_adapter_rejects_adapter_owned_vllm_kwargs(reserved_key: str) -> None:
+    adapter = QwenASRAdapter(vllm_kwargs={reserved_key: object()})
+
     with pytest.raises(ValueError, match="cannot override adapter-owned arguments"):
-        QwenASRAdapter(vllm_kwargs={reserved_key: object()})
+        adapter.load_model(num_gpus=1)
 
 
 def test_download_weights_on_node_downloads_snapshot_without_constructing_model() -> None:

--- a/tests/models/asr/test_qwen_asr.py
+++ b/tests/models/asr/test_qwen_asr.py
@@ -1,0 +1,461 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the Qwen3-ASR implementation of the shared ASR adapter."""
+
+from __future__ import annotations
+
+import inspect
+import wave
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import pytest
+import torch
+
+from nemo_curator.models.asr.base import ASRAdapter
+from nemo_curator.models.asr.qwen_asr import _MIN_SAMPLES, QwenASRAdapter, _patch_transformers_compat
+from nemo_curator.stages.audio.inference.asr.stage import ASRStage
+from nemo_curator.tasks import AudioTask
+
+_MODEL_ID = "Qwen/Qwen3-ASR-0.6B"
+_SAMPLE_RATE = 16_000
+_FIXTURE_PATH = Path(__file__).parents[2] / "fixtures/audio/qwen_omni/audio_1_5s_16khz_mono.wav"
+
+
+def _item(
+    samples: int = _SAMPLE_RATE,
+    *,
+    sample_rate: int = _SAMPLE_RATE,
+    language: str | None = None,
+) -> dict[str, object]:
+    return {
+        "waveform": np.zeros(samples, dtype=np.float32),
+        "sample_rate": sample_rate,
+        "audio_seconds": (float(samples) / float(sample_rate)) if sample_rate else 0.0,
+        "language": language,
+    }
+
+
+def _mock_model(texts: list[str], languages: list[str] | None = None) -> MagicMock:
+    langs = languages if languages is not None else [""] * len(texts)
+    model = MagicMock()
+    model.transcribe.return_value = [
+        SimpleNamespace(text=text, language=lang) for text, lang in zip(texts, langs, strict=True)
+    ]
+    return model
+
+
+def _adapter_with_model(model: MagicMock) -> QwenASRAdapter:
+    adapter = QwenASRAdapter()
+    adapter._model = model
+    return adapter
+
+
+def test_qwen_adapter_conforms_to_asr_protocol() -> None:
+    assert isinstance(QwenASRAdapter(), ASRAdapter)
+
+
+def test_qwen_adapter_default_checkpoint() -> None:
+    assert QwenASRAdapter().model_id == "Qwen/Qwen3-ASR-0.6B"
+
+
+def test_qwen_adapter_rejects_empty_model_id() -> None:
+    with pytest.raises(ValueError, match="model_id must be non-empty"):
+        QwenASRAdapter(model_id="")
+
+
+@pytest.mark.parametrize("utilization", [0.0, -0.1, 1.5])
+def test_qwen_adapter_rejects_out_of_range_gpu_utilization(utilization: float) -> None:
+    with pytest.raises(ValueError, match="gpu_memory_utilization must be in"):
+        QwenASRAdapter(gpu_memory_utilization=utilization)
+
+
+@pytest.mark.parametrize("max_new_tokens", [0, -1, 1.5, True])
+def test_qwen_adapter_rejects_invalid_max_new_tokens(max_new_tokens: object) -> None:
+    with pytest.raises(ValueError, match="max_new_tokens must be a positive integer"):
+        QwenASRAdapter(max_new_tokens=max_new_tokens)  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize("max_inference_batch_size", [0, -1, 1.5, True])
+def test_qwen_adapter_rejects_invalid_inference_batch_size(max_inference_batch_size: object) -> None:
+    with pytest.raises(ValueError, match="max_inference_batch_size must be a positive integer"):
+        QwenASRAdapter(max_inference_batch_size=max_inference_batch_size)  # type: ignore[arg-type]
+
+
+def test_qwen_adapter_copies_nested_vllm_kwargs() -> None:
+    vllm_kwargs = {"compilation_config": {"cudagraph_mode": "NONE"}}
+
+    adapter = QwenASRAdapter(vllm_kwargs=vllm_kwargs)
+    vllm_kwargs["compilation_config"]["cudagraph_mode"] = "FULL"
+
+    assert adapter.vllm_kwargs == {"compilation_config": {"cudagraph_mode": "NONE"}}
+
+
+@pytest.mark.parametrize(
+    "reserved_key",
+    [
+        "model",
+        "revision",
+        "gpu_memory_utilization",
+        "max_inference_batch_size",
+        "max_new_tokens",
+        "trust_remote_code",
+        "enforce_eager",
+        "enable_prefix_caching",
+        "prefix_caching_hash_algo",
+    ],
+)
+def test_qwen_adapter_rejects_adapter_owned_vllm_kwargs(reserved_key: str) -> None:
+    with pytest.raises(ValueError, match="cannot override adapter-owned arguments"):
+        QwenASRAdapter(vllm_kwargs={reserved_key: object()})
+
+
+def test_download_weights_on_node_downloads_snapshot_without_constructing_model() -> None:
+    with patch("nemo_curator.models.asr.qwen_asr.snapshot_download") as snapshot_download:
+        QwenASRAdapter.download_weights_on_node("Qwen/Qwen3-ASR-0.6B", "abc123")
+    snapshot_download.assert_called_once_with("Qwen/Qwen3-ASR-0.6B", revision="abc123")
+
+
+@pytest.mark.parametrize("num_gpus", [0, -1, 2, 1.5, True])
+def test_load_model_requires_exactly_one_integer_gpu(num_gpus: object) -> None:
+    adapter = QwenASRAdapter()
+
+    with pytest.raises(ValueError, match="requires exactly one integer GPU"):
+        adapter.load_model(num_gpus=num_gpus)  # type: ignore[arg-type]
+
+
+def test_load_model_builds_one_worker_local_model_and_is_idempotent() -> None:
+    model_cls = MagicMock()
+    adapter = QwenASRAdapter(max_inference_batch_size=64, max_new_tokens=256)
+
+    with patch("nemo_curator.models.asr.qwen_asr._qwen_asr_model_cls", return_value=model_cls):
+        adapter.load_model(num_gpus=1)
+        adapter.load_model(num_gpus=1)
+
+    model_cls.LLM.assert_called_once()
+    kwargs = model_cls.LLM.call_args.kwargs
+    assert kwargs["model"] == "Qwen/Qwen3-ASR-0.6B"
+    assert kwargs["gpu_memory_utilization"] == 0.7
+    assert kwargs["max_inference_batch_size"] == 64
+    assert kwargs["max_new_tokens"] == 256
+    assert kwargs["trust_remote_code"] is True
+    assert kwargs["enforce_eager"] is True
+    assert kwargs["enable_prefix_caching"] is True
+    assert kwargs["prefix_caching_hash_algo"] == "xxhash"
+
+
+def test_load_model_forwards_gpu_utilization_to_vllm() -> None:
+    model_cls = MagicMock()
+    adapter = QwenASRAdapter(gpu_memory_utilization=0.75)
+
+    with patch("nemo_curator.models.asr.qwen_asr._qwen_asr_model_cls", return_value=model_cls):
+        adapter.load_model(num_gpus=1)
+
+    assert model_cls.LLM.call_args.kwargs["gpu_memory_utilization"] == 0.75
+
+
+def test_load_model_forwards_revision() -> None:
+    model_cls = MagicMock()
+    adapter = QwenASRAdapter(revision="abc123")
+
+    with patch("nemo_curator.models.asr.qwen_asr._qwen_asr_model_cls", return_value=model_cls):
+        adapter.load_model(num_gpus=1)
+
+    assert model_cls.LLM.call_args.kwargs["revision"] == "abc123"
+
+
+def test_load_model_forwards_additional_vllm_kwargs() -> None:
+    model_cls = MagicMock()
+    adapter = QwenASRAdapter(vllm_kwargs={"max_model_len": 8192})
+
+    with patch("nemo_curator.models.asr.qwen_asr._qwen_asr_model_cls", return_value=model_cls):
+        adapter.load_model(num_gpus=1)
+
+    assert model_cls.LLM.call_args.kwargs["max_model_len"] == 8192
+
+
+def test_load_model_applies_nkoluguri_transformers_compat_patch() -> None:
+    model_cls = MagicMock()
+    adapter = QwenASRAdapter()
+
+    with (
+        patch("nemo_curator.models.asr.qwen_asr._patch_transformers_compat") as compat,
+        patch("nemo_curator.models.asr.qwen_asr._qwen_asr_model_cls", return_value=model_cls),
+    ):
+        adapter.load_model(num_gpus=1)
+
+    compat.assert_called_once_with()
+
+
+def test_transformers_compat_wraps_plain_decorator_for_factory_syntax() -> None:
+    def plain_decorator(func):  # noqa: ANN001, ANN202
+        return func
+
+    transformers_stub = SimpleNamespace(check_model_inputs=plain_decorator)
+    with patch("nemo_curator.models.asr.qwen_asr.transformers", transformers_stub):
+        _patch_transformers_compat()
+
+    def decorated() -> str:
+        return "ok"
+
+    assert transformers_stub.check_model_inputs()(decorated)() == "ok"
+    assert transformers_stub.check_model_inputs(decorated)() == "ok"
+
+
+def test_load_model_without_qwen_asr_names_required_extras() -> None:
+    adapter = QwenASRAdapter()
+    with (
+        patch.dict("sys.modules", {"qwen_asr": None}),
+        pytest.raises(ImportError, match="audio_cuda12 and vllm"),
+    ):
+        adapter.load_model(num_gpus=1)
+
+
+def test_load_model_cleans_up_after_model_construction_failure() -> None:
+    model_cls = MagicMock()
+    model_cls.LLM.side_effect = RuntimeError("construction failed")
+    adapter = QwenASRAdapter()
+
+    with (
+        patch("nemo_curator.models.asr.qwen_asr._qwen_asr_model_cls", return_value=model_cls),
+        patch.object(adapter, "unload_model", wraps=adapter.unload_model) as unload_model,
+        pytest.raises(RuntimeError, match="construction failed"),
+    ):
+        adapter.load_model(num_gpus=1)
+
+    unload_model.assert_called_once_with()
+    assert adapter._model is None
+
+
+def test_unload_model_releases_the_model() -> None:
+    adapter = _adapter_with_model(_mock_model(["x"]))
+    adapter.unload_model()
+    assert adapter._model is None
+
+
+def test_transcribe_batch_uses_one_exact_transcribe_call() -> None:
+    model = _mock_model(["one", "two"])
+    adapter = _adapter_with_model(model)
+
+    results = adapter.transcribe_batch([_item(), _item()])
+
+    assert model.transcribe.call_count == 1
+    assert [r.text for r in results] == ["one", "two"]
+    assert all(r.skipped is False for r in results)
+    assert len(model.transcribe.call_args.kwargs["audio"]) == 2
+
+
+def test_transcribe_batch_returns_empty_for_empty_input() -> None:
+    adapter = _adapter_with_model(_mock_model([]))
+    assert adapter.transcribe_batch([]) == []
+
+
+def test_transcribe_batch_preserves_skipped_positions() -> None:
+    """A too-short row keeps its slot so the caller's 1:1 mapping survives."""
+    model = _mock_model(["only valid"])
+    adapter = _adapter_with_model(model)
+
+    results = adapter.transcribe_batch([_item(_MIN_SAMPLES - 1), _item()])
+
+    assert results[0].skipped is True
+    assert results[0].text == ""
+    assert results[1].skipped is False
+    assert results[1].text == "only valid"
+    assert len(model.transcribe.call_args.kwargs["audio"]) == 1
+
+
+def test_transcribe_batch_skips_rows_without_a_sample_rate() -> None:
+    model = _mock_model(["kept"])
+    adapter = _adapter_with_model(model)
+
+    results = adapter.transcribe_batch([_item(sample_rate=0), _item()])
+
+    assert [r.skipped for r in results] == [True, False]
+
+
+def test_transcribe_batch_returns_all_skipped_when_nothing_is_usable() -> None:
+    model = _mock_model([])
+    adapter = _adapter_with_model(model)
+
+    results = adapter.transcribe_batch([_item(_MIN_SAMPLES - 1), _item(10)])
+
+    assert [r.skipped for r in results] == [True, True]
+    model.transcribe.assert_not_called()
+
+
+def test_transcribe_batch_forwards_language_per_item() -> None:
+    model = _mock_model(["a", "b"])
+    adapter = _adapter_with_model(model)
+
+    adapter.transcribe_batch([_item(language="English"), _item(language="Spanish")])
+
+    assert model.transcribe.call_args.kwargs["language"] == ["English", "Spanish"]
+
+
+def test_transcribe_batch_reports_detected_language_in_extras() -> None:
+    model = _mock_model(["hola"], languages=["Spanish"])
+    adapter = _adapter_with_model(model)
+
+    results = adapter.transcribe_batch([_item()])
+
+    assert results[0].extras["detected_language"] == "Spanish"
+
+
+def test_transcribe_batch_omits_detected_language_when_absent() -> None:
+    model = _mock_model(["hi"], languages=[""])
+    adapter = _adapter_with_model(model)
+
+    results = adapter.transcribe_batch([_item()])
+
+    assert results[0].extras == {}
+
+
+@pytest.mark.parametrize("empty_text", ["", "   ", None])
+def test_transcribe_batch_marks_empty_outputs_skipped(empty_text: str | None) -> None:
+    model = MagicMock()
+    model.transcribe.return_value = [SimpleNamespace(text=empty_text, language="English")]
+    adapter = _adapter_with_model(model)
+
+    result = adapter.transcribe_batch([_item()])[0]
+
+    assert result.text == ("" if empty_text is None else empty_text)
+    assert result.skipped is True
+
+
+def test_transcribe_batch_rejects_output_count_mismatch() -> None:
+    model = _mock_model(["only one"])
+    adapter = _adapter_with_model(model)
+
+    with pytest.raises(RuntimeError, match="1 transcriptions for 2 valid inputs"):
+        adapter.transcribe_batch([_item(), _item()])
+
+
+def test_transcribe_batch_accepts_plain_string_outputs() -> None:
+    model = MagicMock()
+    model.transcribe.return_value = ["plain text"]
+    adapter = _adapter_with_model(model)
+
+    assert adapter.transcribe_batch([_item()])[0].text == "plain text"
+
+
+def test_asr_stage_drives_qwen_adapter_end_to_end() -> None:
+    model_cls = MagicMock()
+    model_cls.LLM.return_value = _mock_model(
+        ["one", "two"],
+        languages=["English", "Spanish"],
+    )
+    stage = ASRStage(
+        adapter_target="nemo_curator.models.asr.qwen_asr.QwenASRAdapter",
+        model_id="Qwen/Qwen3-ASR-0.6B",
+        batch_size=2,
+        waveform_key="waveform",
+        sample_rate_key="sample_rate",
+        extras_key="asr_extras",
+    )
+
+    with (
+        patch("hydra.utils.get_class", return_value=QwenASRAdapter),
+        patch("nemo_curator.models.asr.qwen_asr._qwen_asr_model_cls", return_value=model_cls),
+    ):
+        stage.setup()
+
+    tasks = [
+        AudioTask(data={"waveform": np.zeros(_SAMPLE_RATE), "sample_rate": _SAMPLE_RATE, "source_lang": "en"}),
+        AudioTask(data={"waveform": np.zeros(2 * _SAMPLE_RATE), "sample_rate": _SAMPLE_RATE, "source_lang": "es"}),
+    ]
+    results = stage.process_batch(tasks)
+
+    assert [task.data["pred_text"] for task in results] == ["one", "two"]
+    assert [task.data["asr_extras"] for task in results] == [
+        {"detected_language": "English"},
+        {"detected_language": "Spanish"},
+    ]
+    # The stage resolved ISO codes to the names the adapter forwards to Qwen.
+    assert model_cls.LLM.return_value.transcribe.call_args.kwargs["language"] == ["English", "Spanish"]
+
+
+def _load_short_fixture() -> np.ndarray:
+    """Decode Curator's bundled five-second, 16 kHz mono WAV."""
+    with wave.open(str(_FIXTURE_PATH), "rb") as wav_file:
+        assert wav_file.getframerate() == _SAMPLE_RATE
+        assert wav_file.getnchannels() == 1
+        assert wav_file.getsampwidth() == 2
+        assert wav_file.getnframes() == 5 * _SAMPLE_RATE
+        pcm = np.frombuffer(wav_file.readframes(wav_file.getnframes()), dtype="<i2")
+    return np.ascontiguousarray(pcm.astype(np.float32) / 32768.0)
+
+
+def _require_real_qwen_stack() -> type:
+    try:
+        from qwen_asr import Qwen3ASRModel
+    except ImportError as exc:
+        pytest.fail(f"The Qwen3-ASR GPU test environment is missing qwen-asr: {exc}")
+    return Qwen3ASRModel
+
+
+@pytest.mark.gpu
+def test_qwen_asr_real_package_api_contract() -> None:
+    """Exercise the external API surface that mocked CPU tests cannot validate."""
+    model_cls = _require_real_qwen_stack()
+
+    load_parameters = inspect.signature(model_cls.LLM).parameters
+    transcribe_parameters = inspect.signature(model_cls.transcribe).parameters
+
+    assert "model" in load_parameters
+    assert "max_inference_batch_size" in load_parameters
+    assert "max_new_tokens" in load_parameters
+    assert list(transcribe_parameters) == ["self", "audio", "context", "language", "return_time_stamps"]
+    assert callable(model_cls.LLM)
+
+
+@pytest.mark.gpu
+def test_qwen_asr_real_single_gpu_smoke() -> None:
+    """Load the real model through the adapter and transcribe one sample."""
+    _require_real_qwen_stack()
+    if torch.cuda.device_count() < 1:
+        pytest.fail("Qwen3-ASR smoke test requires one visible GPU")
+
+    adapter = QwenASRAdapter(
+        model_id=_MODEL_ID,
+        max_new_tokens=64,
+        max_inference_batch_size=1,
+        # The 12 GB local smoke-test GPU cannot allocate Qwen3-ASR's full
+        # 65,536-token default KV cache. Production/reference defaults remain
+        # unchanged because this is an explicit test-only engine override.
+        vllm_kwargs={"max_model_len": 8192},
+    )
+    adapter.load_model(num_gpus=1)
+    try:
+        assert adapter._model.max_inference_batch_size == 1
+        assert adapter._model.backend == "vllm"
+        results = adapter.transcribe_batch(
+            [
+                {
+                    "waveform": _load_short_fixture(),
+                    "sample_rate": _SAMPLE_RATE,
+                    "language": "English",
+                    "language_code": "en",
+                    "task_id": "qwen-asr-gpu-smoke",
+                }
+            ]
+        )
+    finally:
+        adapter.unload_model()
+
+    assert len(results) == 1
+    assert results[0].text.strip()
+    assert results[0].skipped is False

--- a/tests/models/asr/test_qwen_omni.py
+++ b/tests/models/asr/test_qwen_omni.py
@@ -119,8 +119,10 @@ def test_qwen_adapter_rejects_invalid_prompt_content_order() -> None:
 
 @pytest.mark.parametrize("reserved_key", ["model", "revision", "tensor_parallel_size"])
 def test_qwen_adapter_rejects_stage_owned_vllm_kwargs(reserved_key: str) -> None:
-    with pytest.raises(ValueError, match="cannot override stage-owned arguments"):
-        QwenOmniASRAdapter(model_id="mock/qwen-omni", vllm_kwargs={reserved_key: object()})
+    adapter = QwenOmniASRAdapter(model_id="mock/qwen-omni", vllm_kwargs={reserved_key: object()})
+
+    with _mock_qwen_model_load(), pytest.raises(ValueError, match="cannot override stage-owned arguments"):
+        adapter.load_model(num_gpus=1)
 
 
 def test_qwen_adapter_defaults_to_audio_only_multimodal_limits() -> None:

--- a/tests/models/asr/test_qwen_omni.py
+++ b/tests/models/asr/test_qwen_omni.py
@@ -117,6 +117,12 @@ def test_qwen_adapter_rejects_invalid_prompt_content_order() -> None:
         QwenOmniASRAdapter(model_id="mock/qwen-omni", prompt_content_order="invalid")
 
 
+@pytest.mark.parametrize("reserved_key", ["model", "revision", "tensor_parallel_size"])
+def test_qwen_adapter_rejects_stage_owned_vllm_kwargs(reserved_key: str) -> None:
+    with pytest.raises(ValueError, match="cannot override stage-owned arguments"):
+        QwenOmniASRAdapter(model_id="mock/qwen-omni", vllm_kwargs={reserved_key: object()})
+
+
 def test_qwen_adapter_defaults_to_audio_only_multimodal_limits() -> None:
     adapter = QwenOmniASRAdapter(model_id="mock/qwen-omni")
 

--- a/tests/stages/audio/inference/test_asr_stage.py
+++ b/tests/stages/audio/inference/test_asr_stage.py
@@ -18,7 +18,6 @@ from unittest.mock import MagicMock, patch
 
 import numpy as np
 import pytest
-import torch
 
 from nemo_curator.backends.base import BaseStageAdapter
 from nemo_curator.models.asr.base import ASRResult
@@ -39,6 +38,7 @@ def _make_stage(  # noqa: PLR0913
     skip_if_output_exists: bool = False,
     waveform_key: str | None = None,
     keep_waveform: bool = False,
+    extras_key: str | None = None,
 ) -> ASRStage:
     """Build an ASRStage wired to a mock adapter (no real model load)."""
     stage = ASRStage(
@@ -51,6 +51,7 @@ def _make_stage(  # noqa: PLR0913
         skip_if_output_exists=skip_if_output_exists,
         waveform_key=waveform_key,
         keep_waveform=keep_waveform,
+        extras_key=extras_key,
     )
     mock_adapter = MagicMock()
     stage._adapter = mock_adapter
@@ -298,6 +299,42 @@ def test_inputs_and_exact_output_contract() -> None:
     assert optional_outputs == ["custom_prediction", "_skipme", "additional_notes"]
 
 
+def test_adapter_extras_are_copied_to_one_nested_manifest_field() -> None:
+    stage = _make_stage(extras_key="asr_extras")
+    adapter_extras = {
+        "detected_language": "English",
+        "confidence": 0.98,
+        "segments": [{"start": 0.0, "end": 1.0}],
+    }
+    stage._adapter.transcribe_batch.return_value = [ASRResult(text="hello", extras=adapter_extras)]
+
+    result = stage.process_batch([_make_task()])[0]
+
+    assert result.data["asr_extras"] == adapter_extras
+    assert result.data["asr_extras"] is not adapter_extras
+
+
+def test_empty_adapter_extras_remove_stale_manifest_metadata() -> None:
+    stage = _make_stage(extras_key="asr_extras")
+    stage._adapter.transcribe_batch.return_value = [ASRResult(text="hello")]
+    task = _make_task()
+    task.data["asr_extras"] = {"stale": True}
+
+    result = stage.process_batch([task])[0]
+
+    assert "asr_extras" not in result.data
+
+
+def test_adapter_extras_output_can_be_disabled() -> None:
+    stage = _make_stage(extras_key=None)
+    stage._adapter.transcribe_batch.return_value = [ASRResult(text="hello", extras={"detected_language": "English"})]
+
+    result = stage.process_batch([_make_task()])[0]
+
+    assert "asr_extras" not in result.data
+    assert stage.outputs() == ([], ["pred_text", "_skipme", "additional_notes"])
+
+
 def test_in_memory_input_contract_requires_waveform_and_sample_rate() -> None:
     stage = ASRStage(
         adapter_target=_QWEN_ADAPTER_TARGET,
@@ -313,18 +350,31 @@ def test_in_memory_input_contract_requires_waveform_and_sample_rate() -> None:
 
 def test_stage_loads_resampled_audio_like_tagging_pipeline_and_preserves_sample_rate() -> None:
     decoded_sample_rate = 8000
-    tensor = torch.ones((1, _SR), dtype=torch.float32)
+    decoded = np.ones(_SR, dtype=np.float32)
     with patch(
-        "nemo_curator.stages.audio.inference.asr.stage.torchaudio.load",
-        return_value=(tensor, decoded_sample_rate),
+        "nemo_curator.stages.audio.inference.asr.stage.soundfile.read",
+        return_value=(decoded, decoded_sample_rate),
     ) as load:
         waveform, sample_rate = ASRStage._load_audio(_RESAMPLED_AUDIO_PATH)
 
-    load.assert_called_once_with(_RESAMPLED_AUDIO_PATH)
+    load.assert_called_once_with(_RESAMPLED_AUDIO_PATH, dtype="float32")
     assert sample_rate == decoded_sample_rate
     assert waveform.shape == (_SR,)
     assert waveform.dtype == np.float32
     np.testing.assert_array_equal(waveform, np.ones(_SR, dtype=np.float32))
+
+
+def test_stage_load_audio_transposes_soundfile_stereo_to_channel_first() -> None:
+    decoded = np.ones((_SR, 2), dtype=np.float32)
+    with patch(
+        "nemo_curator.stages.audio.inference.asr.stage.soundfile.read",
+        return_value=(decoded, _SR),
+    ):
+        waveform, sample_rate = ASRStage._load_audio(_RESAMPLED_AUDIO_PATH)
+
+    assert sample_rate == _SR
+    assert waveform.shape == (2, _SR)
+    assert waveform.flags.c_contiguous
 
 
 def test_in_memory_waveform_is_normalized_once_and_removed_after_inference() -> None:
@@ -381,6 +431,25 @@ def test_empty_prediction_key_is_rejected() -> None:
             adapter_target=_QWEN_ADAPTER_TARGET,
             model_id="mock/model",
             pred_text_key="",
+        )
+
+
+def test_empty_extras_key_is_rejected() -> None:
+    with pytest.raises(ValueError, match="extras_key must be non-empty or None"):
+        ASRStage(
+            adapter_target=_QWEN_ADAPTER_TARGET,
+            model_id="mock/model",
+            extras_key=" ",
+        )
+
+
+@pytest.mark.parametrize("extras_key", ["pred_text", "_skipme", "additional_notes"])
+def test_extras_key_cannot_collide_with_another_output(extras_key: str) -> None:
+    with pytest.raises(ValueError, match="extras_key cannot collide"):
+        ASRStage(
+            adapter_target=_QWEN_ADAPTER_TARGET,
+            model_id="mock/model",
+            extras_key=extras_key,
         )
 
 

--- a/tests/utils/test_vllm_utils.py
+++ b/tests/utils/test_vllm_utils.py
@@ -32,7 +32,7 @@ from nemo_curator.utils.vllm_utils import (
 )
 
 
-class TestValidateVllmKwargs:
+class TestVllmKwargs:
     def test_accepts_non_conflicting_kwargs(self) -> None:
         validate_vllm_kwargs(
             {"max_model_len": 8192},
@@ -51,8 +51,6 @@ class TestValidateVllmKwargs:
                 owner_description="adapter-owned arguments",
             )
 
-
-class TestMergeVllmKwargs:
     def test_merges_owned_kwargs_without_mutating_user_kwargs(self) -> None:
         user_kwargs = {"max_model_len": 8192, "compilation_config": {"cudagraph_mode": "NONE"}}
 

--- a/tests/utils/test_vllm_utils.py
+++ b/tests/utils/test_vllm_utils.py
@@ -24,7 +24,27 @@ if TYPE_CHECKING:
     from pathlib import Path
 
 import nemo_curator.utils.vllm_utils as _vllm_utils
-from nemo_curator.utils.vllm_utils import pick_free_port, resolve_local_model_path
+from nemo_curator.utils.vllm_utils import pick_free_port, resolve_local_model_path, validate_vllm_kwargs
+
+
+class TestValidateVllmKwargs:
+    def test_accepts_non_conflicting_kwargs(self) -> None:
+        validate_vllm_kwargs(
+            {"max_model_len": 8192},
+            {"model", "revision"},
+            owner_description="adapter-owned arguments",
+        )
+
+    def test_rejects_conflicts_in_sorted_order(self) -> None:
+        with pytest.raises(
+            ValueError,
+            match=r"vllm_kwargs cannot override adapter-owned arguments: model, revision",
+        ):
+            validate_vllm_kwargs(
+                {"revision": "abc123", "model": "org/model"},
+                {"model", "revision"},
+                owner_description="adapter-owned arguments",
+            )
 
 
 class TestPickFreePort:

--- a/tests/utils/test_vllm_utils.py
+++ b/tests/utils/test_vllm_utils.py
@@ -24,7 +24,12 @@ if TYPE_CHECKING:
     from pathlib import Path
 
 import nemo_curator.utils.vllm_utils as _vllm_utils
-from nemo_curator.utils.vllm_utils import pick_free_port, resolve_local_model_path, validate_vllm_kwargs
+from nemo_curator.utils.vllm_utils import (
+    merge_vllm_kwargs,
+    pick_free_port,
+    resolve_local_model_path,
+    validate_vllm_kwargs,
+)
 
 
 class TestValidateVllmKwargs:
@@ -44,6 +49,32 @@ class TestValidateVllmKwargs:
                 {"revision": "abc123", "model": "org/model"},
                 {"model", "revision"},
                 owner_description="adapter-owned arguments",
+            )
+
+
+class TestMergeVllmKwargs:
+    def test_merges_owned_kwargs_without_mutating_user_kwargs(self) -> None:
+        user_kwargs = {"max_model_len": 8192, "compilation_config": {"cudagraph_mode": "NONE"}}
+
+        merged = merge_vllm_kwargs(
+            user_kwargs,
+            {"model": "org/model", "revision": None},
+            owner_description="adapter-owned arguments",
+        )
+        compilation_config = merged["compilation_config"]
+        assert isinstance(compilation_config, dict)
+        compilation_config["cudagraph_mode"] = "FULL"
+
+        assert merged["model"] == "org/model"
+        assert merged["revision"] is None
+        assert user_kwargs["compilation_config"] == {"cudagraph_mode": "NONE"}
+
+    def test_rejects_owned_key_conflicts(self) -> None:
+        with pytest.raises(ValueError, match="cannot override stage-owned arguments: tensor_parallel_size"):
+            merge_vllm_kwargs(
+                {"tensor_parallel_size": 8},
+                {"model": "org/model", "tensor_parallel_size": 2},
+                owner_description="stage-owned arguments",
             )
 
 

--- a/tutorials/audio/README.md
+++ b/tutorials/audio/README.md
@@ -51,6 +51,7 @@ python tutorials/audio/fleurs/main.py \
 |---|---|---|---|
 | Curate multilingual ASR data (download, transcribe, filter by WER) | [**fleurs/**](fleurs/) | Yes (~4 GB VRAM) | Auto-downloads from HuggingFace |
 | Transcribe a manifest in-process with Qwen3-Omni and vLLM | [**qwen_omni_inprocess/**](qwen_omni_inprocess/) | Yes (2 per ASR actor) | Bundled sample or your own manifest |
+| Transcribe a manifest with Qwen3-ASR through the generic ASR adapter | [**qwen_asr/**](qwen_asr/) | Yes (1 per ASR actor) | Bundled sample or your own manifest |
 | Build training windows for Audio Language Models from diarized manifests | [**alm/**](alm/) | No (CPU-only) | Bundled sample fixtures |
 | Label raw audio for TTS/ASR/ALM via diarization, alignment, and quality metrics | [**tagging/**](tagging/) | Yes (~8 GB VRAM) | Bring your own audio manifest |
 | Evaluate speaker diarization (DER) on a benchmark dataset | [**callhome_diar/**](callhome_diar/) | Yes (~8 GB VRAM) | Requires [LDC license](https://catalog.ldc.upenn.edu/LDC97S42) |
@@ -63,6 +64,7 @@ python tutorials/audio/fleurs/main.py \
 |---|---|---|---|
 | `fleurs/` | Yes | ~50 MB per language split | Downloads from HuggingFace `google/fleurs` |
 | `qwen_omni_inprocess/` | Model only | Two bundled audio files | Downloads Qwen3-Omni weights on first use |
+| `qwen_asr/` | Model only | Two bundled audio files | Downloads Qwen3-ASR weights on first use |
 | `alm/` | N/A | Bundled | Uses `tests/fixtures/audio/alm/sample_input.jsonl` (5 entries) |
 | `tagging/` | No | Varies | Bring your own NeMo-style JSONL manifest with audio paths |
 | `callhome_diar/` | No | ~1 GB | Requires LDC membership and license ([LDC97S42](https://catalog.ldc.upenn.edu/LDC97S42)) |
@@ -83,6 +85,7 @@ sudo apt-get install -y ffmpeg
 |---|---|---|
 | `fleurs/` | `ffmpeg` | `audio_cpu` or `audio_cuda12` |
 | `qwen_omni_inprocess/` | `ffmpeg` | `audio_cuda12`, `vllm` |
+| `qwen_asr/` | `ffmpeg` | `audio_cuda12`, `vllm` |
 | `alm/` | `ffmpeg` | `audio_cpu` |
 | `tagging/` | `ffmpeg` | `audio_cuda12` |
 | `callhome_diar/` | `ffmpeg`, `sox` | `audio_cuda12` |

--- a/tutorials/audio/qwen_asr/README.md
+++ b/tutorials/audio/qwen_asr/README.md
@@ -1,0 +1,147 @@
+# Qwen3-ASR Adapter Tutorial
+
+This tutorial reads a NeMo-style audio manifest, normalizes each file to a
+16 kHz mono WAV, transcribes it with `Qwen/Qwen3-ASR-0.6B`, and writes the
+results to JSONL. The pipeline composes `ManifestReader`, the same
+`ResampleAudioStage` used by the audio tagging tutorial, the generic `ASRStage`
+configured with `QwenASRAdapter`, and `ManifestWriterStage`.
+
+There is no Qwen-specific inference stage or tutorial runner. Model lifecycle,
+audio loading and normalization, language routing, batching, skip handling,
+and output assembly stay in the shared ASR stage; the adapter only owns the
+Qwen3-ASR model call.
+
+## Requirements
+
+- x86_64 Linux with one CUDA GPU per ASR actor
+- `ffmpeg`
+- Audio files accessible from the machine running the pipeline
+
+From the Curator repository root, install the opt-in Qwen3-ASR dependency:
+
+```bash
+uv sync --extra audio_cuda12 --extra vllm
+source .venv/bin/activate
+```
+
+`ResampleAudioStage` invokes `ffmpeg`, so input audio may use any format
+supported by the installed build. It writes PCM 16-bit, 16 kHz, mono WAV files
+under `resampled_audio_dir` before inference.
+
+## Run the bundled smoke input
+
+The bundled manifest contains two short OPUS files:
+
+```bash
+python nemo_curator/config/run.py \
+  --config-path ../../tutorials/audio/qwen_asr \
+  --config-name pipeline \
+  manifest_path=tests/fixtures/audio/tagging/sample_input.jsonl \
+  output_path=/tmp/qwen_asr_output.jsonl \
+  workspace_dir=/tmp/qwen_asr_workspace \
+  default_language=en
+```
+
+`--config-path` is relative to `nemo_curator/config/run.py`; manifest, audio,
+and output paths resolve from the current working directory. Run the command
+from the repository root as shown.
+
+The first run downloads `Qwen/Qwen3-ASR-0.6B`. The pipeline allocates one GPU
+to each ASR actor. `QwenASRAdapter` constructs `Qwen3ASRModel.LLM`, matching the
+nkoluguri reference's vLLM backend and engine settings. The
+`audio_cuda12` extra installs qwen-asr without its conflicting vLLM pin, while
+the shared `vllm` extra provides the same Curator-pinned engine stack used by
+Qwen-Omni.
+
+## Effective defaults
+
+The tutorial caps vLLM's model context at 8,192 tokens so the bundled smoke
+input can run on a 12 GB GPU. This does not change the adapter's default.
+
+| Setting | Tutorial value |
+|---|---:|
+| Executor | Ray Data |
+| ASR stage batch size | `128` |
+| GPUs per ASR actor | `1` |
+| GPU memory limit | `0.7` of device memory |
+| Maximum vLLM model length | `8192` tokens |
+| Maximum generated tokens | `4096` |
+| Qwen internal inference batch cap | `128` |
+| Prediction field | `pred_text` |
+| Adapter extras field | `asr_extras` |
+
+The stage batch is passed to one adapter `transcribe_batch()` call. The adapter
+forwards `max_inference_batch_size` to Qwen3-ASR as its internal cap.
+
+## Select the executor
+
+Ray Data is the default. To use Xenna streaming:
+
+```bash
+python nemo_curator/config/run.py \
+  --config-path ../../tutorials/audio/qwen_asr \
+  --config-name pipeline \
+  manifest_path=/data/input.jsonl \
+  output_path=/tmp/qwen_asr_output.jsonl \
+  backend=xenna \
+  execution_mode=streaming
+```
+
+Use Xenna batch mode only when its streaming mode is unsuitable for the
+workload:
+
+```bash
+python nemo_curator/config/run.py \
+  --config-path ../../tutorials/audio/qwen_asr \
+  --config-name pipeline \
+  manifest_path=/data/input.jsonl \
+  output_path=/tmp/qwen_asr_output.jsonl \
+  backend=xenna \
+  execution_mode=batch
+```
+
+`execution_mode` applies only to Xenna and is ignored for Ray Data.
+
+## Input and output
+
+The input is JSONL with one object per audio file. Each object must contain
+`audio_filepath` and, unless `default_language` is set, `source_lang`:
+
+```json
+{"audio_filepath": "/data/sample.wav", "source_lang": "en"}
+```
+
+`ResampleAudioStage` preserves `audio_filepath` and adds `audio_item_id`,
+`resampled_audio_filepath`, and `duration`. `ASRStage` opens the resampled file
+for its current batch, converts it to contiguous mono 16 kHz NumPy samples,
+and passes the waveform plus language to the adapter. Waveforms are not stored
+in the output task data.
+
+`ASRStage` adds the configured prediction column and, when applicable,
+`_skipme` or `additional_notes`. Non-empty adapter metadata is written as one
+nested dictionary under `asr_extras`; Qwen3-ASR currently emits
+`asr_extras.detected_language`. Override the fields with, for example,
+`pred_text_key=qwen_transcript extras_key=qwen_metadata`, or disable metadata
+output with `extras_key=null`.
+
+Rows remain in the output when inference is skipped:
+
+- unreadable audio uses `_skipme: audio_load_error`;
+- audio shorter than the adapter minimum uses `_skipme: empty_audio`;
+- unsupported languages use `_skipme: language_not_supported`;
+- missing language metadata uses `_skipme: language_missing` unless
+  `default_language` is configured.
+
+The default language allowlist matches the
+[official Qwen3-ASR language table](https://github.com/QwenLM/Qwen3-ASR#supported-languages):
+`zh`, `en`, `yue`,
+`ar`, `de`, `fr`, `es`, `pt`, `id`, `it`, `ko`, `ru`, `th`, `vi`, `ja`,
+`tr`, `hi`, `ms`, `nl`, `sv`, `da`, `fi`, `pl`, `cs`, `fil`, `fa`, `el`,
+`hu`, `mk`, and `ro`.
+
+## Scope
+
+This is a functional manifest-to-transcript example. It does not perform word
+alignment, diarization, WER calculation, hallucination recovery, or benchmark
+reporting. The audio tagging pipeline continues to use
+`NeMoASRAlignerStage` where word timestamps are required.

--- a/tutorials/audio/qwen_asr/pipeline.yaml
+++ b/tutorials/audio/qwen_asr/pipeline.yaml
@@ -1,0 +1,63 @@
+# Qwen3-ASR pipeline using Curator's generic ASR adapter stage.
+#
+# Usage (from the Curator repository root):
+#   python nemo_curator/config/run.py \
+#     --config-path ../../tutorials/audio/qwen_asr \
+#     --config-name pipeline \
+#     manifest_path=tests/fixtures/audio/tagging/sample_input.jsonl
+
+defaults:
+  - _self_
+  - override hydra/job_logging: none
+  - override hydra/hydra_logging: none
+
+hydra:
+  run:
+    dir: .
+  output_subdir: null
+
+manifest_path: ???
+output_path: ./qwen_asr_output.jsonl
+workspace_dir: /tmp/qwen_asr_workspace
+resampled_audio_dir: ${workspace_dir}/audio_resampled
+model_id: Qwen/Qwen3-ASR-0.6B
+default_language: null
+supported_language_codes: [zh, en, yue, ar, de, fr, es, pt, id, it, ko, ru, th, vi, ja, tr, hi, ms, nl, sv, da, fi, pl, cs, fil, fa, el, hu, mk, ro]
+pred_text_key: pred_text
+extras_key: asr_extras
+gpus_per_actor: 1
+backend: ray_data
+execution_mode: streaming
+
+stages:
+  - _target_: nemo_curator.stages.audio.common.ManifestReader
+    manifest_path: ${manifest_path}
+    files_per_partition: 1
+
+  - _target_: nemo_curator.stages.audio.tagging.ResampleAudioStage
+    name: "ResampleAudio"
+    resampled_audio_dir: ${resampled_audio_dir}
+    target_sample_rate: 16000
+    target_format: "wav"
+    target_nchannels: 1
+
+  - _target_: nemo_curator.stages.audio.inference.asr.stage.ASRStage
+    adapter_target: nemo_curator.models.asr.qwen_asr.QwenASRAdapter
+    model_id: ${model_id}
+    default_language: ${default_language}
+    supported_language_codes: ${supported_language_codes}
+    pred_text_key: ${pred_text_key}
+    extras_key: ${extras_key}
+    batch_size: 128
+    resources:
+      _target_: nemo_curator.stages.resources.Resources
+      gpus: ${gpus_per_actor}
+    adapter_kwargs:
+      gpu_memory_utilization: 0.7
+      max_new_tokens: 4096
+      max_inference_batch_size: 128
+      vllm_kwargs:
+        max_model_len: 8192
+
+  - _target_: nemo_curator.stages.audio.common.ManifestWriterStage
+    output_path: ${output_path}

--- a/tutorials/audio/qwen_omni_inprocess/README.md
+++ b/tutorials/audio/qwen_omni_inprocess/README.md
@@ -124,7 +124,7 @@ contain `audio_filepath` and, by default, `source_lang`:
 `${workspace_dir}/audio_resampled` by default and reuses it on later runs.
 
 Only file paths and metadata travel between pipeline stages. `ASRStage` opens
-`resampled_audio_filepath` with `torchaudio` only for its current batch and
+`resampled_audio_filepath` with SoundFile only for its current batch and
 preserves the decoded sample rate while normalizing each waveform to contiguous
 mono 16 kHz NumPy samples for the adapter. It never stores either the waveform
 or sample rate in `task.data`, so manifest size does not cause all decoded

--- a/uv.lock
+++ b/uv.lock
@@ -687,6 +687,15 @@ wheels = [
 ]
 
 [[package]]
+name = "blinker"
+version = "1.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/21/28/9b3f50ce0e048515135495f198351908d99540d69bfdc8c1d15b73dc55ce/blinker-1.9.0.tar.gz", hash = "sha256:b4ce2265a7abece45e7cc896e98dbebe6cead56bcf805a3d23136d145f5445bf", size = 22460, upload-time = "2024-11-08T17:25:47.436Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/10/cb/f2ad4230dc2eb1a74edf38f1a38b9b52277f75bef262d8908e60d957e13c/blinker-1.9.0-py3-none-any.whl", hash = "sha256:ba0efaa9080b619ff2f3459d1d500c57bddea4a6b424b60a91141db6fd2f08bc", size = 8458, upload-time = "2024-11-08T17:25:46.184Z" },
+]
+
+[[package]]
 name = "blis"
 version = "1.3.3"
 source = { registry = "https://pypi.org/simple" }
@@ -2192,6 +2201,26 @@ wheels = [
 ]
 
 [[package]]
+name = "dynet38"
+version = "2.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cython", marker = "platform_machine == 'x86_64' and sys_platform != 'darwin'" },
+    { name = "numpy", marker = "platform_machine == 'x86_64' and sys_platform != 'darwin'" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fd/c3/46f879632262817aced0889c15c694d327173b3f75467994201d9ddc1f38/dyNET38-2.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8963383d935e802941c8f9d778403798452e172150c3b4b5dee288d50b62ecc8", size = 6961879, upload-time = "2024-01-23T10:31:51.197Z" },
+    { url = "https://files.pythonhosted.org/packages/47/6f/c252d1c450d173e0acca83a9f4edbfa2921ea133f349410fb87ff9c146b8/dyNET38-2.2-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:bb54f56deae8160b7984ade15d377ac655576ea98959b8e10f937ace2d108617", size = 7486721, upload-time = "2024-01-23T10:31:56.726Z" },
+    { url = "https://files.pythonhosted.org/packages/94/da/da6f1e5bcda0cfbadcb1fd1ef8c7435e36b7cc36e57368decb80ac54531f/dyNET38-2.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8693bf8e98fdddfa116fa1e213f1c471be772e1b9e006ad5278a2b2a8f7b4d70", size = 6748542, upload-time = "2024-01-23T10:32:03.414Z" },
+    { url = "https://files.pythonhosted.org/packages/82/1b/d83607f75f5a71d891f2408bdca31eaa166fb43dda2f792625f75bb0d275/dyNET38-2.2-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:573d6d2cccdfee6f93ca4a3a2e4bc12f0e76c75b91d1eeb420546bec28c0b4b0", size = 7246792, upload-time = "2024-01-23T10:32:08.827Z" },
+    { url = "https://files.pythonhosted.org/packages/51/c0/be3c5934bba18fa0fa92e183158423687464e43c484d04fb51dfde3b9bf6/dynet38-2.2-cp311-cp311-win_amd64.whl", hash = "sha256:3d5a88d2ea7b518b422d57b3fbc123cd7f42e78c80357736f6f7b8f179fac6d9", size = 1306616, upload-time = "2025-12-29T12:14:42.027Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/4f/a5b22e11549f0a5dc6feccdb50414aaf3c05decf0d8ca29288984a21fc5a/dynet38-2.2-cp312-cp312-win_amd64.whl", hash = "sha256:fd9967ed3ec071cc4c0c084d758ab44dac34cb37beb625ea9fcf2221c2085975", size = 1299414, upload-time = "2025-12-29T12:14:44Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/b8/8333b9d3427f99d7d7ab5d25e9e9ee03c69aea4af3f9c7a3bb703f51804b/dynet38-2.2-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a58f3f4465660c4003bbf1f473ff4e94793a4c96ec446eb59f836c1f8b5f1829", size = 6731199, upload-time = "2025-05-03T17:26:47.855Z" },
+    { url = "https://files.pythonhosted.org/packages/01/3e/60f4ad7b48d41925cb5af4468cd3310ce171789b977fecefb96e40da2e31/dynet38-2.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:4db01bb52f7a83e3f2dbb4155f6592a86ce94203f7c9c524e32b1680dfd8a38a", size = 7482831, upload-time = "2025-05-03T17:26:54.365Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/12/de2bf28637257739ce802b9221316777e207cb0355dbf91a0377d374decd/dynet38-2.2-cp313-cp313-win_amd64.whl", hash = "sha256:96109717ee604eb18df6951c3a89b889b1a70c2938f8dddcdc16d54b5800c239", size = 1299290, upload-time = "2025-12-29T12:14:45.826Z" },
+]
+
+[[package]]
 name = "easydict"
 version = "1.13"
 source = { registry = "https://pypi.org/simple" }
@@ -2519,6 +2548,23 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/db/53/dbf2157f2bbb96d6f7a6891cf6abfb2e6e18963760a0c53e96c2de5c59db/flashinfer_python-0.6.11.post2.tar.gz", hash = "sha256:e9fdac56aea9f0f58a4e69b0645c54993760d3cc6c7bf5c2df4ce5a0aecc7953", size = 9248515, upload-time = "2026-05-14T04:57:32.83Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c7/bc/518b092473f37d904ae07766ad37c772b93da13ea788777b22a80c3f1a7c/flashinfer_python-0.6.11.post2-py3-none-any.whl", hash = "sha256:550cbdb760f9f7ec0e42055e06636b9489d05f1a38989cafd77e6eb820de0138", size = 13746417, upload-time = "2026-05-14T04:57:30.25Z" },
+]
+
+[[package]]
+name = "flask"
+version = "3.1.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "blinker", marker = "platform_machine == 'x86_64' and sys_platform != 'darwin'" },
+    { name = "click", marker = "platform_machine == 'x86_64' and sys_platform != 'darwin'" },
+    { name = "itsdangerous", marker = "platform_machine == 'x86_64' and sys_platform != 'darwin'" },
+    { name = "jinja2", marker = "platform_machine == 'x86_64' and sys_platform != 'darwin'" },
+    { name = "markupsafe", marker = "platform_machine == 'x86_64' and sys_platform != 'darwin'" },
+    { name = "werkzeug", marker = "platform_machine == 'x86_64' and sys_platform != 'darwin'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/26/00/35d85dcce6c57fdc871f3867d465d780f302a175ea360f62533f12b27e2b/flask-3.1.3.tar.gz", hash = "sha256:0ef0e52b8a9cd932855379197dd8f94047b359ca0a78695144304cb45f87c9eb", size = 759004, upload-time = "2026-02-19T05:00:57.678Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7f/9c/34f6962f9b9e9c71f6e5ed806e0d0ff03c9d1b0b2340088a0cf4bce09b18/flask-3.1.3-py3-none-any.whl", hash = "sha256:f4bcbefc124291925f1a26446da31a5178f9483862233b23c0c96a20701f670c", size = 103424, upload-time = "2026-02-19T05:00:56.027Z" },
 ]
 
 [[package]]
@@ -2891,6 +2937,61 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/79/c4/46d005aec3bf911cb030467d91e062a5386ff4a03e51874424cacc0f60c1/gpustat-1.1.1.tar.gz", hash = "sha256:c18d3ed5518fc16300c42d694debc70aebb3be55cae91f1db64d63b5fa8af9d8", size = 98052, upload-time = "2023-08-22T19:39:06.062Z" }
 
 [[package]]
+name = "gradio"
+version = "6.20.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio", marker = "platform_machine == 'x86_64' and sys_platform != 'darwin'" },
+    { name = "audioop-lts", marker = "python_full_version >= '3.13' and platform_machine == 'x86_64' and sys_platform != 'darwin'" },
+    { name = "brotli", marker = "platform_machine == 'x86_64' and sys_platform != 'darwin'" },
+    { name = "fastapi", marker = "platform_machine == 'x86_64' and sys_platform != 'darwin'" },
+    { name = "gradio-client", marker = "platform_machine == 'x86_64' and sys_platform != 'darwin'" },
+    { name = "groovy", marker = "platform_machine == 'x86_64' and sys_platform != 'darwin'" },
+    { name = "hf-gradio", marker = "platform_machine == 'x86_64' and sys_platform != 'darwin'" },
+    { name = "httpx", marker = "platform_machine == 'x86_64' and sys_platform != 'darwin'" },
+    { name = "huggingface-hub", marker = "platform_machine == 'x86_64' and sys_platform != 'darwin'" },
+    { name = "jinja2", marker = "platform_machine == 'x86_64' and sys_platform != 'darwin'" },
+    { name = "markupsafe", marker = "platform_machine == 'x86_64' and sys_platform != 'darwin'" },
+    { name = "numpy", marker = "platform_machine == 'x86_64' and sys_platform != 'darwin'" },
+    { name = "orjson", marker = "platform_machine == 'x86_64' and sys_platform != 'darwin'" },
+    { name = "packaging", marker = "platform_machine == 'x86_64' and sys_platform != 'darwin'" },
+    { name = "pandas", marker = "platform_machine == 'x86_64' and sys_platform != 'darwin'" },
+    { name = "pillow", marker = "platform_machine == 'x86_64' and sys_platform != 'darwin'" },
+    { name = "pydantic", marker = "platform_machine == 'x86_64' and sys_platform != 'darwin'" },
+    { name = "pydub", marker = "platform_machine == 'x86_64' and sys_platform != 'darwin'" },
+    { name = "python-multipart", marker = "platform_machine == 'x86_64' and sys_platform != 'darwin'" },
+    { name = "pytz", marker = "platform_machine == 'x86_64' and sys_platform != 'darwin'" },
+    { name = "pyyaml", marker = "platform_machine == 'x86_64' and sys_platform != 'darwin'" },
+    { name = "safehttpx", marker = "platform_machine == 'x86_64' and sys_platform != 'darwin'" },
+    { name = "semantic-version", marker = "platform_machine == 'x86_64' and sys_platform != 'darwin'" },
+    { name = "starlette", marker = "platform_machine == 'x86_64' and sys_platform != 'darwin'" },
+    { name = "tomlkit", marker = "platform_machine == 'x86_64' and sys_platform != 'darwin'" },
+    { name = "typer", marker = "platform_machine == 'x86_64' and sys_platform != 'darwin'" },
+    { name = "typing-extensions", marker = "platform_machine == 'x86_64' and sys_platform != 'darwin'" },
+    { name = "uvicorn", marker = "platform_machine == 'x86_64' and sys_platform != 'darwin'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f8/96/3618f8a189180ab3d4e5f8b258fd92e419eda9f49b6ab4dd50c6782cda33/gradio-6.20.0.tar.gz", hash = "sha256:8672866e9225a1f8297325a6742bb525a3a0ddc8aa4d75d99beb10a27ea2915f", size = 44844340, upload-time = "2026-07-07T18:53:57.402Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d7/f4/7dc4540836e326391a9d1ba20193d795d5a4582839b60f5c10397f5120bb/gradio-6.20.0-py3-none-any.whl", hash = "sha256:91d2ec29c37917d55b18dba87aa15bb15c4796d84dce9a9ef4ec7d87453a7fee", size = 30964820, upload-time = "2026-07-07T18:53:52.403Z" },
+]
+
+[[package]]
+name = "gradio-client"
+version = "2.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "fsspec", marker = "platform_machine == 'x86_64' and sys_platform != 'darwin'" },
+    { name = "httpx", marker = "platform_machine == 'x86_64' and sys_platform != 'darwin'" },
+    { name = "huggingface-hub", marker = "platform_machine == 'x86_64' and sys_platform != 'darwin'" },
+    { name = "packaging", marker = "platform_machine == 'x86_64' and sys_platform != 'darwin'" },
+    { name = "typing-extensions", marker = "platform_machine == 'x86_64' and sys_platform != 'darwin'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e8/e6/6b6029f5fe2ad7f1211105d530e34d991014c2cae463f9223033031cfc4f/gradio_client-2.5.0.tar.gz", hash = "sha256:4cde99bad62149595c30c90876ca2e405e3a13687ecf895474f3412cb476673d", size = 59013, upload-time = "2026-04-20T23:16:21.518Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/78/81/0a861b8e1ff42960139c6cd4c7dd591292fa09ea1ae2d87677441cba4c00/gradio_client-2.5.0-py3-none-any.whl", hash = "sha256:d43e2179c29076292a76485ad7ed2e6eaa19d14ac58283bd7f5beabfe4ca958c", size = 59952, upload-time = "2026-04-20T23:16:20.186Z" },
+]
+
+[[package]]
 name = "graphviz"
 version = "0.21"
 source = { registry = "https://pypi.org/simple" }
@@ -2914,6 +3015,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/fd/8e/424b8c6e78bd9837d14ff7df01a9829fc883ba2ab4ea787d4f848435f23f/greenlet-3.3.0-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:087ea5e004437321508a8d6f20efc4cfec5e3c30118e1417ea96ed1d93950527", size = 612833, upload-time = "2025-12-04T14:26:03.669Z" },
     { url = "https://files.pythonhosted.org/packages/1e/37/f31136132967982d698c71a281a8901daf1a8fbab935dce7c0cf15f942cc/greenlet-3.3.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:5375d2e23184629112ca1ea89a53389dddbffcf417dad40125713d88eb5f96e8", size = 1636483, upload-time = "2025-12-04T14:27:30.804Z" },
     { url = "https://files.pythonhosted.org/packages/7e/71/ba21c3fb8c5dce83b8c01f458a42e99ffdb1963aeec08fff5a18588d8fd7/greenlet-3.3.0-cp313-cp313-win_amd64.whl", hash = "sha256:9ee1942ea19550094033c35d25d20726e4f1c40d59545815e1128ac58d416d38", size = 301833, upload-time = "2025-12-04T14:32:23.929Z" },
+]
+
+[[package]]
+name = "groovy"
+version = "0.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/52/36/bbdede67400277bef33d3ec0e6a31750da972c469f75966b4930c753218f/groovy-0.1.2.tar.gz", hash = "sha256:25c1dc09b3f9d7e292458aa762c6beb96ea037071bf5e917fc81fb78d2231083", size = 17325, upload-time = "2025-02-28T20:24:56.068Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/28/27/3d6dcadc8a3214d8522c1e7f6a19554e33659be44546d44a2f7572ac7d2a/groovy-0.1.2-py3-none-any.whl", hash = "sha256:7f7975bab18c729a257a8b1ae9dcd70b7cafb1720481beae47719af57c35fa64", size = 14090, upload-time = "2025-02-28T20:24:55.152Z" },
 ]
 
 [[package]]
@@ -2992,6 +3102,19 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
+name = "hf-gradio"
+version = "0.4.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "gradio-client", marker = "platform_machine == 'x86_64' and sys_platform != 'darwin'" },
+    { name = "typer", marker = "platform_machine == 'x86_64' and sys_platform != 'darwin'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ce/86/c9694b7cfada5780e75769e60dc161a161f4dd7fc91b61db5e3a3338bef9/hf_gradio-0.4.1.tar.gz", hash = "sha256:a017d942618f0d495a58ee4563047fa04bef614c00e0cb789a9a6d0633cffa7b", size = 6560, upload-time = "2026-04-22T14:01:32.334Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/30/2d/afff2ee87e75d8eb85c92bb8cf0e15b05c23c2ebd8fd8dec781d8601ed7f/hf_gradio-0.4.1-py3-none-any.whl", hash = "sha256:76b8cb8be6abe62d74c1ad2d35b42f0629db89aa9e1a8d033cecfe7c856eeab3", size = 4482, upload-time = "2026-04-17T19:53:31.827Z" },
 ]
 
 [[package]]
@@ -3424,6 +3547,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/7c/1a/3c8edc664e06e6bd06cce40c6b22da5f1429aa4224d0c590f3be21c91ead/isoduration-20.11.0.tar.gz", hash = "sha256:ac2f9015137935279eac671f94f89eb00584f940f5dc49462a0c4ee692ba1bd9", size = 11649, upload-time = "2020-11-01T11:00:00.312Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7b/55/e5326141505c5d5e34c5e0935d2908a74e4561eca44108fbfb9c13d2911a/isoduration-20.11.0-py3-none-any.whl", hash = "sha256:b2904c2a4228c3d44f409c8ae8e2370eb21a26f7ac2ec5446df141dde3452042", size = 11321, upload-time = "2020-11-01T10:59:58.02Z" },
+]
+
+[[package]]
+name = "itsdangerous"
+version = "2.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9c/cb/8ac0172223afbccb63986cc25049b154ecfb5e85932587206f42317be31d/itsdangerous-2.2.0.tar.gz", hash = "sha256:e0050c0b7da1eea53ffaf149c0cfbb5c6e2e2b69c4bef22c81fa6eb73e5f6173", size = 54410, upload-time = "2024-04-16T21:28:15.614Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/96/92447566d16df59b2a776c0fb82dbc4d9e07cd95062562af01e408583fc4/itsdangerous-2.2.0-py3-none-any.whl", hash = "sha256:c6242fc49e35958c8b15141343aa660db5fc54d4f13a1db01a3f5891b98700ef", size = 16234, upload-time = "2024-04-16T21:28:14.499Z" },
 ]
 
 [[package]]
@@ -5128,6 +5260,28 @@ wheels = [
 ]
 
 [[package]]
+name = "nagisa"
+version = "0.2.11"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "dynet38", marker = "platform_machine == 'x86_64' and sys_platform != 'darwin'" },
+    { name = "numpy", marker = "platform_machine == 'x86_64' and sys_platform != 'darwin'" },
+    { name = "six", marker = "platform_machine == 'x86_64' and sys_platform != 'darwin'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e1/71/1cc63f4fde1c1ca491ea69b46c3c5bd6bb06f3efa8262f34b227fe25dbf5/nagisa-0.2.11.tar.gz", hash = "sha256:213e8f837c6f7391ea1f56f4fa6047612d117e3f0e9c4f6b93a3a77f78ba6e6f", size = 20930765, upload-time = "2024-01-28T17:32:49.924Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/71/e8/72c93208e9301d614d3cd190e495ee11321b1fe42165a3e2128ac8b9d1a9/nagisa-0.2.11-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:70d715680e33c48a8066a8588a52149d98644cddae1b5127cc5660c6418c81ce", size = 21678750, upload-time = "2024-01-28T17:29:32.458Z" },
+    { url = "https://files.pythonhosted.org/packages/87/10/479edb36afd987c3e15b3279a0a5d0aa68e5915c0104052fa7965eadb0cc/nagisa-0.2.11-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:9ed1e1c700c4785bd576d670e650f2093d10606c41018e953986f0f0a39fa994", size = 21675016, upload-time = "2024-01-28T17:29:48.002Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/07/78c9b8f676f19f7714b15722dd512058c6b82b4627db35ceeb4ccb82475f/nagisa-0.2.11-cp311-cp311-win_amd64.whl", hash = "sha256:551f8060e0208bbc80ab8766f923568b2cdbe49d47012cc0d29a310de0bd3a32", size = 21354044, upload-time = "2025-12-29T12:15:43.315Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/ea/3467d0b2362996eb079ea49d58e7708bd174c04b0e29672bb50b1c984d21/nagisa-0.2.11-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:43f2a5a30aa4b5c3f9018062e4c892efb6c18ae80f0d67a9a0611aa3d260dc37", size = 21657127, upload-time = "2024-01-28T17:30:03.871Z" },
+    { url = "https://files.pythonhosted.org/packages/31/7a/10bf406cdc83831614311c785be077292d299dec3d51657ec219a4144593/nagisa-0.2.11-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:128510d25293e1ce40bb62da8e4a35a69eec7076ff498c1e3ee82178dcf4b3e6", size = 21655942, upload-time = "2024-01-28T17:30:19.129Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/f5/6c6206fad84dca34e4383994fab176bd99f9293d731fc3e72bd7da0ab74c/nagisa-0.2.11-cp312-cp312-win_amd64.whl", hash = "sha256:6d68ee11ee6e82a37e54ad10885c120ac5e69446fe635d65327c4931b281d996", size = 21352973, upload-time = "2025-12-29T12:15:50.156Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/c6/0f035e298e8c7d8fa33a19bf15228890c9fb078b4470120feea4525308d6/nagisa-0.2.11-cp313-cp313-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4fb475b3b74f19d8a1e5ec7133fcec9fb8f3dbe1292e711e08a6f9857e6f50ae", size = 21653290, upload-time = "2025-05-03T17:29:05.851Z" },
+    { url = "https://files.pythonhosted.org/packages/37/7d/0e33d5e682daec7a6795e34bf744909bec7f50e8d06dcd87ce09a2f2113f/nagisa-0.2.11-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:d700a50ca90fdca0351822f1f39d10e0dc24000168f0427ebed5e35a81c773b1", size = 21670116, upload-time = "2025-05-03T17:29:20.987Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/55/6c328708ae081fffb8df200ba1f0e38d501a0ff2b66eadf0049018fb3471/nagisa-0.2.11-cp313-cp313-win_amd64.whl", hash = "sha256:4ae21df165b31145353c011d78b20658fa8d0e5571ac77da5fbc005c58e0318f", size = 21352513, upload-time = "2025-12-29T12:15:57.756Z" },
+]
+
+[[package]]
 name = "nbclient"
 version = "0.10.3"
 source = { registry = "https://pypi.org/simple" }
@@ -5254,6 +5408,7 @@ all = [
     { name = "pylibraft-cu12" },
     { name = "pypdfium2" },
     { name = "python-magic" },
+    { name = "qwen-asr", marker = "platform_machine == 'x86_64' and sys_platform != 'darwin'" },
     { name = "qwen-omni-utils" },
     { name = "raft-dask-cu12" },
     { name = "rapidsmpf-cu12" },
@@ -5332,6 +5487,7 @@ audio-cuda12 = [
     { name = "opencc-python-reimplemented" },
     { name = "pyannote-audio", marker = "platform_machine == 'x86_64' and sys_platform != 'darwin'" },
     { name = "pydub" },
+    { name = "qwen-asr", marker = "platform_machine == 'x86_64' and sys_platform != 'darwin'" },
     { name = "qwen-omni-utils" },
     { name = "scipy" },
     { name = "silero-vad" },
@@ -5723,6 +5879,7 @@ requires-dist = [
     { name = "pynvvideocodec", marker = "platform_machine == 'x86_64' and sys_platform != 'darwin' and extra == 'video-media'", specifier = "==2.0.2" },
     { name = "pypdfium2", marker = "extra == 'interleaved-cpu'" },
     { name = "python-magic", marker = "extra == 'math-cpu'", specifier = "==0.4.24" },
+    { name = "qwen-asr", marker = "platform_machine == 'x86_64' and sys_platform != 'darwin' and extra == 'audio-cuda12'", specifier = "==0.0.6" },
     { name = "qwen-omni-utils", marker = "extra == 'audio-cuda12'", specifier = ">=0.0.9" },
     { name = "raft-dask-cu12", marker = "extra == 'deduplication-cuda12'", specifier = "==25.10.*" },
     { name = "rapidsmpf-cu12", marker = "extra == 'deduplication-cuda12'", specifier = "==25.10.*" },
@@ -7405,6 +7562,23 @@ wheels = [
 ]
 
 [[package]]
+name = "orjson"
+version = "3.11.9"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7e/0c/964746fcafbd16f8ff53219ad9f6b412b34f345c75f384ad434ceaadb538/orjson-3.11.9.tar.gz", hash = "sha256:4fef17e1f8722c11587a6ef18e35902450221da0028e65dbaaa543619e68e48f", size = 5599163, upload-time = "2026-05-06T15:11:08.309Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/bd/360686f39348aa88827cb6fbf7dc606fd41c831a35235e1abf1db8e3a9e6/orjson-3.11.9-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:147302878da387104b66bb4a8b0227d1d487e976ce41a8501916161072ed87b1", size = 133971, upload-time = "2026-05-06T15:09:45.239Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/8a/4081492586d75b073d60c5271a8d0f05a0955cabf1e34c8473f6fcd84235/orjson-3.11.9-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:63e0efbc991250c0b3143488fa57d95affcabbfc63c99c48d625dd37779aafe2", size = 136959, upload-time = "2026-05-06T15:09:51.311Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/17/1a1a228183d62d1b77e2c30d210f47dd4768b310ebe1607c63e3c0e3a71e/orjson-3.11.9-cp311-cp311-win_amd64.whl", hash = "sha256:57ea77fb70a448ce87d18fca050193202a3da5e54598f6501ca5476fb66cfe02", size = 127106, upload-time = "2026-05-06T15:09:54.204Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/a4/82b7a2fe5d8a67a59ed831b24d59a3d46ea7d207b66e1602d376541d94a6/orjson-3.11.9-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:be4fa4f0af7fa18951f7ab3fc2148e223af211bf03f59e1c6034ec3f97f21d61", size = 134014, upload-time = "2026-05-06T15:10:08.213Z" },
+    { url = "https://files.pythonhosted.org/packages/df/e5/4d2d8af06f788329b4f78f8cc3679bb395392fcaa1e4d8d3c33e85308fa4/orjson-3.11.9-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:71e63adb0e1f1ed5d9e168f50a91ceb93ae6420731d222dc7da5c69409aa47aa", size = 136943, upload-time = "2026-05-06T15:10:14.405Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/d5/973a43fc9c55e20f2051e9830997649f669be0cb3ca52192087c0143f118/orjson-3.11.9-cp312-cp312-win_amd64.whl", hash = "sha256:59e403b1cc5a676da8eaf31f6254801b7341b3e29efa85f92b48d272637e77be", size = 127101, upload-time = "2026-05-06T15:10:17.129Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/08/dca0082dd2a194acb93e5457e73455388e2e2ca464a2672449a9ddbb679d/orjson-3.11.9-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4e39364e726a8fff737309aff059ff67d8a8c8d5b677be7bb49a8b3e84b7e218", size = 134033, upload-time = "2026-05-06T15:10:31.152Z" },
+    { url = "https://files.pythonhosted.org/packages/04/83/45fbb6d962e260807f99441db9613cee868ceda4baceda59b3720a563f97/orjson-3.11.9-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:9f78cf8fec5bd627f4082b8dfeac7871b43d7f3274904492a43dab39f18a19a0", size = 136915, upload-time = "2026-05-06T15:10:38.013Z" },
+    { url = "https://files.pythonhosted.org/packages/67/bd/2775ff28bfe883b9aa1ff348300542eb2ef1ee18d8ae0e3a49846817a865/orjson-3.11.9-cp313-cp313-win_amd64.whl", hash = "sha256:051b102c93b4f634e89f3866b07b9a9a98915ada541f4ec30f177067b2694979", size = 127086, upload-time = "2026-05-06T15:10:41.262Z" },
+]
+
+[[package]]
 name = "outlines-core"
 version = "0.2.14"
 source = { registry = "https://pypi.org/simple" }
@@ -8857,6 +9031,28 @@ wheels = [
 ]
 
 [[package]]
+name = "qwen-asr"
+version = "0.0.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "accelerate", marker = "platform_machine == 'x86_64' and sys_platform != 'darwin'" },
+    { name = "flask", marker = "platform_machine == 'x86_64' and sys_platform != 'darwin'" },
+    { name = "gradio", marker = "platform_machine == 'x86_64' and sys_platform != 'darwin'" },
+    { name = "librosa", marker = "platform_machine == 'x86_64' and sys_platform != 'darwin'" },
+    { name = "nagisa", marker = "platform_machine == 'x86_64' and sys_platform != 'darwin'" },
+    { name = "pytz", marker = "platform_machine == 'x86_64' and sys_platform != 'darwin'" },
+    { name = "qwen-omni-utils", marker = "platform_machine == 'x86_64' and sys_platform != 'darwin'" },
+    { name = "soundfile", marker = "platform_machine == 'x86_64' and sys_platform != 'darwin'" },
+    { name = "sox", marker = "platform_machine == 'x86_64' and sys_platform != 'darwin'" },
+    { name = "soynlp", marker = "platform_machine == 'x86_64' and sys_platform != 'darwin'" },
+    { name = "transformers", marker = "platform_machine == 'x86_64' and sys_platform != 'darwin'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7f/5b/56c5175d1a4d6ed8602003385570304305e4ae9c40b999d12d75a70c0561/qwen_asr-0.0.6.tar.gz", hash = "sha256:294893f2340dc2d58d1f1d1cb8ce26ac0a79f254805ab432dda2892bd5c8d13c", size = 146666, upload-time = "2026-01-30T03:24:02.697Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/01/12/d3027a7e4dc2eea0b12a4bf8414a7109f055004e1771666e01d8859d3ca0/qwen_asr-0.0.6-py3-none-any.whl", hash = "sha256:b9c55a38413298f3a990a4475467399daec6e8f4172363053fc42e2166c2dfd3", size = 141603, upload-time = "2026-01-30T03:24:00.82Z" },
+]
+
+[[package]]
 name = "qwen-omni-utils"
 version = "0.0.9"
 source = { registry = "https://pypi.org/simple" }
@@ -9578,6 +9774,18 @@ wheels = [
 ]
 
 [[package]]
+name = "safehttpx"
+version = "0.1.7"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "httpx", marker = "platform_machine == 'x86_64' and sys_platform != 'darwin'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/89/d1/4282284d9cf1ee873607a46442da977fc3c985059315ab23610be31d5885/safehttpx-0.1.7.tar.gz", hash = "sha256:db201c0978c41eddb8bb480f3eee59dd67304fdd91646035e9d9a720049a9d23", size = 10385, upload-time = "2025-10-24T18:30:09.783Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2e/a3/0f0b7d78e2f1eb9e8e1afbff1d2bff8d60144aee17aca51c065b516743dd/safehttpx-0.1.7-py3-none-any.whl", hash = "sha256:c4f4a162db6993464d7ca3d7cc4af0ffc6515a606dfd220b9f82c6945d869cde", size = 8959, upload-time = "2025-10-24T18:30:08.733Z" },
+]
+
+[[package]]
 name = "safetensors"
 version = "0.7.0"
 source = { registry = "https://pypi.org/simple" }
@@ -9682,6 +9890,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ab/f2/b31d75cb9b5fa4dd39a0a931ee9b33e7f6f36f23be5ef560bf72e0f92f32/scipy-1.16.3-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:e7efa2681ea410b10dde31a52b18b0154d66f2485328830e45fdf183af5aefc6", size = 38796678, upload-time = "2025-10-28T17:35:26.354Z" },
     { url = "https://files.pythonhosted.org/packages/b4/1e/b3723d8ff64ab548c38d87055483714fefe6ee20e0189b62352b5e015bb1/scipy-1.16.3-cp313-cp313t-win_amd64.whl", hash = "sha256:2d1ae2cf0c350e7705168ff2429962a89ad90c2d49d1dd300686d8b2a5af22fc", size = 38640178, upload-time = "2025-10-28T17:35:35.304Z" },
     { url = "https://files.pythonhosted.org/packages/8e/f3/d854ff38789aca9b0cc23008d607ced9de4f7ab14fa1ca4329f86b3758ca/scipy-1.16.3-cp313-cp313t-win_arm64.whl", hash = "sha256:0c623a54f7b79dd88ef56da19bc2873afec9673a48f3b85b18e4d402bdd29a5a", size = 25803246, upload-time = "2025-10-28T17:35:42.155Z" },
+]
+
+[[package]]
+name = "semantic-version"
+version = "2.10.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/31/f2289ce78b9b473d582568c234e104d2a342fd658cc288a7553d83bb8595/semantic_version-2.10.0.tar.gz", hash = "sha256:bdabb6d336998cbb378d4b9db3a4b56a1e3235701dc05ea2690d9a997ed5041c", size = 52289, upload-time = "2022-05-26T13:35:23.454Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6a/23/8146aad7d88f4fcb3a6218f41a60f6c2d4e3a72de72da1825dc7c8f7877c/semantic_version-2.10.0-py2.py3-none-any.whl", hash = "sha256:de78a3b8e0feda74cabc54aab2da702113e33ac9d9eb9d2389bcf1f58b7d9177", size = 15552, upload-time = "2022-05-26T13:35:21.206Z" },
 ]
 
 [[package]]
@@ -9972,6 +10189,21 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/b5/80/10640970998a1d2199bef6c4d92205f36968cddaf3e4d0e9fe35ddd405bd/soxr-1.0.0-cp312-abi3-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e8ce273cca101aff3d8c387db5a5a41001ba76ef1837883438d3c652507a9ccc", size = 204707, upload-time = "2025-09-07T13:22:05.125Z" },
     { url = "https://files.pythonhosted.org/packages/b1/87/2726603c13c2126cb8ded9e57381b7377f4f0df6ba4408e1af5ddbfdc3dd/soxr-1.0.0-cp312-abi3-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e8f2a69686f2856d37823bbb7b78c3d44904f311fe70ba49b893af11d6b6047b", size = 238032, upload-time = "2025-09-07T13:22:06.428Z" },
     { url = "https://files.pythonhosted.org/packages/ce/04/530252227f4d0721a5524a936336485dfb429bb206a66baf8e470384f4a2/soxr-1.0.0-cp312-abi3-win_amd64.whl", hash = "sha256:2a3b77b115ae7c478eecdbd060ed4f61beda542dfb70639177ac263aceda42a2", size = 172070, upload-time = "2025-09-07T13:22:07.62Z" },
+]
+
+[[package]]
+name = "soynlp"
+version = "0.0.493"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy", marker = "platform_machine == 'x86_64' and sys_platform != 'darwin'" },
+    { name = "psutil", marker = "platform_machine == 'x86_64' and sys_platform != 'darwin'" },
+    { name = "scikit-learn", marker = "platform_machine == 'x86_64' and sys_platform != 'darwin'" },
+    { name = "scipy", marker = "platform_machine == 'x86_64' and sys_platform != 'darwin'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7d/05/fb3f0c9248e60a0224e77198c31517b93b92d6060873b641caf474d42993/soynlp-0.0.493.tar.gz", hash = "sha256:4b20b825edbcadb9ebd494de54d8ca50b0ee317fe58d090e8b509d733422136a", size = 405393, upload-time = "2019-08-25T05:28:00.755Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/50/6913dc52a86a6b189419e59f9eef1b8d599cffb6f44f7bb91854165fc603/soynlp-0.0.493-py3-none-any.whl", hash = "sha256:2aed0ced1f0f74f7bdd0bdc24a979c5cb9ee4a28393642db52a83d174ed65b7a", size = 416753, upload-time = "2019-08-25T05:27:54.56Z" },
 ]
 
 [[package]]
@@ -10545,6 +10777,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/f8/84/ef50c51b5a9472e7265ce1ffc7f24cd4023d289e109f669bdb1553f6a7c2/tomli-2.3.0-cp313-cp313-win32.whl", hash = "sha256:97d5eec30149fd3294270e889b4234023f2c69747e555a27bd708828353ab606", size = 96946, upload-time = "2025-10-08T22:01:24.893Z" },
     { url = "https://files.pythonhosted.org/packages/b2/b7/718cd1da0884f281f95ccfa3a6cc572d30053cba64603f79d431d3c9b61b/tomli-2.3.0-cp313-cp313-win_amd64.whl", hash = "sha256:0c95ca56fbe89e065c6ead5b593ee64b84a26fca063b5d71a1122bf26e533999", size = 107705, upload-time = "2025-10-08T22:01:26.153Z" },
     { url = "https://files.pythonhosted.org/packages/77/b8/0135fadc89e73be292b473cb820b4f5a08197779206b33191e801feeae40/tomli-2.3.0-py3-none-any.whl", hash = "sha256:e95b1af3c5b07d9e643909b5abbec77cd9f1217e6d0bca72b0234736b9fb1f1b", size = 14408, upload-time = "2025-10-08T22:01:46.04Z" },
+]
+
+[[package]]
+name = "tomlkit"
+version = "0.14.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/af/14b24e41977adb296d6bd1fb59402cf7d60ce364f90c890bd2ec65c43b5a/tomlkit-0.14.0.tar.gz", hash = "sha256:cf00efca415dbd57575befb1f6634c4f42d2d87dbba376128adb42c121b87064", size = 187167, upload-time = "2026-01-13T01:14:53.304Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b5/11/87d6d29fb5d237229d67973a6c9e06e048f01cf4994dee194ab0ea841814/tomlkit-0.14.0-py3-none-any.whl", hash = "sha256:592064ed85b40fa213469f81ac584f67a4f2992509a7c3ea2d632208623a3680", size = 39310, upload-time = "2026-01-13T01:14:51.965Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Add Qwen3-ASR as a second implementation of Curator's shared `ASRAdapter` contract.

The PR keeps both adapters:

- `QwenASRAdapter` for `Qwen/Qwen3-ASR-0.6B`, using qwen-asr's vLLM-only `Qwen3ASRModel.LLM` path.
- The existing `QwenOmniASRAdapter`, Qwen3-Omni pipeline, dependency contract, tests, and vLLM behavior remain functionally unchanged.

There is no standalone Qwen-ASR runner. Manifest transcription uses the generic `ASRStage` adapter path.

## Qwen3-ASR adapter

- Implements the shared lifecycle names and signatures used by Qwen-Omni: `download_weights_on_node`, `load_model`, `unload_model`, and `transcribe_batch`.
- Constructs `Qwen3ASRModel.LLM` with the same engine arguments as `nkoluguri/integration-test`: model, GPU-memory utilization, inference batch size, max new tokens, remote-code trust, eager execution, prefix caching, and `xxhash`.
- Contains no Transformers `.from_pretrained` model loading or inference implementation.
- Includes the same scoped `transformers.check_model_inputs` compatibility shim as the nkoluguri reference because qwen-asr 0.0.6 still invokes the decorator-factory form.
- Maps one Curator adapter batch to one qwen-asr `transcribe` call while preserving input order and skipped positions.
- Forwards `revision` to weight download and vLLM construction.
- Exposes a copied `vllm_kwargs` dictionary; adapter-owned engine arguments cannot be overridden through it.
- Requires exactly one integer GPU per ASR actor and validates integer/resource knobs.
- Cleans up after partial model-load failure and marks empty/whitespace/None output as skipped.
- Returns detected language through `ASRResult.extras`.

`audio_cuda12` pins `qwen-asr==0.0.6`. Qwen-ASR installations compose it with Curator's shared `vllm` extra. The dependency intentionally does not use `qwen-asr[vllm]`, whose vLLM 0.14.0 pin conflicts with Curator's Qwen-Omni-compatible vLLM 0.22.0 stack.

## Generic adapter extras

`ASRStage` can persist arbitrary adapter metadata without introducing dynamic top-level columns:

- `ASRResult.extras` remains one generic adapter-owned dictionary.
- Set `ASRStage.extras_key` to write a shallow copy under one nested manifest field.
- `extras_key=None` is the default, preserving the existing Qwen-Omni output contract and existing ASRStage callers.
- Qwen-ASR configures `extras_key: asr_extras`, producing `"asr_extras": {"detected_language": "English"}`.
- Empty extras remove stale metadata for processed rows.
- Empty names and collisions with prediction, `_skipme`, or `additional_notes` columns are rejected.
- The nested dictionary is declared through `outputs()`, so executor/schema planning remains deterministic.

## Shared stage, tests, and tutorial

- Adds `tutorials/audio/qwen_asr/` using `ManifestReader -> ResampleAudioStage -> ASRStage(QwenASRAdapter) -> ManifestWriterStage`.
- Uses SoundFile to decode resampled PCM WAVs in the shared ASR stage.
- Uses Qwen's 30-code language order:
  `zh, en, yue, ar, de, fr, es, pt, id, it, ko, ru, th, vi, ja, tr, hi, ms, nl, sv, da, fi, pl, cs, fil, fa, el, hu, mk, ro`.
- Reuses `tests/fixtures/audio/qwen_omni/audio_1_5s_16khz_mono.wav`; this PR adds no duplicate WAV fixture.
- Keeps the GPU tests in `tests/models/asr/test_qwen_asr.py` under `@pytest.mark.gpu` and adds the `audio_qwen_asr` GPU test group.
- Uses `tests/fixtures/audio/tagging/sample_input.jsonl` as the documented two-file smoke input.
- Adds the tutorial-only `vllm_kwargs.max_model_len=8192` override for 12 GB GPUs; the adapter's production/reference default is unchanged.
- Makes no change to `benchmarking/README.md`.

Shared `validate_vllm_kwargs` and `merge_vllm_kwargs` helpers now live in `nemo_curator.utils.vllm_utils`. Both Qwen adapters describe their actual caller-owned constructor kwargs to `merge_vllm_kwargs`, and the duplicate adapter-local `_RESERVED_VLLM_KWARGS` constants are removed. Protected-key collision checking now occurs once, inside the shared merge helper when `load_model()` assembles engine kwargs; the adapters no longer repeat validation in `__post_init__`. Qwen-Omni's protected-key behavior, engine arguments, and output contract remain unchanged.

## Current-main integration

- PR head: `4c8ac6f6604ec71ea5919ee014e4137ee1d0e560`
- Integrated `main`: `09ae28c41cfb7704d66eb4d6cbffc33fc6f05fe3`
- History: three DCO-signed commits on current main

## Validation

### Current head

- 173 focused Qwen-ASR, Qwen-Omni, generic ASRStage, tutorial-contract, configuration, lazy-import, and shared-vLLM utility tests passed; 2 GPU tests were deselected.
- Exact Qwen-ASR and Qwen-Omni constructor-call tests pass after the shared kwargs merge refactor.
- Ruff formatting and lint checks passed.
- `uv lock --check` passed with the current-main-required uv 0.12.2.
- `git diff --check` passed.
- GPU-test-group coverage passed for all 46 GPU test files.
- GitHub DCO passes for all three signed commits.

### Local GPU and tutorial smoke

The earlier head `ddfb74cdc423dec0ffe64dae3e05fcf210b14617` passed:

- Real one-GPU vLLM smoke on an RTX 3080 Ti using qwen-asr 0.0.6, vLLM 0.22.0, and the existing Qwen-Omni WAV fixture.
- The documented Ray Data tutorial command on both bundled OPUS inputs: 2/2 nonempty transcripts, no skips, and `asr_extras.detected_language == "English"`.

The current head has not repeated that GPU smoke after the main rebase and kwargs-assembly refactor. The exact constructor tests confirm that the refactor preserves the engine arguments used by both Qwen adapters.

### Latest paired Qwen3-ASR parity

The latest paired run compared target commit `ddfb74cdc423dec0ffe64dae3e05fcf210b14617` with `nkoluguri/integration-test` commit `fff467c8d2e3632f9a96c96ec34cd0e6614503da`, using the same frozen eight-row English cohort (569.486 seconds), one node, and one L40 per arm.

- Target run: `1dc99ea4-4b0f-438d-832d-5d902384453b`
- Reference run: `0443d025-95c7-42f8-a68b-ee510c9ce0e1`
- Both independently submitted arms and all tasks succeeded on their first attempt.
- 8/8 expected identities and nonempty predictions in each arm.
- 8/8 target `asr_extras.detected_language` values matched reference `asr_language`; all were `English`.
- No missing, unexpected, duplicate, skipped, malformed, empty, forbidden-payload, or published-WAV cases.
- Mean normalized token similarity: `0.9699208113126543` (gate: at least `0.95`).
- Rows with normalized similarity at least `0.95`: `7/8` (gate: at least `7/8`).
- Normalized exact matches: `2/8`; raw exact matches: `1/8`.
- Lowest row similarity: `0.8516129032258064`.

The target used qwen-asr 0.0.6 with Curator's vLLM 0.22.0 stack; the remote-exact reference used qwen-asr 0.0.6 with its pinned vLLM 0.14.0 stack. Timing is therefore a canary observation, not a performance comparison.

Since the parity-tested head, the branch was rebased onto current `main` and the host-side vLLM kwargs validation/assembly was centralized. The actual Qwen-ASR engine values, input contract, output mapping, and inference path are unchanged; live parity has not been rerun after this review refactor.

## Diff

- 18 files changed
- 1,490 insertions / 32 deletions
