### PR TITLE
feat(audio): add transcript normalization stages

### DIFF
--- a/nemo_curator/stages/audio/__init__.py
+++ b/nemo_curator/stages/audio/__init__.py
@@ -30,6 +30,7 @@ from importlib import import_module
 _LAZY = {
     "ALMDataBuilderStage": "nemo_curator.stages.audio.alm",
     "ALMDataOverlapStage": "nemo_curator.stages.audio.alm",
+    "AbbreviationConcatStage": "nemo_curator.stages.audio.text_filtering",
     "AudioDataFilterStage": "nemo_curator.stages.audio.advanced_pipelines",
     "BandFilterStage": "nemo_curator.stages.audio.filtering",
     "GetAudioDurationStage": "nemo_curator.stages.audio.common",
@@ -37,6 +38,7 @@ _LAZY = {
     "ManifestWriterStage": "nemo_curator.stages.audio.common",
     "MonoConversionStage": "nemo_curator.stages.audio.preprocessing",
     "PreserveByValueStage": "nemo_curator.stages.audio.common",
+    "RegexSubstitutionStage": "nemo_curator.stages.audio.text_filtering",
     "SIGMOSFilterStage": "nemo_curator.stages.audio.filtering",
     "SegmentConcatenationStage": "nemo_curator.stages.audio.preprocessing",
     "SpeakerSeparationStage": "nemo_curator.stages.audio.segmentation",
@@ -49,6 +51,7 @@ _LAZY = {
 __all__ = [
     "ALMDataBuilderStage",
     "ALMDataOverlapStage",
+    "AbbreviationConcatStage",
     "AudioDataFilterStage",
     "BandFilterStage",
     "GetAudioDurationStage",
@@ -56,6 +59,7 @@ __all__ = [
     "ManifestWriterStage",
     "MonoConversionStage",
     "PreserveByValueStage",
+    "RegexSubstitutionStage",
     "SIGMOSFilterStage",
     "SegmentConcatenationStage",
     "SpeakerSeparationStage",

--- a/nemo_curator/stages/audio/text_filtering/__init__.py
+++ b/nemo_curator/stages/audio/text_filtering/__init__.py
@@ -14,10 +14,14 @@
 
 """Audio transcript filtering stages."""
 
+from .abbreviation_concat import AbbreviationConcatStage
+from .regex_substitution import RegexSubstitutionStage
 from .select_best_prediction import SelectBestPredictionStage
 from .whisper_hallucination import WhisperHallucinationStage
 
 __all__ = [
+    "AbbreviationConcatStage",
+    "RegexSubstitutionStage",
     "SelectBestPredictionStage",
     "WhisperHallucinationStage",
 ]

--- a/nemo_curator/stages/audio/text_filtering/abbreviation_concat.py
+++ b/nemo_curator/stages/audio/text_filtering/abbreviation_concat.py
@@ -114,13 +114,15 @@ def _join_match(match: re.Match[str], particles: frozenset[str]) -> str:  # noqa
     if any(len(part) >= _MULTI_CHAR_LEN for part in parts):
         return original
 
-    # Keep trailing words such as "Is", "As", and "Os" separate while
-    # still allowing consonant plural suffixes such as "Xs".
+    # Keep trailing words such as "Is", "As", and "Os" separate. The
+    # sequence "A P Is" is normalized to the plural abbreviation "APIs".
     tail = ""
+    is_api_plural = parts == ["A", "P", "Is"]
     if (
         len(parts) >= _MIN_PARTS
         and len(parts[-1]) == _PLURAL_SUFFIX_LEN
         and parts[-1][1] == "s"
+        and not is_api_plural
         and (parts[-1][0] in _VOWELS or not parts[-1][0].isupper())
     ):
         tail = " " + parts.pop()
@@ -181,7 +183,13 @@ def concat_abbreviations(text: str, language: str = "en") -> tuple[str, list[str
         else:
             joined = _join_match(match, particles)
         if joined != raw:
-            abbreviation = joined.strip().rstrip("’s").rstrip("’s")  # noqa: RUF001
+            abbreviation = joined.strip()
+            raw_parts = raw.split(" ")
+            last_part = raw_parts[-1]
+            if len(last_part) == _PLURAL_SUFFIX_LEN and last_part[0].islower() and last_part[1] == "s":
+                abbreviation = abbreviation.removesuffix(last_part).rstrip()
+            elif not (raw == "A P Is" and abbreviation == "APIs"):
+                abbreviation = abbreviation.rstrip("’s").rstrip("’s")  # noqa: RUF001
             if abbreviation:
                 found.append(abbreviation)
         return joined

--- a/nemo_curator/stages/audio/text_filtering/abbreviation_concat.py
+++ b/nemo_curator/stages/audio/text_filtering/abbreviation_concat.py
@@ -1,0 +1,224 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import functools
+import re
+from dataclasses import dataclass, field
+from typing import Any
+
+from loguru import logger
+
+from nemo_curator.stages.base import ProcessingStage
+from nemo_curator.stages.resources import Resources
+from nemo_curator.tasks import AudioTask
+
+_LANG_CHAR_CLASS: dict[str, str] = {
+    "en": r"[A-Za-z]",
+    "nl": r"[A-Za-z]",
+    "de": r"[A-Za-zÄÖÜäöüß]",
+    "fr": r"[A-Za-zÀ-ÖØ-öø-ÿ]",
+    "es": r"[A-Za-zÁÉÍÓÚÜÑáéíóúüñ]",
+    "it": r"[A-Za-zÀÈÉÌÒÓÙàèéìòóù]",
+    "pt": r"[A-Za-zÀ-ÖØ-öø-ÿ]",
+    "pl": r"[A-Za-zĄĆĘŁŃÓŚŹŻąćęłńóśźż]",
+    "cs": r"[A-Za-zÁČĎÉĚÍŇÓŘŠŤÚŮÝŽáčďéěíňóřšťúůýž]",
+    "sk": r"[A-Za-zÁÄČĎÉÍĽĻŇÓÔŔŠŤÚÝŽáäčďéíľļňóôŕšťúýž]",
+    "sv": r"[A-Za-zÅÄÖåäö]",
+    "no": r"[A-Za-zÆØÅæøå]",
+    "da": r"[A-Za-zÆØÅæøå]",
+    "fi": r"[A-Za-zÄÖÅäöå]",
+    "hu": r"[A-Za-zÁÉÍÓÖŐÚÜŰáéíóöőúüű]",
+    "ro": r"[A-Za-zĂÂÎȘȚăâîșț]",
+    "hr": r"[A-Za-zČĆĐŠŽčćđšž]",
+    "sl": r"[A-Za-zČŠŽčšž]",
+    "ru": r"[А-ЯЁа-яё]",  # noqa: RUF001
+    "bg": r"[А-Яа-я]",  # noqa: RUF001
+    "uk": r"[А-ЯҐЄІЇа-яґєії]",  # noqa: RUF001
+    "sr": r"[А-ЯЂЈЉЊЋЏа-яђјљњћџ]",  # noqa: RUF001
+    "mk": r"[А-Яа-яѓѕѝ]",  # noqa: RUF001
+    "el": r"[Α-Ωα-ω]",  # noqa: RUF001
+}
+_LANG_PARTICLES: dict[str, frozenset[str]] = {
+    "en": frozenset({"a"}),
+    "it": frozenset({"a", "e"}),
+    "pt": frozenset({"a", "e"}),
+    "es": frozenset({"a"}),
+}
+_CONTRACTION_SUFFIXES = ("m", "ll", "ve", "d", "re", "ma")
+_VOWELS = frozenset("AEIOUaeiou")
+
+_TAIL_SLICE = 2
+_MIN_PARTS = 2
+_PLURAL_SUFFIX_LEN = 2
+_MULTI_CHAR_LEN = 3
+
+
+def _set_note(data: dict[str, Any], stage: str, value: str, notes_key: str) -> None:
+    notes = data.get(notes_key)
+    if not isinstance(notes, dict):
+        notes = {}
+        data[notes_key] = notes
+    notes[stage] = value
+
+
+@functools.lru_cache(maxsize=32)
+def _pattern(language: str) -> re.Pattern[str]:
+    char_class = _LANG_CHAR_CLASS.get(language, _LANG_CHAR_CLASS["en"])
+    return re.compile(
+        rf"(?<![\w’’’ʼ])({char_class}(?: {char_class}){{1,}}(?:(?<=[A-Z])s)?)(?!\w)"  # noqa: RUF001
+    )
+
+
+def _strip_particles(raw: str, particles: frozenset[str]) -> str:
+    if not particles:
+        return raw
+    parts = raw.split(" ")
+    if parts[0] in particles:
+        parts = parts[1:]
+    if parts and parts[-1] in particles:
+        keep_trailing = (["D", "N"], ["R", "N"])
+        preceding = [part.upper() for part in parts[:-1]]
+        if preceding[-_TAIL_SLICE:] not in keep_trailing:
+            parts = parts[:-1]
+    if len(parts) < _MIN_PARTS:
+        return raw
+    return " ".join(parts)
+
+
+def _is_mixed_case_pair(letters: str) -> bool:
+    return len(letters) == _MIN_PARTS and letters[0].islower() != letters[1].islower()
+
+
+def _join_match(match: re.Match[str], particles: frozenset[str]) -> str:  # noqa: C901, PLR0911
+    raw = match.group(0)
+    if raw == "I I":
+        return raw
+
+    parts = raw.split(" ")
+    if any(len(part) >= _MULTI_CHAR_LEN for part in parts):
+        return raw
+
+    # Keep trailing words such as "Is", "As", and "Os" separate while
+    # still allowing consonant plural suffixes such as "Xs".
+    tail = ""
+    if (
+        len(parts) >= _MIN_PARTS
+        and len(parts[-1]) == _PLURAL_SUFFIX_LEN
+        and parts[-1][1] == "s"
+        and parts[-1][0] in _VOWELS
+    ):
+        tail = " " + parts.pop()
+        if len(parts) < _MIN_PARTS:
+            return raw
+        raw = " ".join(parts)
+
+    if sum(1 for part in parts if len(part) == 1) < _MIN_PARTS:
+        has_plural_suffix = any(
+            len(part) == _PLURAL_SUFFIX_LEN and part[1] == "s" and part[0].lower() not in "aeiou" for part in parts
+        )
+        if not has_plural_suffix:
+            return raw
+
+    if len(parts) == _MIN_PARTS and particles and any(part in particles for part in parts):
+        return raw
+
+    letters = raw.replace(" ", "")
+    if len(set(letters.upper())) <= 1:
+        return raw
+    if _is_mixed_case_pair(letters):
+        return raw
+
+    stripped = _strip_particles(raw, particles)
+    if stripped == raw:
+        return letters + tail
+    if len(stripped.replace(" ", "")) < _MIN_PARTS:
+        return raw
+
+    prefix = raw[: raw.index(stripped[0])]
+    suffix = raw[raw.rindex(stripped[-1]) + 1 :]
+    return prefix + stripped.replace(" ", "") + suffix + tail
+
+
+def concat_abbreviations(text: str, language: str = "en") -> tuple[str, list[str]]:
+    """Join ASR-spelled letter sequences and return the changed abbreviations."""
+    found: list[str] = []
+    particles = _LANG_PARTICLES.get(language, frozenset())
+
+    def replace(match: re.Match[str]) -> str:
+        raw = match.group(0)
+        joined = _join_match(match, particles)
+        end = match.end()
+        if (
+            joined != raw
+            and joined[-1:].upper() == "I"
+            and len(joined) >= _MULTI_CHAR_LEN
+            and end < len(text)
+            and text[end] in "’’’ʼ"  # noqa: RUF001
+            and text[end + 1 : end + 4].lower().startswith(_CONTRACTION_SUFFIXES)
+        ):
+            joined = joined[:-1]
+        if joined != raw:
+            raw_parts = raw.split()
+            abbreviation = next(
+                (part for part in joined.split() if part not in raw_parts),
+                joined.strip(),
+            )
+            found.append(abbreviation)
+        return joined
+
+    return _pattern(language).sub(replace, text), found
+
+
+@dataclass
+class AbbreviationConcatStage(ProcessingStage[AudioTask, AudioTask]):
+    """Concatenate spaced single-letter abbreviations in a transcript."""
+
+    text_key: str = "text"
+    output_text_key: str = "text"
+    skip_me_key: str = "_skipme"
+    notes_key: str = "additional_notes"
+    source_lang_key: str = "source_lang"
+    default_language: str = "en"
+    name: str = "AbbreviationConcat"
+    resources: Resources = field(default_factory=lambda: Resources(cpus=1.0))
+
+    def inputs(self) -> tuple[list[str], list[str]]:
+        return [], [self.text_key]
+
+    def outputs(self) -> tuple[list[str], list[str]]:
+        return [], [self.output_text_key, self.notes_key]
+
+    def _process_single(self, task: AudioTask) -> None:
+        if task.data.get(self.skip_me_key, ""):
+            task.data.setdefault(self.output_text_key, "")
+            return
+        text = task.data.get(self.text_key, "")
+        if not isinstance(text, str) or not text.strip():
+            task.data.setdefault(self.output_text_key, text if isinstance(text, str) else "")
+            return
+
+        language_value = task.data.get(self.source_lang_key) or self.default_language
+        language = str(language_value).strip().lower()
+        result, found = concat_abbreviations(text, language=language)
+        task.data[self.output_text_key] = result
+        if found:
+            logger.trace("AbbreviationConcat: {!r} -> {!r} abbrevs={}", text, result, found)
+            changes = ", ".join(f"{' '.join(abbreviation)} -> {abbreviation}" for abbreviation in found)
+            _set_note(task.data, self.name, f"applied ({changes})", self.notes_key)
+
+    def process(self, task: AudioTask) -> AudioTask:
+        self._process_single(task)
+        return task

--- a/nemo_curator/stages/audio/text_filtering/abbreviation_concat.py
+++ b/nemo_curator/stages/audio/text_filtering/abbreviation_concat.py
@@ -58,6 +58,7 @@ _LANG_PARTICLES: dict[str, frozenset[str]] = {
     "es": frozenset({"a"}),
 }
 _CONTRACTION_SUFFIXES = ("m", "ll", "ve", "d", "re", "ma")
+_APOSTROPHES = "'’‘ʼ"  # noqa: RUF001
 _VOWELS = frozenset("AEIOUaeiou")
 
 _TAIL_SLICE = 2
@@ -77,9 +78,7 @@ def _set_note(data: dict[str, Any], stage: str, value: str, notes_key: str) -> N
 @functools.lru_cache(maxsize=32)
 def _pattern(language: str) -> re.Pattern[str]:
     char_class = _LANG_CHAR_CLASS.get(language, _LANG_CHAR_CLASS["en"])
-    return re.compile(
-        rf"(?<![\w’’’ʼ])({char_class}(?: {char_class}){{1,}}(?:(?<=[A-Z])s)?)(?!\w)"  # noqa: RUF001
-    )
+    return re.compile(rf"(?<!\w)(?<!\w[{_APOSTROPHES}])({char_class}(?: {char_class}){{1,}}s?)(?!\w)")
 
 
 def _strip_particles(raw: str, particles: frozenset[str]) -> str:
@@ -104,12 +103,13 @@ def _is_mixed_case_pair(letters: str) -> bool:
 
 def _join_match(match: re.Match[str], particles: frozenset[str]) -> str:  # noqa: C901, PLR0911
     raw = match.group(0)
+    original = raw
     if raw == "I I":
-        return raw
+        return original
 
     parts = raw.split(" ")
     if any(len(part) >= _MULTI_CHAR_LEN for part in parts):
-        return raw
+        return original
 
     # Keep trailing words such as "Is", "As", and "Os" separate while
     # still allowing consonant plural suffixes such as "Xs".
@@ -118,37 +118,40 @@ def _join_match(match: re.Match[str], particles: frozenset[str]) -> str:  # noqa
         len(parts) >= _MIN_PARTS
         and len(parts[-1]) == _PLURAL_SUFFIX_LEN
         and parts[-1][1] == "s"
-        and parts[-1][0] in _VOWELS
+        and (parts[-1][0] in _VOWELS or not parts[-1][0].isupper())
     ):
         tail = " " + parts.pop()
         if len(parts) < _MIN_PARTS:
-            return raw
+            return original
         raw = " ".join(parts)
 
     if sum(1 for part in parts if len(part) == 1) < _MIN_PARTS:
         has_plural_suffix = any(
-            len(part) == _PLURAL_SUFFIX_LEN and part[1] == "s" and part[0].lower() not in "aeiou" for part in parts
+            len(part) == _PLURAL_SUFFIX_LEN and part[1] == "s" and part[0].isupper() and part[0].lower() not in "aeiou"
+            for part in parts
         )
         if not has_plural_suffix:
-            return raw
+            return original
 
     if len(parts) == _MIN_PARTS and particles and any(part in particles for part in parts):
-        return raw
+        return original
 
     letters = raw.replace(" ", "")
     if len(set(letters.upper())) <= 1:
-        return raw
+        return original
     if _is_mixed_case_pair(letters):
-        return raw
+        return original
 
     stripped = _strip_particles(raw, particles)
     if stripped == raw:
         return letters + tail
     if len(stripped.replace(" ", "")) < _MIN_PARTS:
-        return raw
+        return original
 
-    prefix = raw[: raw.index(stripped[0])]
-    suffix = raw[raw.rindex(stripped[-1]) + 1 :]
+    stripped_start = raw.index(stripped)
+    stripped_end = stripped_start + len(stripped)
+    prefix = raw[:stripped_start]
+    suffix = raw[stripped_end:]
     return prefix + stripped.replace(" ", "") + suffix + tail
 
 
@@ -159,17 +162,21 @@ def concat_abbreviations(text: str, language: str = "en") -> tuple[str, list[str
 
     def replace(match: re.Match[str]) -> str:
         raw = match.group(0)
-        joined = _join_match(match, particles)
         end = match.end()
-        if (
-            joined != raw
-            and joined[-1:].upper() == "I"
-            and len(joined) >= _MULTI_CHAR_LEN
+        contraction_tail = (
+            raw[-2:-1] == " "
+            and raw[-1:].upper() == "I"
             and end < len(text)
-            and text[end] in "’’’ʼ"  # noqa: RUF001
+            and text[end] in _APOSTROPHES
             and text[end + 1 : end + 4].lower().startswith(_CONTRACTION_SUFFIXES)
-        ):
-            joined = joined[:-1]
+        )
+        if contraction_tail:
+            core = raw[:-2]
+            core_match = _pattern(language).fullmatch(core)
+            joined_core = _join_match(core_match, particles) if core_match else core
+            joined = joined_core + " " + raw[-1] if joined_core != core else raw
+        else:
+            joined = _join_match(match, particles)
         if joined != raw:
             raw_parts = raw.split()
             abbreviation = next(

--- a/nemo_curator/stages/audio/text_filtering/abbreviation_concat.py
+++ b/nemo_curator/stages/audio/text_filtering/abbreviation_concat.py
@@ -78,7 +78,10 @@ def _set_note(data: dict[str, Any], stage: str, value: str, notes_key: str) -> N
 @functools.lru_cache(maxsize=32)
 def _pattern(language: str) -> re.Pattern[str]:
     char_class = _LANG_CHAR_CLASS.get(language, _LANG_CHAR_CLASS["en"])
-    return re.compile(rf"(?<!\w)(?<!\w[{_APOSTROPHES}])({char_class}(?: {char_class}){{1,}}s?)(?!\w)")
+    # ASCII and left-curly apostrophes are token boundaries except after the pronoun I.
+    return re.compile(
+        rf"(?<![\w’ʼ])(?<![Ii]['‘])({char_class}(?: {char_class}){{1,}}s?)(?!\w)"  # noqa: RUF001
+    )
 
 
 def _strip_particles(raw: str, particles: frozenset[str]) -> str:

--- a/nemo_curator/stages/audio/text_filtering/abbreviation_concat.py
+++ b/nemo_curator/stages/audio/text_filtering/abbreviation_concat.py
@@ -201,14 +201,14 @@ class AbbreviationConcatStage(ProcessingStage[AudioTask, AudioTask]):
     def outputs(self) -> tuple[list[str], list[str]]:
         return [], [self.output_text_key, self.notes_key]
 
-    def _process_single(self, task: AudioTask) -> None:
+    def process(self, task: AudioTask) -> AudioTask:
         if task.data.get(self.skip_me_key, ""):
             task.data.setdefault(self.output_text_key, "")
-            return
+            return task
         text = task.data.get(self.text_key, "")
         if not isinstance(text, str) or not text.strip():
             task.data.setdefault(self.output_text_key, text if isinstance(text, str) else "")
-            return
+            return task
 
         language_value = task.data.get(self.source_lang_key) or self.default_language
         language = str(language_value).strip().lower()
@@ -218,7 +218,4 @@ class AbbreviationConcatStage(ProcessingStage[AudioTask, AudioTask]):
             logger.trace("AbbreviationConcat: {!r} -> {!r} abbrevs={}", text, result, found)
             changes = ", ".join(f"{' '.join(abbreviation)} -> {abbreviation}" for abbreviation in found)
             _set_note(task.data, self.name, f"applied ({changes})", self.notes_key)
-
-    def process(self, task: AudioTask) -> AudioTask:
-        self._process_single(task)
         return task

--- a/nemo_curator/stages/audio/text_filtering/abbreviation_concat.py
+++ b/nemo_curator/stages/audio/text_filtering/abbreviation_concat.py
@@ -181,12 +181,9 @@ def concat_abbreviations(text: str, language: str = "en") -> tuple[str, list[str
         else:
             joined = _join_match(match, particles)
         if joined != raw:
-            raw_parts = raw.split()
-            abbreviation = next(
-                (part for part in joined.split() if part not in raw_parts),
-                joined.strip(),
-            )
-            found.append(abbreviation)
+            abbreviation = joined.strip().rstrip("’s").rstrip("’s")  # noqa: RUF001
+            if abbreviation:
+                found.append(abbreviation)
         return joined
 
     return _pattern(language).sub(replace, text), found

--- a/nemo_curator/stages/audio/text_filtering/regex_substitution.py
+++ b/nemo_curator/stages/audio/text_filtering/regex_substitution.py
@@ -31,7 +31,8 @@ class RegexSubstitutionStage(ProcessingStage[AudioTask, AudioTask]):
     Each rule must define ``pattern`` and ``repl`` and may define the
     standard ``re.sub`` ``count`` limit. Rules run in file order before
     whitespace is collapsed. Rows carrying an existing skip reason are not
-    normalized.
+    normalized. The empty-result skip is set only when cleaning removes
+    non-whitespace input; already-empty input remains unskipped.
     """
 
     regex_params_yaml: str = ""
@@ -76,6 +77,7 @@ class RegexSubstitutionStage(ProcessingStage[AudioTask, AudioTask]):
         if not isinstance(text, str):
             task.data.setdefault(self.output_text_key, "")
             return task
+        had_text = bool(text.strip())
 
         result = f" {text} "
         for rule in self._rules:
@@ -87,6 +89,6 @@ class RegexSubstitutionStage(ProcessingStage[AudioTask, AudioTask]):
             )
         result = re.sub(r"\s+", " ", result).strip()
         task.data[self.output_text_key] = result
-        if not result:
+        if not result and had_text:
             task.data[self.skip_me_key] = "Empty after regex cleaning"
         return task

--- a/nemo_curator/stages/audio/text_filtering/regex_substitution.py
+++ b/nemo_curator/stages/audio/text_filtering/regex_substitution.py
@@ -1,0 +1,92 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from nemo_curator.stages.base import ProcessingStage
+from nemo_curator.stages.resources import Resources
+from nemo_curator.tasks import AudioTask
+
+
+@dataclass
+class RegexSubstitutionStage(ProcessingStage[AudioTask, AudioTask]):
+    """Apply an ordered YAML list of regex substitutions to one transcript field.
+
+    Each rule must define ``pattern`` and ``repl`` and may define the
+    standard ``re.sub`` ``count`` limit. Rules run in file order before
+    whitespace is collapsed. Rows carrying an existing skip reason are not
+    normalized.
+    """
+
+    regex_params_yaml: str = ""
+    text_key: str = "pred_text"
+    output_text_key: str = "text"
+    skip_me_key: str = "_skipme"
+    name: str = "RegexSubstitution"
+    resources: Resources = field(default_factory=lambda: Resources(cpus=1.0))
+
+    _rules: list[dict[str, Any]] = field(default_factory=list, init=False, repr=False)
+
+    def __post_init__(self) -> None:
+        if not self.regex_params_yaml:
+            msg = "regex_params_yaml is required for RegexSubstitutionStage"
+            raise ValueError(msg)
+
+    def setup(self, _worker_metadata: object | None = None) -> None:
+        with Path(self.regex_params_yaml).open(encoding="utf-8") as stream:
+            raw_rules = yaml.safe_load(stream) or []
+        if not isinstance(raw_rules, list):
+            msg = "Regex substitution YAML must contain a list of rules"
+            raise TypeError(msg)
+        for index, rule in enumerate(raw_rules):
+            if not isinstance(rule, dict) or "pattern" not in rule or "repl" not in rule:
+                msg = f"Regex rule {index} must define pattern and repl"
+                raise ValueError(msg)
+            re.compile(str(rule["pattern"]))
+        self._rules = raw_rules
+
+    def inputs(self) -> tuple[list[str], list[str]]:
+        return [], [self.text_key]
+
+    def outputs(self) -> tuple[list[str], list[str]]:
+        return [], [self.output_text_key, self.skip_me_key]
+
+    def process(self, task: AudioTask) -> AudioTask:
+        if task.data.get(self.skip_me_key, ""):
+            task.data.setdefault(self.output_text_key, "")
+            return task
+
+        text = task.data.get(self.text_key, "")
+        if not isinstance(text, str):
+            task.data.setdefault(self.output_text_key, "")
+            return task
+
+        result = f" {text} "
+        for rule in self._rules:
+            result = re.sub(
+                str(rule["pattern"]),
+                str(rule["repl"]),
+                result,
+                count=int(rule.get("count", 0)),
+            )
+        result = re.sub(r"\s+", " ", result).strip()
+        task.data[self.output_text_key] = result
+        if not result:
+            task.data[self.skip_me_key] = "Empty after regex cleaning"
+        return task

--- a/nemo_curator/stages/audio/text_filtering/regex_substitution.py
+++ b/nemo_curator/stages/audio/text_filtering/regex_substitution.py
@@ -109,6 +109,6 @@ class RegexSubstitutionStage(ProcessingStage[AudioTask, AudioTask]):
             )
         result = re.sub(r"\s+", " ", result).strip()
         task.data[self.output_text_key] = result
-        if not result and had_text:
+        if not result and had_text and not task.data.get(self.skip_me_key, ""):
             task.data[self.skip_me_key] = "Empty after regex cleaning"
         return task

--- a/nemo_curator/stages/audio/text_filtering/regex_substitution.py
+++ b/nemo_curator/stages/audio/text_filtering/regex_substitution.py
@@ -28,11 +28,12 @@ from nemo_curator.tasks import AudioTask
 class RegexSubstitutionStage(ProcessingStage[AudioTask, AudioTask]):
     """Apply an ordered YAML list of regex substitutions to one transcript field.
 
-    Each rule must define ``pattern`` and ``repl`` and may define the
-    standard ``re.sub`` ``count`` limit. Rules run in file order before
-    whitespace is collapsed. Rows carrying an existing skip reason are not
-    normalized. The empty-result skip is set only when cleaning removes
-    non-whitespace input; already-empty input remains unskipped.
+    The YAML document must be a list. Each rule must define string
+    ``pattern`` and ``repl`` values and may define a non-negative integer
+    ``count`` limit. Rules run in file order before whitespace is collapsed.
+    Rows carrying an existing skip reason are not normalized. The empty-result
+    skip is set only when cleaning removes non-whitespace input; already-empty
+    input remains unskipped.
     """
 
     regex_params_yaml: str = ""
@@ -51,15 +52,34 @@ class RegexSubstitutionStage(ProcessingStage[AudioTask, AudioTask]):
 
     def setup(self, _worker_metadata: object | None = None) -> None:
         with Path(self.regex_params_yaml).open(encoding="utf-8") as stream:
-            raw_rules = yaml.safe_load(stream) or []
+            raw_rules = yaml.safe_load(stream)
         if not isinstance(raw_rules, list):
             msg = "Regex substitution YAML must contain a list of rules"
             raise TypeError(msg)
         for index, rule in enumerate(raw_rules):
-            if not isinstance(rule, dict) or "pattern" not in rule or "repl" not in rule:
+            if not isinstance(rule, dict):
+                msg = f"Regex rule {index} must be a mapping"
+                raise TypeError(msg)
+            if "pattern" not in rule or "repl" not in rule:
                 msg = f"Regex rule {index} must define pattern and repl"
                 raise ValueError(msg)
-            re.compile(str(rule["pattern"]))
+            pattern = rule["pattern"]
+            repl = rule["repl"]
+            count = rule.get("count", 0)
+            if not isinstance(pattern, str):
+                msg = f"Regex rule {index} pattern must be a string"
+                raise TypeError(msg)
+            if not isinstance(repl, str):
+                msg = f"Regex rule {index} repl must be a string"
+                raise TypeError(msg)
+            if isinstance(count, bool) or not isinstance(count, int):
+                msg = f"Regex rule {index} count must be an integer"
+                raise TypeError(msg)
+            if count < 0:
+                msg = f"Regex rule {index} count must be non-negative"
+                raise ValueError(msg)
+            compiled = re.compile(pattern)
+            compiled.sub(repl, "", count=count)
         self._rules = raw_rules
 
     def inputs(self) -> tuple[list[str], list[str]]:
@@ -82,10 +102,10 @@ class RegexSubstitutionStage(ProcessingStage[AudioTask, AudioTask]):
         result = f" {text} "
         for rule in self._rules:
             result = re.sub(
-                str(rule["pattern"]),
-                str(rule["repl"]),
+                rule["pattern"],
+                rule["repl"],
                 result,
-                count=int(rule.get("count", 0)),
+                count=rule.get("count", 0),
             )
         result = re.sub(r"\s+", " ", result).strip()
         task.data[self.output_text_key] = result

--- a/tests/stages/audio/text_filtering/__init__.py
+++ b/tests/stages/audio/text_filtering/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for audio text normalization stages."""

--- a/tests/stages/audio/text_filtering/__init__.py
+++ b/tests/stages/audio/text_filtering/__init__.py
@@ -1,1 +1,0 @@
-"""Tests for audio text normalization stages."""

--- a/tests/stages/audio/text_filtering/test_abbreviation_concat.py
+++ b/tests/stages/audio/text_filtering/test_abbreviation_concat.py
@@ -46,6 +46,10 @@ from nemo_curator.tasks import AudioTask
         ("I\u2018m A B", "en", "I\u2018m AB"),
         ("'A B C", "en", "'ABC"),
         ("\u2018A B C\u2019", "en", "\u2018ABC\u2019"),
+        ("\u2019A B C\u2019", "en", "\u2019A BC\u2019"),
+        ("x'A B", "en", "x'AB"),
+        ("x\u2018A B", "en", "x\u2018AB"),
+        ("x\u2019A B", "en", "x\u2019A B"),
         ("A B I'm", "en", "AB I'm"),
         ("A B i'm", "en", "AB i'm"),
         ("A B I\u2019m", "en", "AB I\u2019m"),
@@ -79,6 +83,8 @@ def test_concat_abbreviations(text: str, language: str, expected: str) -> None:
         ("A P I and G P U", ["API", "GPU"]),
         ("a A P I", ["API"]),
         ("A P Is", ["AP"]),
+        ("\u2019A B C\u2019", ["BC"]),
+        ("x'A B", ["AB"]),
     ],
 )
 def test_reports_each_changed_abbreviation(text: str, expected: list[str]) -> None:

--- a/tests/stages/audio/text_filtering/test_abbreviation_concat.py
+++ b/tests/stages/audio/text_filtering/test_abbreviation_concat.py
@@ -81,8 +81,8 @@ def test_concat_abbreviations(text: str, language: str, expected: str) -> None:
     ("text", "expected"),
     [
         ("A P I and G P U", ["API", "GPU"]),
-        ("a A P I", ["API"]),
-        ("A P Is", ["AP"]),
+        ("a A P I", ["a API"]),
+        ("A P Is", ["AP I"]),
         ("\u2019A B C\u2019", ["BC"]),
         ("x'A B", ["AB"]),
     ],
@@ -99,7 +99,7 @@ def test_stage_records_changed_abbreviations() -> None:
     AbbreviationConcatStage().process(task)
 
     assert task.data["text"] == "a API"
-    assert task.data["additional_notes"]["AbbreviationConcat"] == "applied (A P I -> API)"
+    assert task.data["additional_notes"]["AbbreviationConcat"] == "applied (a   A P I -> a API)"
 
 
 def test_stage_preserves_skipped_rows() -> None:

--- a/tests/stages/audio/text_filtering/test_abbreviation_concat.py
+++ b/tests/stages/audio/text_filtering/test_abbreviation_concat.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# ruff: noqa: INP001
+
 import pytest
 
 from nemo_curator.stages.audio import (
@@ -34,7 +36,9 @@ from nemo_curator.tasks import AudioTask
         ("the A P I uses G P U acceleration", "en", "the API uses GPU acceleration"),
         ("the U K's policy", "en", "the UK's policy"),
         ("A P Xs", "en", "APXs"),
-        ("A P Is", "en", "AP Is"),
+        ("A P Is", "en", "APIs"),
+        ("A B Is", "en", "AB Is"),
+        ("A P As", "en", "AP As"),
         ("A Is", "en", "A Is"),
         ("a A P I", "en", "a API"),
         ("A P I a", "en", "API a"),
@@ -82,7 +86,10 @@ def test_concat_abbreviations(text: str, language: str, expected: str) -> None:
     [
         ("A P I and G P U", ["API", "GPU"]),
         ("a A P I", ["a API"]),
-        ("A P Is", ["AP I"]),
+        ("A P Is", ["APIs"]),
+        ("A P Xs", ["APX"]),
+        ("A B Is", ["AB I"]),
+        ("A B bs", ["AB"]),
         ("\u2019A B C\u2019", ["BC"]),
         ("x'A B", ["AB"]),
     ],

--- a/tests/stages/audio/text_filtering/test_abbreviation_concat.py
+++ b/tests/stages/audio/text_filtering/test_abbreviation_concat.py
@@ -1,0 +1,108 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+
+from nemo_curator.stages.audio import (
+    AbbreviationConcatStage as PublicAbbreviationConcatStage,
+)
+from nemo_curator.stages.audio import (
+    RegexSubstitutionStage as PublicRegexSubstitutionStage,
+)
+from nemo_curator.stages.audio.text_filtering.abbreviation_concat import (
+    AbbreviationConcatStage,
+    concat_abbreviations,
+)
+from nemo_curator.stages.audio.text_filtering.regex_substitution import RegexSubstitutionStage
+from nemo_curator.tasks import AudioTask
+
+
+@pytest.mark.parametrize(
+    ("text", "language", "expected"),
+    [
+        ("the A P I uses G P U acceleration", "en", "the API uses GPU acceleration"),
+        ("the U K's policy", "en", "the UK's policy"),
+        ("A P Xs", "en", "APXs"),
+        ("A P Is", "en", "AP Is"),
+        ("A Is", "en", "A Is"),
+        ("a A P I", "en", "a API"),
+        ("A P I a", "en", "API a"),
+        ("D N a and R N a", "en", "DNa and RNa"),
+        ("I I and A A", "en", "I I and A A"),
+        ("x I and A x", "en", "x I and A x"),
+        ("A B I\u2019m", "en", "AB\u2019m"),
+        ("A B I\u2019s", "en", "ABI\u2019s"),
+        ("А Б В", "ru", "АБВ"),  # noqa: RUF001
+        ("Α Β Γ", "el", "ΑΒΓ"),  # noqa: RUF001
+        ("a cat sat nearby", "en", "a cat sat nearby"),
+    ],
+)
+def test_concat_abbreviations(text: str, language: str, expected: str) -> None:
+    result, _ = concat_abbreviations(text, language=language)
+
+    assert result == expected
+
+
+@pytest.mark.parametrize(
+    ("text", "expected"),
+    [
+        ("A P I and G P U", ["API", "GPU"]),
+        ("a A P I", ["API"]),
+        ("A P Is", ["AP"]),
+    ],
+)
+def test_reports_each_changed_abbreviation(text: str, expected: list[str]) -> None:
+    _, found = concat_abbreviations(text)
+
+    assert found == expected
+
+
+def test_stage_records_changed_abbreviations() -> None:
+    task = AudioTask(data={"text": "a A P I"})
+
+    AbbreviationConcatStage().process(task)
+
+    assert task.data["text"] == "a API"
+    assert task.data["additional_notes"]["AbbreviationConcat"] == "applied (A P I -> API)"
+
+
+def test_stage_preserves_skipped_rows() -> None:
+    task = AudioTask(data={"text": "A P I", "_skipme": "read_error"})
+
+    AbbreviationConcatStage().process(task)
+
+    assert task.data["text"] == "A P I"
+    assert "additional_notes" not in task.data
+
+
+def test_stage_normalizes_language_code() -> None:
+    task = AudioTask(data={"text": "А Б В", "source_lang": "RU"})  # noqa: RUF001
+
+    AbbreviationConcatStage().process(task)
+
+    assert task.data["text"] == "АБВ"
+
+
+def test_stage_preserves_non_string_input() -> None:
+    task = AudioTask(data={"text": None})
+
+    AbbreviationConcatStage().process(task)
+
+    assert task.data["text"] is None
+    assert "additional_notes" not in task.data
+
+
+def test_audio_package_exports_stages() -> None:
+    assert PublicAbbreviationConcatStage is AbbreviationConcatStage
+    assert PublicRegexSubstitutionStage is RegexSubstitutionStage

--- a/tests/stages/audio/text_filtering/test_abbreviation_concat.py
+++ b/tests/stages/audio/text_filtering/test_abbreviation_concat.py
@@ -41,10 +41,29 @@ from nemo_curator.tasks import AudioTask
         ("D N a and R N a", "en", "DNa and RNa"),
         ("I I and A A", "en", "I I and A A"),
         ("x I and A x", "en", "x I and A x"),
-        ("A B I\u2019m", "en", "AB\u2019m"),
+        ("I'm A B", "en", "I'm AB"),
+        ("i'm A B", "en", "i'm AB"),
+        ("I\u2018m A B", "en", "I\u2018m AB"),
+        ("'A B C", "en", "'ABC"),
+        ("\u2018A B C\u2019", "en", "\u2018ABC\u2019"),
+        ("A B I'm", "en", "AB I'm"),
+        ("A B i'm", "en", "AB i'm"),
+        ("A B I\u2019m", "en", "AB I\u2019m"),
+        ("A B i\u2019m", "en", "AB i\u2019m"),
+        ("A B I\u2018m", "en", "AB I\u2018m"),
+        ("A A I'm", "en", "A A I'm"),
         ("A B I\u2019s", "en", "ABI\u2019s"),
+        ("A A Is", "en", "A A Is"),
+        ("a A Is", "en", "a A Is"),
+        ("a a B", "en", "a aB"),
+        ("B a a", "en", "Ba a"),
+        ("A B bs", "en", "AB bs"),
+        ("a bs", "en", "a bs"),
         ("А Б В", "ru", "АБВ"),  # noqa: RUF001
+        ("А Б Вs", "ru", "АБВs"),  # noqa: RUF001
+        ("Ä Ö Üs", "de", "ÄÖÜs"),
         ("Α Β Γ", "el", "ΑΒΓ"),  # noqa: RUF001
+        ("Α Β Γs", "el", "ΑΒΓs"),  # noqa: RUF001
         ("a cat sat nearby", "en", "a cat sat nearby"),
     ],
 )

--- a/tests/stages/audio/text_filtering/test_regex_substitution.py
+++ b/tests/stages/audio/text_filtering/test_regex_substitution.py
@@ -82,8 +82,9 @@ def test_does_not_mark_rows_already_empty(tmp_path: Path, pred_text: str) -> Non
     assert task.data["_skipme"] == ""
 
 
-def test_rejects_invalid_rule_shape(tmp_path: Path) -> None:
-    stage = RegexSubstitutionStage(regex_params_yaml=_rules(tmp_path, [{"pattern": "foo"}]))
+@pytest.mark.parametrize("rule", [{"pattern": "foo"}, {"repl": "bar"}])
+def test_rejects_invalid_rule_shape(tmp_path: Path, rule: dict[str, str]) -> None:
+    stage = RegexSubstitutionStage(regex_params_yaml=_rules(tmp_path, [rule]))
 
     with pytest.raises(ValueError, match="pattern and repl"):
         stage.setup()
@@ -117,6 +118,17 @@ def test_inherited_batch_processing_and_default_stage_chain(tmp_path: Path) -> N
     results = abbreviation_stage.process_batch(normalized)
 
     assert [task.data["text"] for task in results] == ["API on GPU", "NVIDIA"]
+
+
+def test_stage_chain_preserves_contraction_pronoun(tmp_path: Path) -> None:
+    regex_stage = RegexSubstitutionStage(regex_params_yaml=_rules(tmp_path, [{"pattern": "\u2019", "repl": "'"}]))
+    regex_stage.setup()
+    task = AudioTask(data={"pred_text": "A B I’m ready"})  # noqa: RUF001
+
+    regex_stage.process(task)
+    AbbreviationConcatStage().process(task)
+
+    assert task.data["text"] == "AB I'm ready"
 
 
 # Golden outputs verified against nithinraok/Curator@a1df5ec9 with
@@ -184,15 +196,93 @@ def test_non_string_input_stabilizes_output_schema(tmp_path: Path) -> None:
     assert task.data["cleaned"] == ""
 
 
-def test_rejects_non_list_yaml(tmp_path: Path) -> None:
-    stage = RegexSubstitutionStage(regex_params_yaml=_rules(tmp_path, {"pattern": "foo", "repl": "bar"}))
+@pytest.mark.parametrize("document", [None, False, 0, {}, ""])
+def test_rejects_falsey_non_list_yaml(tmp_path: Path, document: object) -> None:
+    stage = RegexSubstitutionStage(regex_params_yaml=_rules(tmp_path, document))
 
     with pytest.raises(TypeError, match="must contain a list"):
         stage.setup()
 
 
+@pytest.mark.parametrize("document", [{"pattern": "foo", "repl": "bar"}, "not a list", 1])
+def test_rejects_truthy_non_list_yaml(tmp_path: Path, document: object) -> None:
+    stage = RegexSubstitutionStage(regex_params_yaml=_rules(tmp_path, document))
+
+    with pytest.raises(TypeError, match="must contain a list"):
+        stage.setup()
+
+
+def test_rejects_blank_yaml(tmp_path: Path) -> None:
+    path = tmp_path / "blank.yaml"
+    path.write_text("", encoding="utf-8")
+    stage = RegexSubstitutionStage(regex_params_yaml=str(path))
+
+    with pytest.raises(TypeError, match="must contain a list"):
+        stage.setup()
+
+
+def test_rejects_non_mapping_rule(tmp_path: Path) -> None:
+    stage = RegexSubstitutionStage(regex_params_yaml=_rules(tmp_path, ["not a rule"]))
+
+    with pytest.raises(TypeError, match="must be a mapping"):
+        stage.setup()
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("pattern", None),
+        ("pattern", 1),
+        ("repl", None),
+        ("repl", ["replacement"]),
+    ],
+)
+def test_rejects_non_string_pattern_or_repl(tmp_path: Path, field: str, value: object) -> None:
+    rule: dict[str, object] = {"pattern": "foo", "repl": "bar"}
+    rule[field] = value
+    stage = RegexSubstitutionStage(regex_params_yaml=_rules(tmp_path, [rule]))
+
+    with pytest.raises(TypeError, match=rf"{field} must be a string"):
+        stage.setup()
+
+
+@pytest.mark.parametrize("count", [None, "1", 1.0, True])
+def test_rejects_non_integer_count(tmp_path: Path, count: object) -> None:
+    stage = RegexSubstitutionStage(
+        regex_params_yaml=_rules(tmp_path, [{"pattern": "foo", "repl": "bar", "count": count}])
+    )
+
+    with pytest.raises(TypeError, match="count must be an integer"):
+        stage.setup()
+
+
+def test_rejects_negative_count(tmp_path: Path) -> None:
+    stage = RegexSubstitutionStage(
+        regex_params_yaml=_rules(tmp_path, [{"pattern": "foo", "repl": "bar", "count": -1}])
+    )
+
+    with pytest.raises(ValueError, match="count must be non-negative"):
+        stage.setup()
+
+
 def test_rejects_invalid_regex(tmp_path: Path) -> None:
     stage = RegexSubstitutionStage(regex_params_yaml=_rules(tmp_path, [{"pattern": "[", "repl": ""}]))
+
+    with pytest.raises(re.error):
+        stage.setup()
+
+
+def test_rejects_malformed_yaml(tmp_path: Path) -> None:
+    path = tmp_path / "malformed.yaml"
+    path.write_text("- pattern: [\n", encoding="utf-8")
+    stage = RegexSubstitutionStage(regex_params_yaml=str(path))
+
+    with pytest.raises(yaml.YAMLError):
+        stage.setup()
+
+
+def test_rejects_invalid_replacement(tmp_path: Path) -> None:
+    stage = RegexSubstitutionStage(regex_params_yaml=_rules(tmp_path, [{"pattern": "(foo)", "repl": r"\2"}]))
 
     with pytest.raises(re.error):
         stage.setup()

--- a/tests/stages/audio/text_filtering/test_regex_substitution.py
+++ b/tests/stages/audio/text_filtering/test_regex_substitution.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# ruff: noqa: INP001
+
 import re
 from pathlib import Path
 

--- a/tests/stages/audio/text_filtering/test_regex_substitution.py
+++ b/tests/stages/audio/text_filtering/test_regex_substitution.py
@@ -70,6 +70,18 @@ def test_marks_rows_that_clean_to_empty(tmp_path: Path) -> None:
     assert task.data["_skipme"] == "Empty after regex cleaning"
 
 
+@pytest.mark.parametrize("pred_text", ["", "   "])
+def test_does_not_mark_rows_already_empty(tmp_path: Path, pred_text: str) -> None:
+    stage = RegexSubstitutionStage(regex_params_yaml=_rules(tmp_path, [{"pattern": r"\w+", "repl": ""}]))
+    stage.setup()
+    task = AudioTask(data={"pred_text": pred_text, "_skipme": ""})
+
+    stage.process(task)
+
+    assert task.data["text"] == ""
+    assert task.data["_skipme"] == ""
+
+
 def test_rejects_invalid_rule_shape(tmp_path: Path) -> None:
     stage = RegexSubstitutionStage(regex_params_yaml=_rules(tmp_path, [{"pattern": "foo"}]))
 
@@ -107,7 +119,7 @@ def test_inherited_batch_processing_and_default_stage_chain(tmp_path: Path) -> N
     assert [task.data["text"] for task in results] == ["API on GPU", "NVIDIA"]
 
 
-# Golden outputs verified against nithinraok/Curator@1f1e770b with
+# Golden outputs verified against nithinraok/Curator@a1df5ec9 with
 # branch-neutral field names and the current-main stage lifecycle.
 @pytest.mark.parametrize(
     ("rules", "raw", "language", "expected"),

--- a/tests/stages/audio/text_filtering/test_regex_substitution.py
+++ b/tests/stages/audio/text_filtering/test_regex_substitution.py
@@ -1,0 +1,125 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import re
+from pathlib import Path
+
+import pytest
+import yaml
+
+from nemo_curator.stages.audio.text_filtering.abbreviation_concat import AbbreviationConcatStage
+from nemo_curator.stages.audio.text_filtering.regex_substitution import RegexSubstitutionStage
+from nemo_curator.tasks import AudioTask
+
+
+def _rules(tmp_path: Path, rules: object) -> str:
+    path = tmp_path / "rules.yaml"
+    path.write_text(yaml.safe_dump(rules, sort_keys=False), encoding="utf-8")
+    return str(path)
+
+
+def test_applies_ordered_rules_and_normalizes_whitespace(tmp_path: Path) -> None:
+    stage = RegexSubstitutionStage(
+        regex_params_yaml=_rules(
+            tmp_path,
+            [
+                {"pattern": r"\bum\b", "repl": ""},
+                {"pattern": r"\bN V I D I A\b", "repl": "NVIDIA"},
+            ],
+        )
+    )
+    stage.setup()
+    task = AudioTask(data={"pred_text": "um  N V I D I A builds GPUs"})
+
+    stage.process(task)
+
+    assert task.data["text"] == "NVIDIA builds GPUs"
+
+
+def test_preserves_skipped_rows(tmp_path: Path) -> None:
+    stage = RegexSubstitutionStage(regex_params_yaml=_rules(tmp_path, []))
+    stage.setup()
+    task = AudioTask(data={"pred_text": "ignored", "text": "preserved", "_skipme": "read_error"})
+
+    stage.process(task)
+
+    assert task.data["text"] == "preserved"
+    assert task.data["_skipme"] == "read_error"
+
+
+def test_marks_rows_that_clean_to_empty(tmp_path: Path) -> None:
+    stage = RegexSubstitutionStage(regex_params_yaml=_rules(tmp_path, [{"pattern": r"\S+", "repl": ""}]))
+    stage.setup()
+    task = AudioTask(data={"pred_text": "remove me"})
+
+    stage.process(task)
+
+    assert task.data["text"] == ""
+    assert task.data["_skipme"] == "Empty after regex cleaning"
+
+
+def test_rejects_invalid_rule_shape(tmp_path: Path) -> None:
+    stage = RegexSubstitutionStage(regex_params_yaml=_rules(tmp_path, [{"pattern": "foo"}]))
+
+    with pytest.raises(ValueError, match="pattern and repl"):
+        stage.setup()
+
+
+def test_honors_rule_count_and_custom_fields(tmp_path: Path) -> None:
+    stage = RegexSubstitutionStage(
+        regex_params_yaml=_rules(tmp_path, [{"pattern": "bad", "repl": "good", "count": 1}]),
+        text_key="transcript",
+        output_text_key="normalized",
+    )
+    stage.setup()
+    task = AudioTask(data={"transcript": "bad bad"})
+
+    stage.process(task)
+
+    assert task.data["normalized"] == "good bad"
+    assert task.data["transcript"] == "bad bad"
+
+
+def test_inherited_batch_processing_and_default_stage_chain(tmp_path: Path) -> None:
+    regex_stage = RegexSubstitutionStage(regex_params_yaml=_rules(tmp_path, [{"pattern": r"\bum\b", "repl": ""}]))
+    regex_stage.setup()
+    abbreviation_stage = AbbreviationConcatStage()
+    tasks = [
+        AudioTask(data={"pred_text": "um A P I on G P U", "source_lang": "en"}),
+        AudioTask(data={"pred_text": "N V I D I A", "source_lang": "en"}),
+    ]
+
+    normalized = regex_stage.process_batch(tasks)
+    results = abbreviation_stage.process_batch(normalized)
+
+    assert [task.data["text"] for task in results] == ["API on GPU", "NVIDIA"]
+
+
+def test_rejects_non_list_yaml(tmp_path: Path) -> None:
+    stage = RegexSubstitutionStage(regex_params_yaml=_rules(tmp_path, {"pattern": "foo", "repl": "bar"}))
+
+    with pytest.raises(TypeError, match="must contain a list"):
+        stage.setup()
+
+
+def test_rejects_invalid_regex(tmp_path: Path) -> None:
+    stage = RegexSubstitutionStage(regex_params_yaml=_rules(tmp_path, [{"pattern": "[", "repl": ""}]))
+
+    with pytest.raises(re.error):
+        stage.setup()
+
+
+def test_requires_rules_path() -> None:
+    with pytest.raises(ValueError, match="regex_params_yaml is required"):
+        RegexSubstitutionStage()

--- a/tests/stages/audio/text_filtering/test_regex_substitution.py
+++ b/tests/stages/audio/text_filtering/test_regex_substitution.py
@@ -34,17 +34,18 @@ def test_applies_ordered_rules_and_normalizes_whitespace(tmp_path: Path) -> None
         regex_params_yaml=_rules(
             tmp_path,
             [
-                {"pattern": r"\bum\b", "repl": ""},
-                {"pattern": r"\bN V I D I A\b", "repl": "NVIDIA"},
+                {"pattern": r"\bfoo\b", "repl": "A P I"},
+                {"pattern": r"\bA P I\b", "repl": "G P U"},
+                {"pattern": r"\bG P U\b", "repl": "GPU"},
             ],
         )
     )
     stage.setup()
-    task = AudioTask(data={"pred_text": "um  N V I D I A builds GPUs"})
+    task = AudioTask(data={"pred_text": "  foo   acceleration  "})
 
     stage.process(task)
 
-    assert task.data["text"] == "NVIDIA builds GPUs"
+    assert task.data["text"] == "GPU acceleration"
 
 
 def test_preserves_skipped_rows(tmp_path: Path) -> None:
@@ -104,6 +105,71 @@ def test_inherited_batch_processing_and_default_stage_chain(tmp_path: Path) -> N
     results = abbreviation_stage.process_batch(normalized)
 
     assert [task.data["text"] for task in results] == ["API on GPU", "NVIDIA"]
+
+
+# Golden outputs verified against nithinraok/Curator@1f1e770b with
+# branch-neutral field names and the current-main stage lifecycle.
+@pytest.mark.parametrize(
+    ("rules", "raw", "language", "expected"),
+    [
+        ([{"pattern": "’", "repl": "'"}], "we’re  A P I", "en", ("we're A P I", "we're API")),  # noqa: RUF001
+        (
+            [
+                {"pattern": r"\bfoo\b", "repl": "A P I"},
+                {"pattern": r"\bA P I\b", "repl": "G P U"},
+            ],
+            "foo",
+            "en",
+            ("G P U", "GPU"),
+        ),
+        ([], "  А Б В  ", "ru", ("А Б В", "АБВ")),  # noqa: RUF001
+    ],
+)
+def test_reference_compatible_stage_chain(
+    tmp_path: Path,
+    rules: list[dict[str, object]],
+    raw: str,
+    language: str,
+    expected: tuple[str, str],
+) -> None:
+    regex_stage = RegexSubstitutionStage(
+        regex_params_yaml=_rules(tmp_path, rules),
+        text_key="raw",
+        output_text_key="cleaned",
+        skip_me_key="skip_reason",
+    )
+    abbreviation_stage = AbbreviationConcatStage(
+        text_key="cleaned",
+        output_text_key="normalized",
+        skip_me_key="skip_reason",
+        source_lang_key="language",
+    )
+    regex_stage.setup()
+    tasks = [AudioTask(data={"raw": raw, "language": language, "skip_reason": ""})]
+
+    cleaned = regex_stage.process_batch(tasks)
+    results = abbreviation_stage.process_batch(cleaned)
+    expected_cleaned, expected_normalized = expected
+
+    assert results[0].data["raw"] == raw
+    assert results[0].data["cleaned"] == expected_cleaned
+    assert results[0].data["normalized"] == expected_normalized
+    assert results[0].data["skip_reason"] == ""
+
+
+def test_non_string_input_stabilizes_output_schema(tmp_path: Path) -> None:
+    stage = RegexSubstitutionStage(
+        regex_params_yaml=_rules(tmp_path, []),
+        text_key="raw",
+        output_text_key="cleaned",
+    )
+    stage.setup()
+    task = AudioTask(data={"raw": None})
+
+    stage.process(task)
+
+    assert task.data["raw"] is None
+    assert task.data["cleaned"] == ""
 
 
 def test_rejects_non_list_yaml(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- Add ordered YAML-driven regex substitution for ASR transcripts (`pred_text` → `text`) with strict setup-time rule validation, whitespace normalization, skip preservation, and empty-after-cleaning handling.
- Add language-aware concatenation of ASR-spelled abbreviations with contraction, particle, and Unicode plural handling plus normalization notes.
- Export both stages through `nemo_curator.stages.audio.text_filtering` and the lazy `nemo_curator.stages.audio` API.
- Use the current-main stage lifecycle with inline `process()` and inherited batch processing.

## Validation
- 79 focused tests pass.
- A 492,274-case generated abbreviation probe is idempotent and preserves character sequences apart from intended space removal.
- Target/reference differential checks cover abbreviation text and metadata, regex rules, and the default chained stages.
- Ruff and pre-commit pass.

Includes and supersedes #2268.