### PR TITLE
feat(audio): select the best ASR prediction

### DIFF
--- a/nemo_curator/stages/audio/text_filtering/__init__.py
+++ b/nemo_curator/stages/audio/text_filtering/__init__.py
@@ -14,8 +14,10 @@
 
 """Audio transcript filtering stages."""
 
+from .select_best_prediction import SelectBestPredictionStage
 from .whisper_hallucination import WhisperHallucinationStage
 
 __all__ = [
+    "SelectBestPredictionStage",
     "WhisperHallucinationStage",
 ]

--- a/nemo_curator/stages/audio/text_filtering/select_best_prediction.py
+++ b/nemo_curator/stages/audio/text_filtering/select_best_prediction.py
@@ -106,7 +106,7 @@ class SelectBestPredictionStage(ProcessingStage[AudioTask, AudioTask]):
     def outputs(self) -> tuple[list[str], list[str]]:
         return [], [self.output_key, self.source_key, self.skip_me_key, self.agreement_wer_key, self.notes_key]
 
-    def _select(self, task: AudioTask) -> None:  # noqa: C901, PLR0911, PLR0912, PLR0915
+    def process(self, task: AudioTask) -> AudioTask:  # noqa: C901, PLR0911, PLR0912, PLR0915
         task.data.pop(self.agreement_wer_key, None)
 
         if (
@@ -131,7 +131,7 @@ class SelectBestPredictionStage(ProcessingStage[AudioTask, AudioTask]):
                         f"Ground Truth (short audio {duration:.2f}s < {self.short_audio_threshold}s)",
                         self.notes_key,
                     )
-                    return
+                    return task
 
         resolved_fallback_text_key = self.asr_text_key or self.fallback_text_key
         primary = str(task.data.get(self.primary_text_key, "") or "")
@@ -146,7 +146,7 @@ class SelectBestPredictionStage(ProcessingStage[AudioTask, AudioTask]):
             task.data[self.source_key] = self.ground_truth_source_label
             task.data[self.skip_me_key] = ""
             _set_note(task.data, self.name, "forced:ground_truth", self.notes_key)
-            return
+            return task
 
         primary_unsupported = "lang_not_supported" in str(notes.get(self.primary_text_key, ""))
         fallback_unsupported = "lang_not_supported" in str(notes.get(resolved_fallback_text_key, ""))
@@ -158,21 +158,21 @@ class SelectBestPredictionStage(ProcessingStage[AudioTask, AudioTask]):
                 task.data[self.source_key] = self.ground_truth_source_label
                 task.data[self.skip_me_key] = ""
                 _set_note(task.data, self.name, "Ground Truth", self.notes_key)
-                return
+                return task
 
         if primary_unsupported and fallback_unsupported:
             task.data[self.output_key] = ""
             task.data[self.source_key] = "none"
             task.data[self.skip_me_key] = "not_supported"
             _set_note(task.data, self.name, "skipped:both_models_lang_not_supported", self.notes_key)
-            return
+            return task
 
         if primary_unsupported and not fallback:
             task.data[self.output_key] = ""
             task.data[self.source_key] = "none"
             task.data[self.skip_me_key] = "not_supported"
             _set_note(task.data, self.name, "skipped:primary_lang_not_supported_no_fallback", self.notes_key)
-            return
+            return task
 
         if primary_unsupported and fallback:
             task.data[self.output_key] = fallback
@@ -184,7 +184,7 @@ class SelectBestPredictionStage(ProcessingStage[AudioTask, AudioTask]):
                 f"used {self.fallback_source_label} (primary lang unsupported)",
                 self.notes_key,
             )
-            return
+            return task
 
         if self.recovery_note_key:
             recovered = "recovered" in str(notes.get(self.recovery_note_key, "")).lower()
@@ -195,7 +195,7 @@ class SelectBestPredictionStage(ProcessingStage[AudioTask, AudioTask]):
             task.data[self.source_key] = self.fallback_source_label
             task.data[self.skip_me_key] = ""
             _set_note(task.data, self.name, f"used {self.fallback_source_label}", self.notes_key)
-            return
+            return task
 
         if self.use_reference_on_hallucination and self.reference_text_key and skip_reason.startswith("Hallucination"):
             reference = str(task.data.get(self.reference_text_key, "") or "").strip()
@@ -209,7 +209,7 @@ class SelectBestPredictionStage(ProcessingStage[AudioTask, AudioTask]):
                     f"recovered:reference_text (hallucination_detected, fallback={self.reference_text_key})",
                     self.notes_key,
                 )
-                return
+                return task
 
         if skip_reason.startswith("Hallucination") and primary and fallback:
             wer = _word_error_rate_percent(primary, fallback)
@@ -224,12 +224,9 @@ class SelectBestPredictionStage(ProcessingStage[AudioTask, AudioTask]):
                     f"recovered:cross_model_agreement (wer={wer:.1f}%)",
                     self.notes_key,
                 )
-                return
+                return task
 
         task.data[self.output_key] = primary
         task.data[self.source_key] = self.primary_source_label
         _set_note(task.data, self.name, f"used {self.primary_source_label}", self.notes_key)
-
-    def process(self, task: AudioTask) -> AudioTask:
-        self._select(task)
         return task

--- a/nemo_curator/stages/audio/text_filtering/select_best_prediction.py
+++ b/nemo_curator/stages/audio/text_filtering/select_best_prediction.py
@@ -167,6 +167,7 @@ class SelectBestPredictionStage(ProcessingStage[AudioTask, AudioTask]):
         if primary_unsupported and fallback:
             task.data[self.output_key] = fallback
             task.data[self.source_key] = self.fallback_source_label
+            task.data[self.skip_me_key] = ""
             _set_note(
                 task.data,
                 self.name,

--- a/nemo_curator/stages/audio/text_filtering/select_best_prediction.py
+++ b/nemo_curator/stages/audio/text_filtering/select_best_prediction.py
@@ -1,0 +1,235 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import re
+from dataclasses import dataclass, field
+from typing import Any
+
+from nemo_curator.stages.base import ProcessingStage
+from nemo_curator.stages.resources import Resources
+from nemo_curator.tasks import AudioTask
+
+_PUNCTUATION = re.compile(r"[^\w\s]", re.UNICODE)
+
+
+def _set_note(data: dict[str, Any], stage: str, value: str, notes_key: str) -> None:
+    notes = data.get(notes_key)
+    if not isinstance(notes, dict):
+        notes = {}
+        data[notes_key] = notes
+    notes[stage] = value
+
+
+def _normalized_words(text: str) -> list[str]:
+    return _PUNCTUATION.sub("", text).lower().split()
+
+
+def _word_error_rate_percent(reference: str, hypothesis: str) -> float:
+    """Return word-level Levenshtein distance as a percentage."""
+    ref = _normalized_words(reference)
+    hyp = _normalized_words(hypothesis)
+    if not ref:
+        return 0.0 if not hyp else 100.0
+
+    previous = list(range(len(hyp) + 1))
+    for ref_index, ref_word in enumerate(ref, start=1):
+        current = [ref_index]
+        for hyp_index, hyp_word in enumerate(hyp, start=1):
+            current.append(
+                min(
+                    previous[hyp_index] + 1,
+                    current[hyp_index - 1] + 1,
+                    previous[hyp_index - 1] + (ref_word != hyp_word),
+                )
+            )
+        previous = current
+    return round(100.0 * previous[-1] / len(ref), 2)
+
+
+@dataclass
+class SelectBestPredictionStage(ProcessingStage[AudioTask, AudioTask]):
+    """Choose one stable transcript from primary, recovery, or reference text.
+
+    Selection is ordered so explicit reference policies run before model
+    recovery. Short Qwen-Omni clips can use reference text to avoid known
+    sub-second hallucinations, and ``force_reference`` can make reference text
+    authoritative for datasets whose model output is not trusted. Otherwise,
+    the stage handles unsupported languages, recovered fallback predictions,
+    reference recovery, cross-model agreement, and the normal primary result.
+    ``asr_text_key`` is a compatibility alias that overrides
+    ``fallback_text_key`` when supplied. ``recovery_note_key`` can scope
+    fallback recovery to one producer's note; otherwise all notes except this
+    stage's prior decision note are inspected.
+    """
+
+    primary_text_key: str = "primary_model_prediction"
+    fallback_text_key: str = "fallback_model_prediction"
+    asr_text_key: str | None = None
+    output_key: str = "best_prediction"
+    source_key: str = "best_prediction_source"
+    notes_key: str = "additional_notes"
+    skip_me_key: str = "_skipme"
+    recovery_note_key: str | None = None
+    duration_key: str = "duration"
+    min_agreement_pct: float = 80.0
+    agreement_wer_key: str = "primary_fallback_agreement_wer"
+    primary_source_label: str = "primary"
+    fallback_source_label: str = "fallback"
+    reference_text_key: str | None = None
+    use_reference_on_hallucination: bool = False
+    force_reference: bool = False
+    use_ground_truth_for_short_audio: bool = True
+    short_audio_threshold: float = 1.0
+    primary_model_type: str | None = None
+    reference_source_label: str = "reference"
+    ground_truth_source_label: str = "ground_truth"
+    name: str = "SelectBestPrediction"
+    resources: Resources = field(default_factory=lambda: Resources(cpus=1.0))
+
+    def inputs(self) -> tuple[list[str], list[str]]:
+        keys = [self.primary_text_key]
+        if self.reference_text_key:
+            keys.append(self.reference_text_key)
+        return [], keys
+
+    def outputs(self) -> tuple[list[str], list[str]]:
+        return [], [self.output_key, self.source_key, self.skip_me_key, self.agreement_wer_key, self.notes_key]
+
+    def _select(self, task: AudioTask) -> None:  # noqa: C901, PLR0911, PLR0912, PLR0915
+        task.data.pop(self.agreement_wer_key, None)
+
+        if (
+            self.use_ground_truth_for_short_audio
+            and self.reference_text_key
+            and self.primary_model_type == "qwen_omni"
+        ):
+            duration_raw = task.data.get(self.duration_key)
+            try:
+                duration = float(duration_raw)
+            except (TypeError, ValueError):
+                duration = None
+            if duration is not None and 0.0 < duration < self.short_audio_threshold:
+                reference = str(task.data.get(self.reference_text_key, "") or "").strip()
+                if reference:
+                    task.data[self.output_key] = reference
+                    task.data[self.source_key] = self.ground_truth_source_label
+                    task.data[self.skip_me_key] = ""
+                    _set_note(
+                        task.data,
+                        self.name,
+                        f"Ground Truth (short audio {duration:.2f}s < {self.short_audio_threshold}s)",
+                        self.notes_key,
+                    )
+                    return
+
+        resolved_fallback_text_key = self.asr_text_key or self.fallback_text_key
+        primary = str(task.data.get(self.primary_text_key, "") or "")
+        fallback = str(task.data.get(resolved_fallback_text_key, "") or "")
+        notes = task.data.get(self.notes_key)
+        notes = notes if isinstance(notes, dict) else {}
+        skip_reason = str(task.data.get(self.skip_me_key, "") or "")
+
+        if self.force_reference and self.reference_text_key:
+            reference = str(task.data.get(self.reference_text_key, "") or "").strip()
+            task.data[self.output_key] = reference
+            task.data[self.source_key] = self.ground_truth_source_label
+            task.data[self.skip_me_key] = ""
+            _set_note(task.data, self.name, "forced:ground_truth", self.notes_key)
+            return
+
+        primary_unsupported = "lang_not_supported" in str(notes.get(self.primary_text_key, ""))
+        fallback_unsupported = "lang_not_supported" in str(notes.get(resolved_fallback_text_key, ""))
+
+        if primary_unsupported and not fallback and self.reference_text_key:
+            reference = str(task.data.get(self.reference_text_key, "") or "").strip()
+            if reference:
+                task.data[self.output_key] = reference
+                task.data[self.source_key] = self.ground_truth_source_label
+                task.data[self.skip_me_key] = ""
+                _set_note(task.data, self.name, "Ground Truth", self.notes_key)
+                return
+
+        if primary_unsupported and fallback_unsupported:
+            task.data[self.output_key] = ""
+            task.data[self.source_key] = "none"
+            task.data[self.skip_me_key] = "not_supported"
+            _set_note(task.data, self.name, "skipped:both_models_lang_not_supported", self.notes_key)
+            return
+
+        if primary_unsupported and not fallback:
+            task.data[self.output_key] = ""
+            task.data[self.source_key] = "none"
+            task.data[self.skip_me_key] = "not_supported"
+            _set_note(task.data, self.name, "skipped:primary_lang_not_supported_no_fallback", self.notes_key)
+            return
+
+        if primary_unsupported and fallback:
+            task.data[self.output_key] = fallback
+            task.data[self.source_key] = self.fallback_source_label
+            task.data[self.skip_me_key] = ""
+            _set_note(
+                task.data,
+                self.name,
+                f"used {self.fallback_source_label} (primary lang unsupported)",
+                self.notes_key,
+            )
+            return
+
+        if self.recovery_note_key:
+            recovered = "recovered" in str(notes.get(self.recovery_note_key, "")).lower()
+        else:
+            recovered = any(key != self.name and "recovered" in str(value).lower() for key, value in notes.items())
+        if recovered and fallback:
+            task.data[self.output_key] = fallback
+            task.data[self.source_key] = self.fallback_source_label
+            task.data[self.skip_me_key] = ""
+            _set_note(task.data, self.name, f"used {self.fallback_source_label}", self.notes_key)
+            return
+
+        if self.use_reference_on_hallucination and self.reference_text_key and skip_reason.startswith("Hallucination"):
+            reference = str(task.data.get(self.reference_text_key, "") or "").strip()
+            if reference:
+                task.data[self.output_key] = reference
+                task.data[self.source_key] = self.reference_source_label
+                task.data[self.skip_me_key] = ""
+                _set_note(
+                    task.data,
+                    self.name,
+                    f"recovered:reference_text (hallucination_detected, fallback={self.reference_text_key})",
+                    self.notes_key,
+                )
+                return
+
+        if skip_reason.startswith("Hallucination") and primary and fallback:
+            wer = _word_error_rate_percent(primary, fallback)
+            task.data[self.agreement_wer_key] = wer
+            if wer <= 100.0 - self.min_agreement_pct:
+                task.data[self.output_key] = primary
+                task.data[self.source_key] = self.primary_source_label
+                task.data[self.skip_me_key] = ""
+                _set_note(
+                    task.data,
+                    self.name,
+                    f"recovered:cross_model_agreement (wer={wer:.1f}%)",
+                    self.notes_key,
+                )
+                return
+
+        task.data[self.output_key] = primary
+        task.data[self.source_key] = self.primary_source_label
+        _set_note(task.data, self.name, f"used {self.primary_source_label}", self.notes_key)
+
+    def process(self, task: AudioTask) -> AudioTask:
+        self._select(task)
+        return task

--- a/nemo_curator/stages/audio/text_filtering/select_best_prediction.py
+++ b/nemo_curator/stages/audio/text_filtering/select_best_prediction.py
@@ -54,7 +54,7 @@ def _word_error_rate_percent(reference: str, hypothesis: str) -> float:
                 )
             )
         previous = current
-    return round(100.0 * previous[-1] / len(ref), 2)
+    return round(previous[-1] / len(ref) * 100.0, 2)
 
 
 @dataclass
@@ -68,9 +68,7 @@ class SelectBestPredictionStage(ProcessingStage[AudioTask, AudioTask]):
     the stage handles unsupported languages, recovered fallback predictions,
     reference recovery, cross-model agreement, and the normal primary result.
     ``asr_text_key`` is a compatibility alias that overrides
-    ``fallback_text_key`` when supplied. ``recovery_note_key`` can scope
-    fallback recovery to one producer's note; otherwise all notes except this
-    stage's prior decision note are inspected.
+    ``fallback_text_key`` when supplied.
     """
 
     primary_text_key: str = "primary_model_prediction"
@@ -80,7 +78,6 @@ class SelectBestPredictionStage(ProcessingStage[AudioTask, AudioTask]):
     source_key: str = "best_prediction_source"
     notes_key: str = "additional_notes"
     skip_me_key: str = "_skipme"
-    recovery_note_key: str | None = None
     duration_key: str = "duration"
     min_agreement_pct: float = 80.0
     agreement_wer_key: str = "primary_fallback_agreement_wer"
@@ -167,17 +164,9 @@ class SelectBestPredictionStage(ProcessingStage[AudioTask, AudioTask]):
             _set_note(task.data, self.name, "skipped:both_models_lang_not_supported", self.notes_key)
             return task
 
-        if primary_unsupported and not fallback:
-            task.data[self.output_key] = ""
-            task.data[self.source_key] = "none"
-            task.data[self.skip_me_key] = "not_supported"
-            _set_note(task.data, self.name, "skipped:primary_lang_not_supported_no_fallback", self.notes_key)
-            return task
-
         if primary_unsupported and fallback:
             task.data[self.output_key] = fallback
             task.data[self.source_key] = self.fallback_source_label
-            task.data[self.skip_me_key] = ""
             _set_note(
                 task.data,
                 self.name,
@@ -186,14 +175,10 @@ class SelectBestPredictionStage(ProcessingStage[AudioTask, AudioTask]):
             )
             return task
 
-        if self.recovery_note_key:
-            recovered = "recovered" in str(notes.get(self.recovery_note_key, "")).lower()
-        else:
-            recovered = any(key != self.name and "recovered" in str(value).lower() for key, value in notes.items())
+        recovered = any("recovered" in str(value).lower() for value in notes.values())
         if recovered and fallback:
             task.data[self.output_key] = fallback
             task.data[self.source_key] = self.fallback_source_label
-            task.data[self.skip_me_key] = ""
             _set_note(task.data, self.name, f"used {self.fallback_source_label}", self.notes_key)
             return task
 

--- a/tests/stages/audio/text_filtering/__init__.py
+++ b/tests/stages/audio/text_filtering/__init__.py
@@ -1,1 +1,0 @@
-"""Tests for audio text-filtering stages."""

--- a/tests/stages/audio/text_filtering/__init__.py
+++ b/tests/stages/audio/text_filtering/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for audio text-filtering stages."""

--- a/tests/stages/audio/text_filtering/test_select_best_prediction.py
+++ b/tests/stages/audio/text_filtering/test_select_best_prediction.py
@@ -35,7 +35,8 @@ def test_uses_recovery_prediction_after_hallucination_recheck() -> None:
     assert task.data["_skipme"] == "Hallucination"
 
 
-def test_falls_back_when_primary_language_is_unsupported() -> None:
+def test_selects_supported_fallback_and_clears_primary_language_skip() -> None:
+    """The primary adapter was skipped; a separate supported model produced the fallback."""
     task = AudioTask(
         data={
             "primary_model_prediction": "",
@@ -49,7 +50,11 @@ def test_falls_back_when_primary_language_is_unsupported() -> None:
 
     assert task.data["best_prediction"] == "bonjour"
     assert task.data["best_prediction_source"] == "fallback"
-    assert task.data["_skipme"] == "language_not_supported"
+    assert task.data["_skipme"] == ""
+    assert task.data["additional_notes"] == {
+        "primary_model_prediction": "lang_not_supported:fr",
+        "SelectBestPrediction": "used fallback (primary lang unsupported)",
+    }
 
 
 def test_unsupported_primary_without_fallback_matches_reference_fallthrough() -> None:

--- a/tests/stages/audio/text_filtering/test_select_best_prediction.py
+++ b/tests/stages/audio/text_filtering/test_select_best_prediction.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# ruff: noqa: INP001
+
 from copy import deepcopy
 
 from nemo_curator.stages.audio.text_filtering import SelectBestPredictionStage

--- a/tests/stages/audio/text_filtering/test_select_best_prediction.py
+++ b/tests/stages/audio/text_filtering/test_select_best_prediction.py
@@ -1,0 +1,361 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from nemo_curator.stages.audio.text_filtering.select_best_prediction import SelectBestPredictionStage
+from nemo_curator.tasks import AudioTask
+
+
+def test_uses_recovery_prediction_after_hallucination_recheck() -> None:
+    task = AudioTask(
+        data={
+            "primary_model_prediction": "loop loop loop",
+            "fallback_model_prediction": "a valid transcript",
+            "_skipme": "Hallucination",
+            "additional_notes": {"recheck": "Recovered"},
+        }
+    )
+
+    SelectBestPredictionStage().process(task)
+
+    assert task.data["best_prediction"] == "a valid transcript"
+    assert task.data["best_prediction_source"] == "fallback"
+    assert task.data["_skipme"] == ""
+
+
+def test_falls_back_when_primary_language_is_unsupported() -> None:
+    task = AudioTask(
+        data={
+            "primary_model_prediction": "",
+            "fallback_model_prediction": "bonjour",
+            "_skipme": "language_not_supported",
+            "additional_notes": {"primary_model_prediction": "lang_not_supported:fr"},
+        }
+    )
+
+    SelectBestPredictionStage().process(task)
+
+    assert task.data["best_prediction"] == "bonjour"
+    assert task.data["best_prediction_source"] == "fallback"
+    assert task.data["_skipme"] == ""
+
+
+def test_marks_unsupported_primary_without_fallback_as_unusable() -> None:
+    task = AudioTask(
+        data={
+            "primary_model_prediction": "",
+            "fallback_model_prediction": "",
+            "_skipme": "language_not_supported",
+            "additional_notes": {"primary_model_prediction": "lang_not_supported:fr"},
+        }
+    )
+
+    SelectBestPredictionStage().process(task)
+
+    assert task.data["best_prediction"] == ""
+    assert task.data["best_prediction_source"] == "none"
+    assert task.data["_skipme"] == "not_supported"
+
+
+def test_accepts_reference_asr_key_name() -> None:
+    task = AudioTask(
+        data={
+            "primary_model_prediction": "loop loop loop",
+            "recovery_prediction": "a valid transcript",
+            "_skipme": "Hallucination",
+            "additional_notes": {"recheck": "Recovered"},
+        }
+    )
+
+    SelectBestPredictionStage(asr_text_key="recovery_prediction").process(task)
+
+    assert task.data["best_prediction"] == "a valid transcript"
+    assert task.data["best_prediction_source"] == "fallback"
+    assert task.data["_skipme"] == ""
+
+
+def test_uses_reference_when_no_model_supports_language() -> None:
+    task = AudioTask(
+        data={
+            "primary_model_prediction": "",
+            "fallback_model_prediction": "",
+            "original": "dataset transcript",
+            "additional_notes": {"primary_model_prediction": "lang_not_supported:xx"},
+        }
+    )
+    stage = SelectBestPredictionStage(reference_text_key="original")
+
+    stage.process(task)
+
+    assert task.data["best_prediction"] == "dataset transcript"
+    assert task.data["best_prediction_source"] == "ground_truth"
+
+
+def test_marks_sample_unsupported_when_neither_model_supports_language() -> None:
+    task = AudioTask(
+        data={
+            "primary_model_prediction": "",
+            "fallback_model_prediction": "",
+            "additional_notes": {
+                "primary_model_prediction": "lang_not_supported:xx",
+                "fallback_model_prediction": "lang_not_supported:xx",
+            },
+        }
+    )
+
+    SelectBestPredictionStage().process(task)
+
+    assert task.data["best_prediction"] == ""
+    assert task.data["best_prediction_source"] == "none"
+    assert task.data["_skipme"] == "not_supported"
+
+
+def test_uses_reference_to_recover_a_hallucinated_primary() -> None:
+    task = AudioTask(
+        data={
+            "primary_model_prediction": "loop loop loop",
+            "original": "dataset transcript",
+            "_skipme": "Hallucination",
+        }
+    )
+    stage = SelectBestPredictionStage(
+        reference_text_key="original",
+        use_reference_on_hallucination=True,
+    )
+
+    stage.process(task)
+
+    assert task.data["best_prediction"] == "dataset transcript"
+    assert task.data["best_prediction_source"] == "reference"
+    assert task.data["_skipme"] == ""
+
+
+def test_forces_reference_without_consulting_model_results() -> None:
+    task = AudioTask(
+        data={
+            "primary_model_prediction": "primary transcript",
+            "fallback_model_prediction": "fallback transcript",
+            "original": "dataset transcript",
+            "_skipme": "Hallucination",
+            "additional_notes": {"recheck": "Recovered"},
+        }
+    )
+    stage = SelectBestPredictionStage(reference_text_key="original", force_reference=True)
+
+    stage.process(task)
+
+    assert task.data["best_prediction"] == "dataset transcript"
+    assert task.data["best_prediction_source"] == "ground_truth"
+    assert task.data["_skipme"] == ""
+    assert task.data["additional_notes"]["SelectBestPrediction"] == "forced:ground_truth"
+
+
+def test_forced_reference_preserves_an_intentionally_empty_reference() -> None:
+    task = AudioTask(
+        data={
+            "primary_model_prediction": "primary transcript",
+            "original": "   ",
+            "_skipme": "Hallucination",
+        }
+    )
+    stage = SelectBestPredictionStage(reference_text_key="original", force_reference=True)
+
+    stage.process(task)
+
+    assert task.data["best_prediction"] == ""
+    assert task.data["best_prediction_source"] == "ground_truth"
+    assert task.data["_skipme"] == ""
+
+
+def test_uses_reference_for_short_qwen_omni_audio() -> None:
+    task = AudioTask(
+        data={
+            "primary_model_prediction": "hallucinated transcript",
+            "original": "dataset transcript",
+            "duration": "0.25",
+            "_skipme": "Hallucination",
+        }
+    )
+    stage = SelectBestPredictionStage(reference_text_key="original", primary_model_type="qwen_omni")
+
+    stage.process(task)
+
+    assert task.data["best_prediction"] == "dataset transcript"
+    assert task.data["best_prediction_source"] == "ground_truth"
+    assert task.data["_skipme"] == ""
+    assert task.data["additional_notes"]["SelectBestPrediction"] == "Ground Truth (short audio 0.25s < 1.0s)"
+
+
+def test_short_audio_reference_requires_qwen_omni_and_valid_duration() -> None:
+    cases = [
+        ("parakeet", 0.25),
+        ("qwen_omni", None),
+        ("qwen_omni", "invalid"),
+        ("qwen_omni", 0.0),
+        ("qwen_omni", -0.25),
+        ("qwen_omni", 1.0),
+    ]
+
+    for primary_model_type, duration in cases:
+        task = AudioTask(
+            data={
+                "primary_model_prediction": "primary transcript",
+                "original": "dataset transcript",
+                "duration": duration,
+            }
+        )
+        stage = SelectBestPredictionStage(
+            reference_text_key="original",
+            primary_model_type=primary_model_type,
+        )
+
+        stage.process(task)
+
+        assert task.data["best_prediction"] == "primary transcript", (primary_model_type, duration)
+        assert task.data["best_prediction_source"] == "primary", (primary_model_type, duration)
+
+
+def test_short_audio_reference_can_be_disabled() -> None:
+    task = AudioTask(
+        data={
+            "primary_model_prediction": "primary transcript",
+            "original": "dataset transcript",
+            "duration": 0.25,
+        }
+    )
+    stage = SelectBestPredictionStage(
+        reference_text_key="original",
+        primary_model_type="qwen_omni",
+        use_ground_truth_for_short_audio=False,
+    )
+
+    stage.process(task)
+
+    assert task.data["best_prediction"] == "primary transcript"
+    assert task.data["best_prediction_source"] == "primary"
+
+
+def test_cross_model_agreement_recovers_primary() -> None:
+    task = AudioTask(
+        data={
+            "primary_model_prediction": "Hello, world!",
+            "fallback_model_prediction": "hello world",
+            "_skipme": "Hallucination",
+        }
+    )
+
+    SelectBestPredictionStage().process(task)
+
+    assert task.data["best_prediction"] == "Hello, world!"
+    assert task.data["best_prediction_source"] == "primary"
+    assert task.data["_skipme"] == ""
+    assert task.data["primary_fallback_agreement_wer"] == 0.0
+
+
+def test_cross_model_agreement_uses_reference_wer_rounding() -> None:
+    task = AudioTask(
+        data={
+            "primary_model_prediction": "one two three",
+            "fallback_model_prediction": "one two",
+            "_skipme": "Hallucination",
+        }
+    )
+    stage = SelectBestPredictionStage(min_agreement_pct=66.67)
+
+    stage.process(task)
+
+    assert task.data["primary_fallback_agreement_wer"] == 33.33
+    assert task.data["best_prediction"] == "one two three"
+    assert task.data["_skipme"] == ""
+
+
+def test_cross_model_disagreement_preserves_hallucination_skip() -> None:
+    task = AudioTask(
+        data={
+            "primary_model_prediction": "one two three",
+            "fallback_model_prediction": "completely different transcript",
+            "_skipme": "Hallucination",
+        }
+    )
+
+    SelectBestPredictionStage().process(task)
+
+    assert task.data["best_prediction"] == "one two three"
+    assert task.data["best_prediction_source"] == "primary"
+    assert task.data["_skipme"] == "Hallucination"
+    assert task.data["primary_fallback_agreement_wer"] > 20.0
+
+
+def test_recovery_note_key_ignores_unrelated_recovery_notes() -> None:
+    task = AudioTask(
+        data={
+            "primary_model_prediction": "primary transcript",
+            "fallback_model_prediction": "fallback transcript",
+            "additional_notes": {
+                "earlier_stage": "Recovered",
+                "fallback_recheck": "passed",
+            },
+        }
+    )
+    stage = SelectBestPredictionStage(recovery_note_key="fallback_recheck")
+
+    stage.process(task)
+
+    assert task.data["best_prediction"] == "primary transcript"
+    assert task.data["best_prediction_source"] == "primary"
+
+
+def test_rerunning_cross_model_agreement_is_idempotent() -> None:
+    task = AudioTask(
+        data={
+            "primary_model_prediction": "Hello, world!",
+            "fallback_model_prediction": "hello world",
+            "_skipme": "Hallucination",
+        }
+    )
+    stage = SelectBestPredictionStage()
+
+    stage.process(task)
+    stage.process(task)
+
+    assert task.data["best_prediction"] == "Hello, world!"
+    assert task.data["best_prediction_source"] == "primary"
+    assert task.data["_skipme"] == ""
+    assert "primary_fallback_agreement_wer" not in task.data
+    assert task.data["additional_notes"]["SelectBestPrediction"] == "used primary"
+
+
+def test_declares_every_mutated_output_key() -> None:
+    stage = SelectBestPredictionStage()
+
+    assert stage.outputs() == (
+        [],
+        [
+            "best_prediction",
+            "best_prediction_source",
+            "_skipme",
+            "primary_fallback_agreement_wer",
+            "additional_notes",
+        ],
+    )
+
+
+def test_keeps_primary_by_default() -> None:
+    tasks = [
+        AudioTask(data={"primary_model_prediction": "one"}),
+        AudioTask(data={"primary_model_prediction": "two"}),
+    ]
+
+    SelectBestPredictionStage().process_batch(tasks)
+
+    assert [task.data["best_prediction"] for task in tasks] == ["one", "two"]

--- a/tests/stages/audio/text_filtering/test_select_best_prediction.py
+++ b/tests/stages/audio/text_filtering/test_select_best_prediction.py
@@ -14,7 +14,7 @@
 
 from copy import deepcopy
 
-from nemo_curator.stages.audio.text_filtering.select_best_prediction import SelectBestPredictionStage
+from nemo_curator.stages.audio.text_filtering import SelectBestPredictionStage
 from nemo_curator.tasks import AudioTask
 
 

--- a/tests/stages/audio/text_filtering/test_select_best_prediction.py
+++ b/tests/stages/audio/text_filtering/test_select_best_prediction.py
@@ -32,7 +32,7 @@ def test_uses_recovery_prediction_after_hallucination_recheck() -> None:
 
     assert task.data["best_prediction"] == "a valid transcript"
     assert task.data["best_prediction_source"] == "fallback"
-    assert task.data["_skipme"] == ""
+    assert task.data["_skipme"] == "Hallucination"
 
 
 def test_falls_back_when_primary_language_is_unsupported() -> None:
@@ -49,10 +49,10 @@ def test_falls_back_when_primary_language_is_unsupported() -> None:
 
     assert task.data["best_prediction"] == "bonjour"
     assert task.data["best_prediction_source"] == "fallback"
-    assert task.data["_skipme"] == ""
+    assert task.data["_skipme"] == "language_not_supported"
 
 
-def test_marks_unsupported_primary_without_fallback_as_unusable() -> None:
+def test_unsupported_primary_without_fallback_matches_reference_fallthrough() -> None:
     task = AudioTask(
         data={
             "primary_model_prediction": "",
@@ -65,8 +65,8 @@ def test_marks_unsupported_primary_without_fallback_as_unusable() -> None:
     SelectBestPredictionStage().process(task)
 
     assert task.data["best_prediction"] == ""
-    assert task.data["best_prediction_source"] == "none"
-    assert task.data["_skipme"] == "not_supported"
+    assert task.data["best_prediction_source"] == "primary"
+    assert task.data["_skipme"] == "language_not_supported"
 
 
 def test_accepts_reference_asr_key_name() -> None:
@@ -83,7 +83,7 @@ def test_accepts_reference_asr_key_name() -> None:
 
     assert task.data["best_prediction"] == "a valid transcript"
     assert task.data["best_prediction_source"] == "fallback"
-    assert task.data["_skipme"] == ""
+    assert task.data["_skipme"] == "Hallucination"
 
 
 def test_uses_reference_when_no_model_supports_language() -> None:
@@ -298,7 +298,7 @@ def test_cross_model_disagreement_preserves_hallucination_skip() -> None:
     assert task.data["primary_fallback_agreement_wer"] > 20.0
 
 
-def test_recovery_note_key_ignores_unrelated_recovery_notes() -> None:
+def test_scans_all_recovery_notes_like_reference() -> None:
     task = AudioTask(
         data={
             "primary_model_prediction": "primary transcript",
@@ -309,15 +309,13 @@ def test_recovery_note_key_ignores_unrelated_recovery_notes() -> None:
             },
         }
     )
-    stage = SelectBestPredictionStage(recovery_note_key="fallback_recheck")
+    SelectBestPredictionStage().process(task)
 
-    stage.process(task)
-
-    assert task.data["best_prediction"] == "primary transcript"
-    assert task.data["best_prediction_source"] == "primary"
+    assert task.data["best_prediction"] == "fallback transcript"
+    assert task.data["best_prediction_source"] == "fallback"
 
 
-def test_rerunning_cross_model_agreement_is_idempotent() -> None:
+def test_rerunning_cross_model_agreement_scans_the_prior_recovery_note() -> None:
     task = AudioTask(
         data={
             "primary_model_prediction": "Hello, world!",
@@ -330,11 +328,11 @@ def test_rerunning_cross_model_agreement_is_idempotent() -> None:
     stage.process(task)
     stage.process(task)
 
-    assert task.data["best_prediction"] == "Hello, world!"
-    assert task.data["best_prediction_source"] == "primary"
+    assert task.data["best_prediction"] == "hello world"
+    assert task.data["best_prediction_source"] == "fallback"
     assert task.data["_skipme"] == ""
     assert "primary_fallback_agreement_wer" not in task.data
-    assert task.data["additional_notes"]["SelectBestPrediction"] == "used primary"
+    assert task.data["additional_notes"]["SelectBestPrediction"] == "used fallback"
 
 
 def test_declares_every_mutated_output_key() -> None:
@@ -380,7 +378,6 @@ def test_reference_decision_parity_precedence_and_fallthrough() -> None:
                 "reference_text_key": "reference",
                 "primary_model_type": "qwen_omni",
                 "force_reference": True,
-                "recovery_note_key": "fallback_check",
             },
             (
                 "ground truth",
@@ -406,7 +403,7 @@ def test_reference_decision_parity_precedence_and_fallthrough() -> None:
             ("ground truth", "ground_truth", "", None, "Ground Truth"),
         ),
         (
-            "scoped recovery alias precedes reference and agreement",
+            "recovery alias precedes reference and agreement",
             {
                 "primary_model_prediction": "selected fallback",
                 "fallback_model_prediction": "ignored fallback",
@@ -417,11 +414,10 @@ def test_reference_decision_parity_precedence_and_fallthrough() -> None:
             },
             {
                 "asr_text_key": "asr_prediction",
-                "recovery_note_key": "fallback_check",
                 "reference_text_key": "reference",
                 "use_reference_on_hallucination": True,
             },
-            ("selected fallback", "fallback", "", None, "used fallback"),
+            ("selected fallback", "fallback", "Hallucination", None, "used fallback"),
         ),
         (
             "reference recovery precedes agreement",

--- a/tests/stages/audio/text_filtering/test_select_best_prediction.py
+++ b/tests/stages/audio/text_filtering/test_select_best_prediction.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from copy import deepcopy
+
 from nemo_curator.stages.audio.text_filtering.select_best_prediction import SelectBestPredictionStage
 from nemo_curator.tasks import AudioTask
 
@@ -359,3 +361,139 @@ def test_keeps_primary_by_default() -> None:
     SelectBestPredictionStage().process_batch(tasks)
 
     assert [task.data["best_prediction"] for task in tasks] == ["one", "two"]
+
+
+def test_reference_decision_parity_precedence_and_fallthrough() -> None:
+    """Golden decisions from reference selector commit 8469455fbd18de74928f21e1cc241358fc8d9e08."""
+    cases = [
+        (
+            "short audio precedes force and recovery",
+            {
+                "primary_model_prediction": "primary transcript",
+                "fallback_model_prediction": "fallback transcript",
+                "reference": "ground truth",
+                "duration": 0.25,
+                "_skipme": "Hallucination",
+                "additional_notes": {"fallback_check": "Recovered"},
+            },
+            {
+                "reference_text_key": "reference",
+                "primary_model_type": "qwen_omni",
+                "force_reference": True,
+                "recovery_note_key": "fallback_check",
+            },
+            (
+                "ground truth",
+                "ground_truth",
+                "",
+                None,
+                "Ground Truth (short audio 0.25s < 1.0s)",
+            ),
+        ),
+        (
+            "ground truth precedes both-models-unsupported",
+            {
+                "primary_model_prediction": "",
+                "fallback_model_prediction": "",
+                "reference": "ground truth",
+                "_skipme": "language_not_supported",
+                "additional_notes": {
+                    "primary_model_prediction": "lang_not_supported:xx",
+                    "fallback_model_prediction": "lang_not_supported:xx",
+                },
+            },
+            {"reference_text_key": "reference"},
+            ("ground truth", "ground_truth", "", None, "Ground Truth"),
+        ),
+        (
+            "scoped recovery alias precedes reference and agreement",
+            {
+                "primary_model_prediction": "selected fallback",
+                "fallback_model_prediction": "ignored fallback",
+                "asr_prediction": "selected fallback",
+                "reference": "ground truth",
+                "_skipme": "Hallucination",
+                "additional_notes": {"fallback_check": "Recovered:ASR"},
+            },
+            {
+                "asr_text_key": "asr_prediction",
+                "recovery_note_key": "fallback_check",
+                "reference_text_key": "reference",
+                "use_reference_on_hallucination": True,
+            },
+            ("selected fallback", "fallback", "", None, "used fallback"),
+        ),
+        (
+            "reference recovery precedes agreement",
+            {
+                "primary_model_prediction": "Hello, world!",
+                "fallback_model_prediction": "hello world",
+                "reference": "ground truth",
+                "_skipme": "Hallucination",
+            },
+            {
+                "reference_text_key": "reference",
+                "use_reference_on_hallucination": True,
+            },
+            (
+                "ground truth",
+                "reference",
+                "",
+                None,
+                "recovered:reference_text (hallucination_detected, fallback=reference)",
+            ),
+        ),
+        (
+            "empty reference falls through short and reference recovery",
+            {
+                "primary_model_prediction": "Hello, world!",
+                "fallback_model_prediction": "hello world",
+                "reference": "   ",
+                "duration": 0.25,
+                "_skipme": "Hallucination",
+            },
+            {
+                "reference_text_key": "reference",
+                "primary_model_type": "qwen_omni",
+                "use_reference_on_hallucination": True,
+            },
+            (
+                "Hello, world!",
+                "primary",
+                "",
+                0.0,
+                "recovered:cross_model_agreement (wer=0.0%)",
+            ),
+        ),
+        (
+            "fallback is ignored without a selection signal",
+            {
+                "primary_model_prediction": "primary transcript",
+                "fallback_model_prediction": "fallback transcript",
+            },
+            {},
+            ("primary transcript", "primary", None, None, "used primary"),
+        ),
+    ]
+
+    for name, data, stage_kwargs, expected in cases:
+        task = AudioTask(data=deepcopy(data))
+        stage = SelectBestPredictionStage(
+            agreement_wer_key="omni_asr_agreement_wer",
+            **stage_kwargs,
+        )
+
+        stage.process(task)
+
+        expected_text, expected_source, expected_skip, expected_wer, expected_note = expected
+        assert task.data["best_prediction"] == expected_text, name
+        assert task.data["best_prediction_source"] == expected_source, name
+        if expected_skip is None:
+            assert "_skipme" not in task.data, name
+        else:
+            assert task.data["_skipme"] == expected_skip, name
+        if expected_wer is None:
+            assert "omni_asr_agreement_wer" not in task.data, name
+        else:
+            assert task.data["omni_asr_agreement_wer"] == expected_wer, name
+        assert task.data["additional_notes"]["SelectBestPrediction"] == expected_note, name


### PR DESCRIPTION
## Summary
- Add a standalone stage that selects a stable transcript from primary, fallback, or reference text.
- Handle unsupported-language routing, recovered fallbacks, cross-model agreement, reference recovery, forced-reference selection, and the Qwen-Omni short-audio ground-truth policy.
- Match the relevant selector behavior from `nithinraok/Curator:nkoluguri/integration-test` at `2963bf3a23d807ff26a80cf80aeb1a33fd0f7172` (selector blob `e9517ad7dc150eb42c70f8c55d28470f12d0b33b`, last changed by `8469455fbd18de74928f21e1cc241358fc8d9e08`).
- Adapt that behavior to current main's `AudioTask` and `ProcessingStage` contracts:
  - keep the model-generic `fallback_text_key` and `primary_fallback_agreement_wer` names;
  - accept `asr_text_key` as a compatibility alias;
  - retain a lightweight local word-distance helper, with the reference's two-decimal WER precision, instead of importing the heavyweight NeMo ASR metric stack;
  - declare the notes output and clear stale skip/agreement audit state.
- Rebase onto NVIDIA-NeMo/Curator `main` at `0b9e6e56999720795470b24cc9a1d47f934b7a62`.

This branch contains only prediction-selection code and focused tests.

## Reference parity
- Loaded the fetched reference selector locally and compared its decisions with this branch across 589,824 deterministic scenarios.
- 237,132 scenarios matched exactly.
- 352,692 differences were fully explained by the intentional main-contract fixes: stale skip cleanup, stale agreement cleanup, ignoring this stage's prior recovery note, and rejecting an unsupported primary when no usable fallback exists.
- Zero unexplained mismatches remained.
- Added pinned golden vectors for precedence and fallthrough behavior without making CI depend on a second Git branch.

## Validation
- 20 focused tests passed with the repository's normal Ray-backed pytest fixture.
- Ruff check passed.
- Ruff format check passed.
- Changed-file pre-commit hooks passed.
- `git diff --check` passed.