### PR TITLE
Core: add shared performance telemetry foundation

### DIFF
--- a/nemo_curator/backends/base.py
+++ b/nemo_curator/backends/base.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import time
 import uuid
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
@@ -56,11 +57,13 @@ class NodeInfo:
 class WorkerMetadata:
     """Generic worker metadata for setup_on_node calls across backends.
     Simplified to match Xenna's structure. The allocation field can contain
-    backend-specific allocation information.
+    backend-specific allocation information and ``perf_identity`` can carry an
+    optional backend-owned immutable identity value.
     """
 
     worker_id: str = ""
     allocation: Any = None  # Backend-specific allocation info
+    perf_identity: Any = None
 
 
 class BaseExecutor(ABC):
@@ -69,10 +72,43 @@ class BaseExecutor(ABC):
     def __init__(self, config: dict[str, Any] | None = None, ignore_head_node: bool = False):
         self.config = config or {}
         self.ignore_head_node = ignore_head_node or ignore_ray_head_node()
+        self._external_perf_records: list[Any] = []
 
     @abstractmethod
     def execute(self, stages: list["ProcessingStage"], initial_tasks: list[Task] | None = None) -> None:
         """Execute the pipeline."""
+
+    @staticmethod
+    def _start_stage_perf_collector(stages: list["ProcessingStage"]) -> Any | None:  # noqa: ANN401
+        """Start the run-scoped collector when performance collection is enabled."""
+        try:
+            from nemo_curator.utils.stage_perf_collector import start_stage_perf_collector
+
+            return start_stage_perf_collector(stages)
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("Stage performance collector disabled: {}", exc)
+            return None
+
+    def _stop_stage_perf_collector(
+        self,
+        collector: Any | None,  # noqa: ANN401
+        stages: list["ProcessingStage"],
+        *,
+        keep_records: bool,
+    ) -> None:
+        try:
+            from nemo_curator.utils.stage_perf_collector import stop_stage_perf_collector
+
+            records = stop_stage_perf_collector(collector, stages)
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("Stage performance collector stop failed: {}", exc)
+            records = []
+        self._external_perf_records = [stats for stats, _attached in records] if keep_records else []
+
+    def consume_external_perf_records(self) -> list[Any]:
+        """Return and clear the authoritative invocation records for this run."""
+        records, self._external_perf_records = self._external_perf_records, []
+        return records
 
 
 class BaseStageAdapter:
@@ -81,7 +117,7 @@ class BaseStageAdapter:
     def __init__(self, stage: "ProcessingStage"):
         self.stage = stage
 
-    def process_batch(self, tasks: list[Task]) -> list[Task]:
+    def process_batch(self, tasks: list[Task]) -> list[Task]:  # noqa: C901
         """Process a batch of tasks.
 
         Args:
@@ -99,9 +135,14 @@ class BaseStageAdapter:
         # Initialize performance timer for this batch
         self._timer.reinit(input_size)
 
+        capture_metrics = bool(getattr(self.stage, "_curator_stage_perf_collector_name", ""))
+        window_start_s = time.time() if capture_metrics else 0.0
+        process_start_s = time.perf_counter() if capture_metrics else 0.0
         with self._timer.time_process(input_size):
             # Use the batch processing logic
             results = self.stage.process_batch(tasks)
+        process_elapsed_s = max(time.perf_counter() - process_start_s, 0.0) if capture_metrics else 0.0
+        window_end_s = time.time() if capture_metrics else 0.0
 
         # A returned ``None`` ("filter this slot") becomes a NoneTask so every
         # output is a real Task that gets a task_id. Sentinels (NoneTask /
@@ -116,9 +157,7 @@ class BaseStageAdapter:
         is_source_stage = getattr(self.stage, "is_source_stage", False)
         failed_tasks = [r for r in results if isinstance(r, FailedTask)]
         if failed_tasks and is_source_stage:
-            msg = (
-                f"Source stage {self.stage.name} emitted FailedTask, which is not supported."
-            )
+            msg = f"Source stage {self.stage.name} emitted FailedTask, which is not supported."
             raise ValueError(msg)
 
         # Record failed tasks for later inspection or retry bookkeeping.
@@ -146,12 +185,31 @@ class BaseStageAdapter:
 
         # Log performance stats and add to result tasks
         _, stage_perf_stats = self._timer.log_stats()
+        if capture_metrics:
+            stage_perf_stats.process_time = process_elapsed_s
+            stage_perf_stats.invocation_id = uuid.uuid4().hex
+            stage_perf_stats.window_start_s = window_start_s
+            stage_perf_stats.window_end_s = window_end_s
         # Consume and attach any custom metrics recorded by the stage during this call
         custom_metrics = self.stage._consume_custom_metrics()
         if custom_metrics:
             stage_perf_stats.custom_metrics.update(custom_metrics)
+        enrich_perf = getattr(self, "_enrich_stage_perf_record", None)
+        if callable(enrich_perf):
+            enrich_perf(stage_perf_stats, results)
         for task in results:
             task.add_stage_perf(stage_perf_stats)
+        if capture_metrics:
+            try:
+                from nemo_curator.utils.stage_perf_collector import record_stage_perf
+
+                record_stage_perf(
+                    self.stage,
+                    stage_perf_stats,
+                    attached_to_output=bool(results),
+                )
+            except Exception as exc:  # noqa: BLE001
+                logger.debug("Stage performance collector publish failed for {}: {}", self.stage.name, exc)
 
         return results
 
@@ -300,8 +358,17 @@ class BaseStageAdapter:
         Args:
             worker_metadata (WorkerMetadata, optional): Information about the worker
         """
+        self._worker_metadata = worker_metadata
         self.stage.setup(worker_metadata)
+        setup_perf = getattr(self, "_setup_performance_telemetry", None)
+        if callable(setup_perf):
+            setup_perf(worker_metadata)
 
     def teardown(self) -> None:
         """Teardown the stage once per actor."""
-        self.stage.teardown()
+        try:
+            self.stage.teardown()
+        finally:
+            teardown_perf = getattr(self, "_teardown_performance_telemetry", None)
+            if callable(teardown_perf):
+                teardown_perf()

--- a/nemo_curator/backends/base.py
+++ b/nemo_curator/backends/base.py
@@ -57,13 +57,11 @@ class NodeInfo:
 class WorkerMetadata:
     """Generic worker metadata for setup_on_node calls across backends.
     Simplified to match Xenna's structure. The allocation field can contain
-    backend-specific allocation information and ``perf_identity`` can carry an
-    optional backend-owned immutable identity value.
+    backend-specific allocation information.
     """
 
     worker_id: str = ""
     allocation: Any = None  # Backend-specific allocation info
-    perf_identity: Any = None
 
 
 class BaseExecutor(ABC):
@@ -146,7 +144,7 @@ class BaseStageAdapter:
     def __init__(self, stage: "ProcessingStage"):
         self.stage = stage
 
-    def process_batch(self, tasks: list[Task]) -> list[Task]:  # noqa: C901, PLR0912, PLR0915
+    def process_batch(self, tasks: list[Task]) -> list[Task]:  # noqa: C901
         """Process a batch of tasks.
 
         Args:
@@ -223,9 +221,6 @@ class BaseStageAdapter:
         custom_metrics = self.stage._consume_custom_metrics()
         if custom_metrics:
             stage_perf_stats.custom_metrics.update(custom_metrics)
-        enrich_perf = getattr(self, "_enrich_stage_perf_record", None)
-        if callable(enrich_perf):
-            enrich_perf(stage_perf_stats, results)
         for task in results:
             task.add_stage_perf(stage_perf_stats)
         if capture_metrics:
@@ -390,22 +385,13 @@ class BaseStageAdapter:
         Args:
             worker_metadata (WorkerMetadata, optional): Information about the worker
         """
-        self._worker_metadata = worker_metadata
         self.stage.setup(worker_metadata)
-        setup_perf = getattr(self, "_setup_performance_telemetry", None)
-        if callable(setup_perf):
-            setup_perf(worker_metadata)
 
     def teardown(self) -> None:
         """Teardown the stage once per actor."""
         try:
             self.stage.teardown()
         finally:
-            try:
-                from nemo_curator.utils.stage_perf_collector import flush_stage_perf_records
+            from nemo_curator.utils.stage_perf_collector import flush_stage_perf_records
 
-                flush_stage_perf_records(self.stage)
-            finally:
-                teardown_perf = getattr(self, "_teardown_performance_telemetry", None)
-                if callable(teardown_perf):
-                    teardown_perf()
+            flush_stage_perf_records(self.stage)

--- a/nemo_curator/backends/base.py
+++ b/nemo_curator/backends/base.py
@@ -99,13 +99,19 @@ class BaseExecutor(ABC):
         try:
             from nemo_curator.utils.stage_perf_collector import stop_stage_perf_collector
 
-            records = stop_stage_perf_collector(collector, stages)
+            record_store = stop_stage_perf_collector(collector, stages)
         except Exception as exc:  # noqa: BLE001
             logger.debug("Stage performance collector stop failed: {}", exc)
-            records = []
-        self._external_perf_records = [stats for stats, _attached in records] if keep_records else []
+            record_store = None
+        if keep_records:
+            self._external_perf_records = record_store
+        else:
+            cleanup = getattr(record_store, "cleanup", None)
+            if callable(cleanup):
+                cleanup()
+            self._external_perf_records = []
 
-    def consume_external_perf_records(self) -> list[Any]:
+    def consume_external_perf_records(self) -> Any:  # noqa: ANN401
         """Return and clear the authoritative invocation records for this run."""
         records, self._external_perf_records = self._external_perf_records, []
         return records

--- a/nemo_curator/backends/base.py
+++ b/nemo_curator/backends/base.py
@@ -81,13 +81,25 @@ class BaseExecutor(ABC):
     @staticmethod
     def _start_stage_perf_collector(stages: list["ProcessingStage"]) -> Any | None:  # noqa: ANN401
         """Start the run-scoped collector when performance collection is enabled."""
+        report_required = any(
+            (callable(request := getattr(stage, "requests_performance_records", None)) and request())
+            or bool(getattr(stage, "write_perf_stats", False))
+            for stage in stages
+        )
         try:
             from nemo_curator.utils.stage_perf_collector import start_stage_perf_collector
 
-            return start_stage_perf_collector(stages)
-        except Exception as exc:  # noqa: BLE001
+            collector = start_stage_perf_collector(stages)
+        except Exception as exc:
+            if report_required:
+                msg = f"Required stage performance collector failed to start: {exc}"
+                raise RuntimeError(msg) from exc
             logger.debug("Stage performance collector disabled: {}", exc)
             return None
+        if report_required and collector is None:
+            msg = "Required stage performance collector did not start"
+            raise RuntimeError(msg)
+        return collector
 
     def _stop_stage_perf_collector(
         self,
@@ -96,13 +108,24 @@ class BaseExecutor(ABC):
         *,
         keep_records: bool,
     ) -> None:
+        report_required = keep_records and any(
+            (callable(request := getattr(stage, "requests_performance_records", None)) and request())
+            or bool(getattr(stage, "write_perf_stats", False))
+            for stage in stages
+        )
         try:
             from nemo_curator.utils.stage_perf_collector import stop_stage_perf_collector
 
-            record_store = stop_stage_perf_collector(collector, stages)
-        except Exception as exc:  # noqa: BLE001
+            record_store = stop_stage_perf_collector(collector, stages, raise_on_failure=report_required)
+        except Exception as exc:
+            if report_required:
+                msg = f"Required stage performance collector failed to stop: {exc}"
+                raise RuntimeError(msg) from exc
             logger.debug("Stage performance collector stop failed: {}", exc)
             record_store = None
+        if report_required and record_store is None:
+            msg = "Required stage performance collector returned no record store"
+            raise RuntimeError(msg)
         if keep_records:
             self._external_perf_records = record_store
         else:
@@ -123,7 +146,7 @@ class BaseStageAdapter:
     def __init__(self, stage: "ProcessingStage"):
         self.stage = stage
 
-    def process_batch(self, tasks: list[Task]) -> list[Task]:  # noqa: C901
+    def process_batch(self, tasks: list[Task]) -> list[Task]:  # noqa: C901, PLR0912, PLR0915
         """Process a batch of tasks.
 
         Args:
@@ -136,15 +159,15 @@ class BaseStageAdapter:
         if not hasattr(self, "_timer") or self._timer is None:
             self._timer = StageTimer(self.stage)
 
-        # Calculate input data size for timer
-        input_size = sum(task.num_items for task in tasks)
-        # Initialize performance timer for this batch
-        self._timer.reinit(input_size)
-
         capture_metrics = bool(getattr(self.stage, "_curator_stage_perf_collector_name", ""))
+        num_input_items = sum(task.num_items for task in tasks)
+        input_size_bytes = sum(task.input_data_size_bytes() for task in tasks) if capture_metrics else 0
+        # Initialize performance timer for this batch
+        self._timer.reinit(input_size_bytes)
+
         window_start_s = time.time() if capture_metrics else 0.0
         process_start_s = time.perf_counter() if capture_metrics else 0.0
-        with self._timer.time_process(input_size):
+        with self._timer.time_process(num_input_items):
             # Use the batch processing logic
             results = self.stage.process_batch(tasks)
         process_elapsed_s = max(time.perf_counter() - process_start_s, 0.0) if capture_metrics else 0.0
@@ -214,7 +237,10 @@ class BaseStageAdapter:
                     stage_perf_stats,
                     attached_to_output=bool(results),
                 )
-            except Exception as exc:  # noqa: BLE001
+            except Exception as exc:
+                if bool(getattr(self.stage, "_curator_stage_perf_report_required", False)):
+                    msg = f"Required stage performance collector publish failed for {self.stage.name}: {exc}"
+                    raise RuntimeError(msg) from exc
                 logger.debug("Stage performance collector publish failed for {}: {}", self.stage.name, exc)
 
         return results
@@ -375,6 +401,11 @@ class BaseStageAdapter:
         try:
             self.stage.teardown()
         finally:
-            teardown_perf = getattr(self, "_teardown_performance_telemetry", None)
-            if callable(teardown_perf):
-                teardown_perf()
+            try:
+                from nemo_curator.utils.stage_perf_collector import flush_stage_perf_records
+
+                flush_stage_perf_records(self.stage)
+            finally:
+                teardown_perf = getattr(self, "_teardown_performance_telemetry", None)
+                if callable(teardown_perf):
+                    teardown_perf()

--- a/nemo_curator/backends/base.py
+++ b/nemo_curator/backends/base.py
@@ -37,6 +37,7 @@ from nemo_curator.utils.resumability_client import (
 
 if TYPE_CHECKING:
     from nemo_curator.stages.base import ProcessingStage
+    from nemo_curator.utils.stage_perf_collector import PerformanceRecordStore
 
 
 def _is_sentinel(task: Task) -> bool:
@@ -70,7 +71,7 @@ class BaseExecutor(ABC):
     def __init__(self, config: dict[str, Any] | None = None, ignore_head_node: bool = False):
         self.config = config or {}
         self.ignore_head_node = ignore_head_node or ignore_ray_head_node()
-        self._external_perf_records: list[Any] = []
+        self._external_perf_records: PerformanceRecordStore | None = None
 
     @abstractmethod
     def execute(self, stages: list["ProcessingStage"], initial_tasks: list[Task] | None = None) -> None:
@@ -80,9 +81,7 @@ class BaseExecutor(ABC):
     def _start_stage_perf_collector(stages: list["ProcessingStage"]) -> Any | None:  # noqa: ANN401
         """Start the run-scoped collector when performance collection is enabled."""
         report_required = any(
-            (callable(request := getattr(stage, "requests_performance_records", None)) and request())
-            or bool(getattr(stage, "write_perf_stats", False))
-            for stage in stages
+            callable(request := getattr(stage, "requests_performance_records", None)) and request() for stage in stages
         )
         try:
             from nemo_curator.utils.stage_perf_collector import start_stage_perf_collector
@@ -107,9 +106,7 @@ class BaseExecutor(ABC):
         keep_records: bool,
     ) -> None:
         report_required = keep_records and any(
-            (callable(request := getattr(stage, "requests_performance_records", None)) and request())
-            or bool(getattr(stage, "write_perf_stats", False))
-            for stage in stages
+            callable(request := getattr(stage, "requests_performance_records", None)) and request() for stage in stages
         )
         try:
             from nemo_curator.utils.stage_perf_collector import stop_stage_perf_collector
@@ -130,12 +127,14 @@ class BaseExecutor(ABC):
             cleanup = getattr(record_store, "cleanup", None)
             if callable(cleanup):
                 cleanup()
-            self._external_perf_records = []
+            self._external_perf_records = None
 
-    def consume_external_perf_records(self) -> Any:  # noqa: ANN401
+    def consume_external_perf_records(self) -> "PerformanceRecordStore":
         """Return and clear the authoritative invocation records for this run."""
-        records, self._external_perf_records = self._external_perf_records, []
-        return records
+        from nemo_curator.utils.stage_perf_collector import PerformanceRecordStore
+
+        records, self._external_perf_records = self._external_perf_records, None
+        return records if records is not None else PerformanceRecordStore()
 
 
 class BaseStageAdapter:
@@ -144,7 +143,7 @@ class BaseStageAdapter:
     def __init__(self, stage: "ProcessingStage"):
         self.stage = stage
 
-    def process_batch(self, tasks: list[Task]) -> list[Task]:  # noqa: C901
+    def process_batch(self, tasks: list[Task]) -> list[Task]:  # noqa: C901, PLR0912
         """Process a batch of tasks.
 
         Args:
@@ -221,17 +220,21 @@ class BaseStageAdapter:
         custom_metrics = self.stage._consume_custom_metrics()
         if custom_metrics:
             stage_perf_stats.custom_metrics.update(custom_metrics)
-        for task in results:
-            task.add_stage_perf(stage_perf_stats)
+        # Without a run-scoped collector, preserve the legacy task-attached path.
+        # With collection enabled, the collector is authoritative: copying the
+        # same invocation onto every fan-out output would multiply memory and
+        # serialization cost and invite consumers to over-count one call.
+        if not capture_metrics:
+            for task in results:
+                task.add_stage_perf(stage_perf_stats)
         if capture_metrics:
             try:
                 from nemo_curator.utils.stage_perf_collector import record_stage_perf
 
-                record_stage_perf(
-                    self.stage,
-                    stage_perf_stats,
-                    attached_to_output=bool(results),
-                )
+                # Publish once per process_batch invocation, outside the output
+                # loop. Publishing per output would over-estimate time, bytes,
+                # items, and custom metrics whenever one input fans out.
+                record_stage_perf(self.stage, stage_perf_stats)
             except Exception as exc:
                 if bool(getattr(self.stage, "_curator_stage_perf_report_required", False)):
                     msg = f"Required stage performance collector publish failed for {self.stage.name}: {exc}"

--- a/nemo_curator/backends/ray_data/executor.py
+++ b/nemo_curator/backends/ray_data/executor.py
@@ -69,6 +69,8 @@ class RayDataExecutor(BaseExecutor):
         # Initialize with initial tasks if provided, otherwise start with EmptyTask
         tasks: list[Task] = initial_tasks or [EmptyTask()]
         output_tasks: list[Task] = []
+        self._external_perf_records = []
+        stage_perf_collector = None
         # When runtime_env with pip is used, Ray's pip plugin sets up per-stage virtualenvs
         # lazily on first task dispatch by cloning the current virtualenv. The NeMo Curator
         # container's /opt/venv is created with `uv venv --seed` so pip is available in clones.
@@ -78,6 +80,7 @@ class RayDataExecutor(BaseExecutor):
             ray.init(
                 ignore_reinit_error=True, runtime_env={"env_vars": {"RAY_EXPERIMENTAL_NOSET_CUDA_VISIBLE_DEVICES": ""}}
             )
+            stage_perf_collector = self._start_stage_perf_collector(stages)
 
             # Convert tasks to dataset
             current_dataset = self._tasks_to_dataset(tasks)
@@ -104,9 +107,13 @@ class RayDataExecutor(BaseExecutor):
             # Convert final dataset back to tasks
             # TODO: add pipeline configuration to check if user wants to return last stages output to driver
             output_tasks = self._dataset_to_tasks(current_dataset)
+            self._stop_stage_perf_collector(stage_perf_collector, stages, keep_records=True)
+            stage_perf_collector = None
             logger.info(f"Pipeline completed. Final results: {len(output_tasks)} tasks")
         finally:
             # This ensures we unset all the env vars set above during initialize and kill the pending actors.
+            if stage_perf_collector is not None:
+                self._stop_stage_perf_collector(stage_perf_collector, stages, keep_records=False)
             ray.shutdown()
         return output_tasks
 

--- a/nemo_curator/backends/ray_data/executor.py
+++ b/nemo_curator/backends/ray_data/executor.py
@@ -69,7 +69,7 @@ class RayDataExecutor(BaseExecutor):
         # Initialize with initial tasks if provided, otherwise start with EmptyTask
         tasks: list[Task] = initial_tasks or [EmptyTask()]
         output_tasks: list[Task] = []
-        self._external_perf_records = []
+        self._external_perf_records = None
         stage_perf_collector = None
         # When runtime_env with pip is used, Ray's pip plugin sets up per-stage virtualenvs
         # lazily on first task dispatch by cloning the current virtualenv. The NeMo Curator

--- a/nemo_curator/backends/xenna/executor.py
+++ b/nemo_curator/backends/xenna/executor.py
@@ -146,7 +146,7 @@ class XennaExecutor(BaseExecutor):
         # Log pipeline configuration
         logger.info(f"Execution mode: {exec_mode.name}")
 
-        self._external_perf_records = []
+        self._external_perf_records = None
         stage_perf_collector = None
         try:
             register_loguru_serializer()

--- a/nemo_curator/backends/xenna/executor.py
+++ b/nemo_curator/backends/xenna/executor.py
@@ -146,6 +146,8 @@ class XennaExecutor(BaseExecutor):
         # Log pipeline configuration
         logger.info(f"Execution mode: {exec_mode.name}")
 
+        self._external_perf_records = []
+        stage_perf_collector = None
         try:
             register_loguru_serializer()
             # Prevent Ray from overriding accelerator env vars when num_gpus=0, letting Xenna manage them instead.
@@ -158,14 +160,19 @@ class XennaExecutor(BaseExecutor):
                     }
                 },
             )
+            stage_perf_collector = self._start_stage_perf_collector(stages)
             # Run the pipeline (this will re-initialize ray but that'll be a no-op and the ray.init above will take precedence)
             results = pipelines_v1.run_pipeline(pipeline_spec)
+            self._stop_stage_perf_collector(stage_perf_collector, stages, keep_records=True)
+            stage_perf_collector = None
             logger.info(f"Pipeline completed successfully with {len(results) if results else 0} output tasks")
         except Exception as e:
             logger.error(f"Pipeline execution failed: {e}")
             raise
         finally:
             # This ensures we unset all the env vars set above during initialize and kill the pending actors.
+            if stage_perf_collector is not None:
+                self._stop_stage_perf_collector(stage_perf_collector, stages, keep_records=False)
             ray.shutdown()
         return results if results else []
 

--- a/nemo_curator/config/run.py
+++ b/nemo_curator/config/run.py
@@ -21,7 +21,6 @@ from omegaconf import DictConfig, OmegaConf
 from nemo_curator.backends.base import BaseExecutor
 from nemo_curator.core.client import RayClient
 from nemo_curator.pipeline import Pipeline
-from nemo_curator.stages.base import CompositeStage
 from nemo_curator.stages.resources import Resources
 
 _EXECUTOR_TARGETS = {
@@ -42,7 +41,7 @@ def create_ray_client_from_yaml(cfg: DictConfig) -> RayClient:
 
 def create_executor_from_yaml(cfg: DictConfig) -> BaseExecutor | None:
     """Create the configured pipeline executor, if executor settings are present."""
-    if "backend" not in cfg and "execution_mode" not in cfg and "executor_config" not in cfg:
+    if "backend" not in cfg and "execution_mode" not in cfg:
         return None
 
     backend = str(cfg.get("backend", "xenna"))
@@ -52,34 +51,17 @@ def create_executor_from_yaml(cfg: DictConfig) -> BaseExecutor | None:
         raise ValueError(msg)
 
     executor_cls = hydra.utils.get_class(_EXECUTOR_TARGETS[backend])
-    executor_config_node = cfg.get("executor_config")
-    executor_config = (
-        OmegaConf.to_container(executor_config_node, resolve=True) if executor_config_node is not None else {}
-    )
-    executor_config = executor_config or {}
-    if not isinstance(executor_config, dict):
-        msg = "executor_config must be a mapping."
-        raise TypeError(msg)
     if backend == "xenna":
-        top_level_mode = cfg.get("execution_mode")
-        nested_mode = executor_config.get("execution_mode")
-        if top_level_mode is not None and nested_mode is not None and str(top_level_mode) != str(nested_mode):
-            msg = (
-                "Conflicting Xenna execution modes: "
-                f"execution_mode={top_level_mode!s} and executor_config.execution_mode={nested_mode!s}."
-            )
-            raise ValueError(msg)
-        execution_mode = str(top_level_mode if top_level_mode is not None else nested_mode or "streaming")
+        execution_mode = str(cfg.get("execution_mode", "streaming"))
         if execution_mode not in _XENNA_EXECUTION_MODES:
             choices = ", ".join(sorted(_XENNA_EXECUTION_MODES))
             msg = f"Unknown Xenna execution mode '{execution_mode}'. Choose from: {choices}."
             raise ValueError(msg)
-        executor_config["execution_mode"] = execution_mode
         logger.info(f"Using executor backend '{backend}' in '{execution_mode}' mode.")
-        return executor_cls(config=executor_config)
+        return executor_cls(config={"execution_mode": execution_mode})
 
     logger.info(f"Using executor backend '{backend}'.")
-    return executor_cls(config=executor_config) if executor_config else executor_cls()
+    return executor_cls()
 
 
 def _instantiate_stage(stage_cfg: DictConfig) -> Any:  # noqa: ANN401
@@ -94,29 +76,16 @@ def _instantiate_stage(stage_cfg: DictConfig) -> Any:  # noqa: ANN401
     cfg_dict = OmegaConf.to_container(stage_cfg, resolve=True)
 
     stage_resources = cfg_dict.pop("resources", None)
-    extended_performance_metrics = cfg_dict.pop("extended_performance_metrics", None)
-
     stage = hydra.utils.instantiate(cfg_dict)
 
-    with_kwargs: dict[str, Any] = {}
     if stage_resources:
         if isinstance(stage_resources, dict) and "_target_" in stage_resources:
             resources_obj = hydra.utils.instantiate(stage_resources)
         else:
             resources_obj = Resources(**stage_resources)
-        with_kwargs["resources"] = resources_obj
-    if extended_performance_metrics is not None and not isinstance(stage, CompositeStage):
-        with_kwargs["extended_performance_metrics"] = bool(extended_performance_metrics)
-    if with_kwargs:
+        with_kwargs: dict[str, Any] = {"resources": resources_obj}
         stage = stage.with_(**with_kwargs)
         logger.info(f"Applied .with_() to '{stage.name}': {with_kwargs}")
-    if extended_performance_metrics is not None and isinstance(stage, CompositeStage):
-        stage.extended_performance_metrics = bool(extended_performance_metrics)
-        logger.info(
-            "Applied extended_performance_metrics={} to composite '{}'; it will propagate during decomposition.",
-            stage.extended_performance_metrics,
-            stage.name,
-        )
 
     return stage
 

--- a/nemo_curator/config/run.py
+++ b/nemo_curator/config/run.py
@@ -41,7 +41,7 @@ def create_ray_client_from_yaml(cfg: DictConfig) -> RayClient:
 
 def create_executor_from_yaml(cfg: DictConfig) -> BaseExecutor | None:
     """Create the configured pipeline executor, if executor settings are present."""
-    if "backend" not in cfg and "execution_mode" not in cfg:
+    if "backend" not in cfg and "execution_mode" not in cfg and "executor_config" not in cfg:
         return None
 
     backend = str(cfg.get("backend", "xenna"))
@@ -51,17 +51,26 @@ def create_executor_from_yaml(cfg: DictConfig) -> BaseExecutor | None:
         raise ValueError(msg)
 
     executor_cls = hydra.utils.get_class(_EXECUTOR_TARGETS[backend])
+    executor_config_node = cfg.get("executor_config")
+    executor_config = (
+        OmegaConf.to_container(executor_config_node, resolve=True) if executor_config_node is not None else {}
+    )
+    executor_config = executor_config or {}
+    if not isinstance(executor_config, dict):
+        msg = "executor_config must be a mapping."
+        raise TypeError(msg)
     if backend == "xenna":
         execution_mode = str(cfg.get("execution_mode", "streaming"))
         if execution_mode not in _XENNA_EXECUTION_MODES:
             choices = ", ".join(sorted(_XENNA_EXECUTION_MODES))
             msg = f"Unknown Xenna execution mode '{execution_mode}'. Choose from: {choices}."
             raise ValueError(msg)
+        executor_config.setdefault("execution_mode", execution_mode)
         logger.info(f"Using executor backend '{backend}' in '{execution_mode}' mode.")
-        return executor_cls(config={"execution_mode": execution_mode})
+        return executor_cls(config=executor_config)
 
     logger.info(f"Using executor backend '{backend}'.")
-    return executor_cls()
+    return executor_cls(config=executor_config) if executor_config else executor_cls()
 
 
 def _instantiate_stage(stage_cfg: DictConfig) -> Any:  # noqa: ANN401
@@ -76,15 +85,20 @@ def _instantiate_stage(stage_cfg: DictConfig) -> Any:  # noqa: ANN401
     cfg_dict = OmegaConf.to_container(stage_cfg, resolve=True)
 
     stage_resources = cfg_dict.pop("resources", None)
+    extended_performance_metrics = cfg_dict.pop("extended_performance_metrics", None)
 
     stage = hydra.utils.instantiate(cfg_dict)
 
+    with_kwargs: dict[str, Any] = {}
     if stage_resources:
         if isinstance(stage_resources, dict) and "_target_" in stage_resources:
             resources_obj = hydra.utils.instantiate(stage_resources)
         else:
             resources_obj = Resources(**stage_resources)
-        with_kwargs: dict[str, Any] = {"resources": resources_obj}
+        with_kwargs["resources"] = resources_obj
+    if extended_performance_metrics is not None:
+        with_kwargs["extended_performance_metrics"] = bool(extended_performance_metrics)
+    if with_kwargs:
         stage = stage.with_(**with_kwargs)
         logger.info(f"Applied .with_() to '{stage.name}': {with_kwargs}")
 
@@ -131,7 +145,10 @@ def main(cfg: DictConfig) -> None:
 
     # Execute pipeline
     print("Starting pipeline execution...")
-    _results = pipeline.run() if executor is None else pipeline.run(executor=executor)
+    run_kwargs = {"executor": executor} if executor is not None else {}
+    if report_path := cfg.get("performance_report_path"):
+        run_kwargs["performance_report_path"] = str(report_path)
+    pipeline.run(**run_kwargs)
 
     print("\nPipeline completed!")
 

--- a/nemo_curator/config/run.py
+++ b/nemo_curator/config/run.py
@@ -21,6 +21,7 @@ from omegaconf import DictConfig, OmegaConf
 from nemo_curator.backends.base import BaseExecutor
 from nemo_curator.core.client import RayClient
 from nemo_curator.pipeline import Pipeline
+from nemo_curator.stages.base import CompositeStage
 from nemo_curator.stages.resources import Resources
 
 _EXECUTOR_TARGETS = {
@@ -60,12 +61,20 @@ def create_executor_from_yaml(cfg: DictConfig) -> BaseExecutor | None:
         msg = "executor_config must be a mapping."
         raise TypeError(msg)
     if backend == "xenna":
-        execution_mode = str(cfg.get("execution_mode", "streaming"))
+        top_level_mode = cfg.get("execution_mode")
+        nested_mode = executor_config.get("execution_mode")
+        if top_level_mode is not None and nested_mode is not None and str(top_level_mode) != str(nested_mode):
+            msg = (
+                "Conflicting Xenna execution modes: "
+                f"execution_mode={top_level_mode!s} and executor_config.execution_mode={nested_mode!s}."
+            )
+            raise ValueError(msg)
+        execution_mode = str(top_level_mode if top_level_mode is not None else nested_mode or "streaming")
         if execution_mode not in _XENNA_EXECUTION_MODES:
             choices = ", ".join(sorted(_XENNA_EXECUTION_MODES))
             msg = f"Unknown Xenna execution mode '{execution_mode}'. Choose from: {choices}."
             raise ValueError(msg)
-        executor_config.setdefault("execution_mode", execution_mode)
+        executor_config["execution_mode"] = execution_mode
         logger.info(f"Using executor backend '{backend}' in '{execution_mode}' mode.")
         return executor_cls(config=executor_config)
 
@@ -96,11 +105,18 @@ def _instantiate_stage(stage_cfg: DictConfig) -> Any:  # noqa: ANN401
         else:
             resources_obj = Resources(**stage_resources)
         with_kwargs["resources"] = resources_obj
-    if extended_performance_metrics is not None:
+    if extended_performance_metrics is not None and not isinstance(stage, CompositeStage):
         with_kwargs["extended_performance_metrics"] = bool(extended_performance_metrics)
     if with_kwargs:
         stage = stage.with_(**with_kwargs)
         logger.info(f"Applied .with_() to '{stage.name}': {with_kwargs}")
+    if extended_performance_metrics is not None and isinstance(stage, CompositeStage):
+        stage.extended_performance_metrics = bool(extended_performance_metrics)
+        logger.info(
+            "Applied extended_performance_metrics={} to composite '{}'; it will propagate during decomposition.",
+            stage.extended_performance_metrics,
+            stage.name,
+        )
 
     return stage
 

--- a/nemo_curator/config/run.py
+++ b/nemo_curator/config/run.py
@@ -145,10 +145,7 @@ def main(cfg: DictConfig) -> None:
 
     # Execute pipeline
     print("Starting pipeline execution...")
-    run_kwargs = {"executor": executor} if executor is not None else {}
-    if report_path := cfg.get("performance_report_path"):
-        run_kwargs["performance_report_path"] = str(report_path)
-    pipeline.run(**run_kwargs)
+    pipeline.run() if executor is None else pipeline.run(executor=executor)
 
     print("\nPipeline completed!")
 

--- a/nemo_curator/pipeline/pipeline.py
+++ b/nemo_curator/pipeline/pipeline.py
@@ -71,7 +71,7 @@ class Pipeline:
         self.description = description
         self.stages: list[ProcessingStage] = stages or []
         self.config = config or {}
-        self.performance_records: list[Any] = []
+        self.performance_records: Any = None
 
     def add_stage(self, stage: ProcessingStage) -> "Pipeline":
         """Add a stage to the pipeline.
@@ -273,7 +273,10 @@ class Pipeline:
         Returns:
             list[Task] | None: List of tasks
         """
-        self.performance_records = []
+        cleanup_previous_records = getattr(self.performance_records, "cleanup", None)
+        if callable(cleanup_previous_records):
+            cleanup_previous_records()
+        self.performance_records = None
         self.build()
 
         if checkpoint_path is not None:
@@ -363,7 +366,14 @@ class Pipeline:
 
         consume_external_perf = getattr(executor, "consume_external_perf_records", None)
         consumed_records = consume_external_perf() if callable(consume_external_perf) else []
-        self.performance_records = list(consumed_records) if isinstance(consumed_records, (list, tuple)) else []
+        from nemo_curator.utils.stage_perf_collector import PerformanceRecordStore
+
+        if isinstance(consumed_records, PerformanceRecordStore):
+            self.performance_records = consumed_records
+        elif isinstance(consumed_records, (list, tuple)):
+            self.performance_records = PerformanceRecordStore.from_records(consumed_records)
+        else:
+            self.performance_records = PerformanceRecordStore()
         output_tasks = result if isinstance(result, list) else []
         if performance_consumer is not None:
             performance_consumer.finalize_performance_report(

--- a/nemo_curator/pipeline/pipeline.py
+++ b/nemo_curator/pipeline/pipeline.py
@@ -12,6 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import json
+import os
+import time
+import uuid
 from pathlib import Path
 from typing import Any
 
@@ -68,6 +72,7 @@ class Pipeline:
         self.description = description
         self.stages: list[ProcessingStage] = stages or []
         self.config = config or {}
+        self.performance_records: list[Any] = []
 
     def add_stage(self, stage: ProcessingStage) -> "Pipeline":
         """Add a stage to the pipeline.
@@ -112,6 +117,31 @@ class Pipeline:
         # counters that a sink consumes its outputs (see
         # ``BaseStageAdapter._apply_resumability_counters``).
         self._assign_source_sink_roles()
+        for stage_index, stage in enumerate(self.stages):
+            stage._curator_stage_id = f"{stage_index:03d}:{stage.name}"
+
+    def _set_execution_context(self, executor: BaseExecutor) -> None:
+        """Stamp one run's driver-owned identity onto every planned stage."""
+        run_id = os.environ.get("PIPELINE_RUN_ID", "").strip() or uuid.uuid4().hex
+        executor_name = type(executor).__name__
+        pipeline_metadata = {
+            "pipeline_name": self.name,
+            "pipeline_description": self.description or "",
+            "stages": [
+                {
+                    "stage_id": stage._curator_stage_id,
+                    "name": stage.name,
+                    "type": f"{type(stage).__module__}.{type(stage).__name__}",
+                    "batch_size": stage.batch_size,
+                    "num_workers": stage.num_workers(),
+                }
+                for stage in self.stages
+            ],
+        }
+        for stage in self.stages:
+            stage._curator_run_id = run_id
+            stage._curator_executor = executor_name
+            stage._curator_pipeline_metadata = pipeline_metadata
 
     def _assign_source_sink_roles(self) -> None:
         explicit_sources = [s for s in self.stages if s.is_source_stage]
@@ -224,11 +254,12 @@ class Pipeline:
 
         return "\n".join(lines)
 
-    def run(  # noqa: C901, PLR0912
+    def run(  # noqa: C901, PLR0912, PLR0915
         self,
         executor: BaseExecutor | None = None,
         initial_tasks: list[Task] | None = None,
         checkpoint_path: str | Path | None = None,
+        performance_report_path: str | Path | None = None,
     ) -> list[Task] | None:
         """Run the pipeline.
 
@@ -241,10 +272,13 @@ class Pipeline:
                 tracked (in a ``.nemo_curator_metadata`` subdir) and skipped on
                 rerun. Multiple runs (e.g. a SLURM array) may share the directory
                 — each writes its own LMDB file, so there is no contention.
+            performance_report_path (str | Path, optional): Local JSON path for
+                complete driver-owned performance records.
 
         Returns:
             list[Task] | None: List of tasks
         """
+        self.performance_records = []
         self.build()
 
         if checkpoint_path is not None:
@@ -263,6 +297,7 @@ class Pipeline:
             from nemo_curator.backends.xenna import XennaExecutor
 
             executor = XennaExecutor()
+        self._set_execution_context(executor)
 
         from nemo_curator.core.serve import is_inference_server_active
 
@@ -311,10 +346,38 @@ class Pipeline:
                 minimum_shard_index=slurm_array.minimum_shard_index,
             )
 
+        performance_consumer = next(
+            (
+                stage
+                for stage in reversed(self.stages)
+                if callable(getattr(stage, "finalize_performance_report", None))
+            ),
+            None,
+        )
+        if performance_consumer is not None:
+            prepare_report = getattr(performance_consumer, "prepare_performance_report", None)
+            if callable(prepare_report):
+                prepare_report()
+
+        run_started_s = time.perf_counter()
         if checkpoint_path is None:
             result = executor.execute(self.stages, initial_tasks)
         else:
             result = self._run_with_resumability(executor, initial_tasks, checkpoint_path)
+        wall_time_s = max(time.perf_counter() - run_started_s, 0.0)
+
+        consume_external_perf = getattr(executor, "consume_external_perf_records", None)
+        consumed_records = consume_external_perf() if callable(consume_external_perf) else []
+        self.performance_records = list(consumed_records) if isinstance(consumed_records, (list, tuple)) else []
+        output_tasks = result if isinstance(result, list) else []
+        if performance_consumer is not None:
+            performance_consumer.finalize_performance_report(
+                output_tasks,
+                performance_records=self.performance_records,
+                wall_time_s=wall_time_s,
+            )
+        if performance_report_path is not None:
+            self.write_performance_report(performance_report_path)
 
         if completion_manifest is not None:
             if failed_task_manifest_exists():
@@ -327,6 +390,23 @@ class Pipeline:
                 logger.info(f"Wrote Slurm array completion manifest to {manifest_file}")
 
         return result
+
+    def write_performance_report(self, path: str | Path) -> Path:
+        """Write the current run's complete driver-owned telemetry to JSON."""
+        report_path = Path(path).expanduser().absolute()
+        report_path.parent.mkdir(parents=True, exist_ok=True)
+        payload = {
+            "schema_version": 1,
+            "pipeline_name": self.name,
+            "record_count": len(self.performance_records),
+            "records": [record.to_extended_dict() for record in self.performance_records],
+        }
+        report_path.write_text(
+            json.dumps(payload, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+        logger.info(f"Wrote performance telemetry report to {report_path}")
+        return report_path
 
     def _run_with_resumability(
         self,

--- a/nemo_curator/pipeline/pipeline.py
+++ b/nemo_curator/pipeline/pipeline.py
@@ -179,9 +179,6 @@ class Pipeline:
         for stage in stages:
             # Get the decomposed stages (returns [self] for regular stages)
             sub_stages = stage.decompose_and_apply_with() if isinstance(stage, CompositeStage) else [stage]
-            if isinstance(stage, CompositeStage) and stage.extended_performance_metrics:
-                for sub_stage in sub_stages:
-                    sub_stage.extended_performance_metrics = True
 
             if len(sub_stages) > 1:
                 # This was a composite stage

--- a/nemo_curator/pipeline/pipeline.py
+++ b/nemo_curator/pipeline/pipeline.py
@@ -179,6 +179,9 @@ class Pipeline:
         for stage in stages:
             # Get the decomposed stages (returns [self] for regular stages)
             sub_stages = stage.decompose_and_apply_with() if isinstance(stage, CompositeStage) else [stage]
+            if isinstance(stage, CompositeStage) and stage.extended_performance_metrics:
+                for sub_stage in sub_stages:
+                    sub_stage.extended_performance_metrics = True
 
             if len(sub_stages) > 1:
                 # This was a composite stage
@@ -332,6 +335,9 @@ class Pipeline:
         )
 
         slurm_array = SlurmArrayConfig.from_env()
+        for stage in self.stages:
+            stage._curator_slurm_array_shard_index = slurm_array.shard_index if slurm_array is not None else None
+            stage._curator_slurm_array_total_shards = slurm_array.total_shards if slurm_array is not None else None
         completion_manifest = None
         if slurm_array is not None:
             is_driver = is_slurm_array_driver_process()

--- a/nemo_curator/pipeline/pipeline.py
+++ b/nemo_curator/pipeline/pipeline.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
 import time
 import uuid
 from pathlib import Path
@@ -121,7 +120,10 @@ class Pipeline:
 
     def _set_execution_context(self, executor: BaseExecutor) -> None:
         """Stamp one run's driver-owned identity onto every planned stage."""
-        run_id = os.environ.get("PIPELINE_RUN_ID", "").strip() or uuid.uuid4().hex
+        # This identity belongs to one Curator Pipeline.run() call. Generate it
+        # here instead of accepting ambient process state that Curator does not
+        # own or validate.
+        run_id = uuid.uuid4().hex
         executor_name = type(executor).__name__
         pipeline_metadata = {
             "pipeline_name": self.name,
@@ -367,16 +369,7 @@ class Pipeline:
             result = self._run_with_resumability(executor, initial_tasks, checkpoint_path)
         wall_time_s = max(time.perf_counter() - run_started_s, 0.0)
 
-        consume_external_perf = getattr(executor, "consume_external_perf_records", None)
-        consumed_records = consume_external_perf() if callable(consume_external_perf) else []
-        from nemo_curator.utils.stage_perf_collector import PerformanceRecordStore
-
-        if isinstance(consumed_records, PerformanceRecordStore):
-            self.performance_records = consumed_records
-        elif isinstance(consumed_records, (list, tuple)):
-            self.performance_records = PerformanceRecordStore.from_records(consumed_records)
-        else:
-            self.performance_records = PerformanceRecordStore()
+        self.performance_records = executor.consume_external_perf_records()
         output_tasks = result if isinstance(result, list) else []
         if performance_consumer is not None:
             performance_consumer.finalize_performance_report(

--- a/nemo_curator/pipeline/pipeline.py
+++ b/nemo_curator/pipeline/pipeline.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import json
 import os
 import time
 import uuid
@@ -259,7 +258,6 @@ class Pipeline:
         executor: BaseExecutor | None = None,
         initial_tasks: list[Task] | None = None,
         checkpoint_path: str | Path | None = None,
-        performance_report_path: str | Path | None = None,
     ) -> list[Task] | None:
         """Run the pipeline.
 
@@ -272,9 +270,6 @@ class Pipeline:
                 tracked (in a ``.nemo_curator_metadata`` subdir) and skipped on
                 rerun. Multiple runs (e.g. a SLURM array) may share the directory
                 — each writes its own LMDB file, so there is no contention.
-            performance_report_path (str | Path, optional): Local JSON path for
-                complete driver-owned performance records.
-
         Returns:
             list[Task] | None: List of tasks
         """
@@ -376,9 +371,6 @@ class Pipeline:
                 performance_records=self.performance_records,
                 wall_time_s=wall_time_s,
             )
-        if performance_report_path is not None:
-            self.write_performance_report(performance_report_path)
-
         if completion_manifest is not None:
             if failed_task_manifest_exists():
                 logger.warning(
@@ -390,23 +382,6 @@ class Pipeline:
                 logger.info(f"Wrote Slurm array completion manifest to {manifest_file}")
 
         return result
-
-    def write_performance_report(self, path: str | Path) -> Path:
-        """Write the current run's complete driver-owned telemetry to JSON."""
-        report_path = Path(path).expanduser().absolute()
-        report_path.parent.mkdir(parents=True, exist_ok=True)
-        payload = {
-            "schema_version": 1,
-            "pipeline_name": self.name,
-            "record_count": len(self.performance_records),
-            "records": [record.to_extended_dict() for record in self.performance_records],
-        }
-        report_path.write_text(
-            json.dumps(payload, indent=2, sort_keys=True) + "\n",
-            encoding="utf-8",
-        )
-        logger.info(f"Wrote performance telemetry report to {report_path}")
-        return report_path
 
     def _run_with_resumability(
         self,

--- a/nemo_curator/stages/audio/common.py
+++ b/nemo_curator/stages/audio/common.py
@@ -300,6 +300,18 @@ class ManifestWriterStage(ProcessingStage[AudioTask, AudioTask]):
         wall_time_s: float,
     ) -> None:
         """Write all driver-collected invocation metrics through the existing writer."""
+        self._write_raw_performance_report(
+            performance_records=performance_records,
+            wall_time_s=wall_time_s,
+        )
+
+    def _write_raw_performance_report(
+        self,
+        *,
+        performance_records: list["StagePerfStats"],
+        wall_time_s: float,
+    ) -> None:
+        """Persist the raw report so specialized writers can reuse the contract."""
         if self.performance_report_path is None:
             return
         report_fs, report_path = url_to_fs(self.performance_report_path)

--- a/nemo_curator/stages/audio/common.py
+++ b/nemo_curator/stages/audio/common.py
@@ -17,7 +17,7 @@ import os
 import time
 from dataclasses import dataclass, field
 from operator import eq, ge, gt, le, lt, ne
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import soundfile
 import torch
@@ -28,6 +28,10 @@ from nemo_curator.backends.base import NodeInfo, WorkerMetadata
 from nemo_curator.stages.base import CompositeStage, ProcessingStage
 from nemo_curator.stages.file_partitioning import FilePartitioningStage
 from nemo_curator.tasks import AudioTask, EmptyTask, FileGroupTask
+from nemo_curator.utils.file_utils import write_json_file
+
+if TYPE_CHECKING:
+    from nemo_curator.utils.performance_utils import StagePerfStats
 
 
 def get_audio_duration(audio_filepath: str) -> float:
@@ -243,10 +247,14 @@ class ManifestWriterStage(ProcessingStage[AudioTask, AudioTask]):
 
     Args:
         output_path: Destination JSONL path (local or cloud).
+        performance_report_path: Optional JSON destination for all raw
+            pipeline invocation metrics. Supports local and cloud paths through
+            fsspec.
     """
 
     output_path: str
     name: str = "manifest_writer"
+    performance_report_path: str | None = None
 
     def __post_init__(self) -> None:
         if not self.output_path:
@@ -283,6 +291,33 @@ class ManifestWriterStage(ProcessingStage[AudioTask, AudioTask]):
             _metadata=task._metadata,
             _stage_perf=list(task._stage_perf),
         )
+
+    def finalize_performance_report(
+        self,
+        _tasks: list[AudioTask],
+        *,
+        performance_records: list["StagePerfStats"],
+        wall_time_s: float,
+    ) -> None:
+        """Write all driver-collected invocation metrics through the existing writer."""
+        if self.performance_report_path is None:
+            return
+        report_fs, report_path = url_to_fs(self.performance_report_path)
+        write_json_file(
+            report_path,
+            {
+                "schema_version": 1,
+                "pipeline_name": str((self._curator_pipeline_metadata or {}).get("pipeline_name", "")),
+                "run_id": self._curator_run_id,
+                "executor": self._curator_executor,
+                "pipeline": self._curator_pipeline_metadata or {},
+                "wall_time_s": wall_time_s,
+                "record_count": len(performance_records),
+                "records": [record.to_extended_dict() for record in performance_records],
+            },
+            report_fs,
+        )
+        logger.info(f"ManifestWriterStage: wrote performance report to {self.performance_report_path}")
 
     def num_workers(self) -> int | None:
         return 1

--- a/nemo_curator/stages/audio/common.py
+++ b/nemo_curator/stages/audio/common.py
@@ -28,7 +28,7 @@ from nemo_curator.backends.base import NodeInfo, WorkerMetadata
 from nemo_curator.stages.base import CompositeStage, ProcessingStage
 from nemo_curator.stages.file_partitioning import FilePartitioningStage
 from nemo_curator.tasks import AudioTask, EmptyTask, FileGroupTask
-from nemo_curator.utils.file_utils import write_json_file
+from nemo_curator.utils.file_utils import write_json_file_streaming_array
 
 if TYPE_CHECKING:
     from nemo_curator.utils.performance_utils import StagePerfStats
@@ -315,7 +315,13 @@ class ManifestWriterStage(ProcessingStage[AudioTask, AudioTask]):
         if self.performance_report_path is None:
             return
         report_fs, report_path = url_to_fs(self.performance_report_path)
-        write_json_file(
+        iter_dicts = getattr(performance_records, "iter_dicts", None)
+        record_dicts = (
+            iter_dicts()
+            if callable(iter_dicts)
+            else (record.to_extended_dict() for record in performance_records)
+        )
+        write_json_file_streaming_array(
             report_path,
             {
                 "schema_version": 1,
@@ -325,9 +331,10 @@ class ManifestWriterStage(ProcessingStage[AudioTask, AudioTask]):
                 "pipeline": self._curator_pipeline_metadata or {},
                 "wall_time_s": wall_time_s,
                 "record_count": len(performance_records),
-                "records": [record.to_extended_dict() for record in performance_records],
             },
-            report_fs,
+            array_key="records",
+            items=record_dicts,
+            fs=report_fs,
         )
         logger.info(f"ManifestWriterStage: wrote performance report to {self.performance_report_path}")
 

--- a/nemo_curator/stages/audio/common.py
+++ b/nemo_curator/stages/audio/common.py
@@ -14,6 +14,7 @@
 
 import json
 import os
+import posixpath
 import time
 from dataclasses import dataclass, field
 from operator import eq, ge, gt, le, lt, ne
@@ -22,6 +23,7 @@ from typing import TYPE_CHECKING, Any
 import soundfile
 import torch
 from fsspec.core import url_to_fs
+from fsspec.implementations.local import LocalFileSystem
 from loguru import logger
 
 from nemo_curator.backends.base import NodeInfo, WorkerMetadata
@@ -31,7 +33,37 @@ from nemo_curator.tasks import AudioTask, EmptyTask, FileGroupTask
 from nemo_curator.utils.file_utils import write_json_file_streaming_array
 
 if TYPE_CHECKING:
+    import fsspec
+
     from nemo_curator.utils.performance_utils import StagePerfStats
+
+
+def _normalized_filesystem_path(fs: "fsspec.AbstractFileSystem", path: str) -> str:
+    if isinstance(fs, LocalFileSystem):
+        return os.path.realpath(os.path.abspath(path))
+    return posixpath.normpath(path)
+
+
+def _same_filesystem_path(left_url: str, right_url: str) -> bool:
+    """Return whether two URLs identify the same normalized fsspec destination."""
+    left_fs, left_path = url_to_fs(left_url)
+    right_fs, right_path = url_to_fs(right_url)
+    same_filesystem = left_fs is right_fs or (
+        type(left_fs) is type(right_fs)
+        and left_fs.protocol == right_fs.protocol
+        and left_fs.storage_options == right_fs.storage_options
+    )
+    return same_filesystem and _normalized_filesystem_path(left_fs, left_path) == _normalized_filesystem_path(
+        right_fs, right_path
+    )
+
+
+def _append_slurm_shard_suffix(path: str, shard_index: int, total_shards: int) -> str:
+    """Derive a deterministic per-shard filename without changing its directory."""
+    parent, filename = posixpath.split(path)
+    stem, suffix = posixpath.splitext(filename)
+    sharded_filename = f"{stem}.shard-{shard_index:05d}-of-{total_shards:05d}{suffix}"
+    return posixpath.join(parent, sharded_filename) if parent else sharded_filename
 
 
 def get_audio_duration(audio_filepath: str) -> float:
@@ -260,6 +292,15 @@ class ManifestWriterStage(ProcessingStage[AudioTask, AudioTask]):
         if not self.output_path:
             msg = "output_path is required for ManifestWriterStage"
             raise ValueError(msg)
+        if self.performance_report_path is not None and _same_filesystem_path(
+            self.output_path, self.performance_report_path
+        ):
+            msg = "performance_report_path must not resolve to the manifest output_path"
+            raise ValueError(msg)
+
+    def requests_performance_records(self) -> bool:
+        """A configured raw report requires complete invocation collection."""
+        return self.performance_report_path is not None
 
     def setup(self, _worker_metadata: WorkerMetadata | None = None) -> None:
         """Truncate the output file once on the driver before processing starts."""
@@ -315,11 +356,13 @@ class ManifestWriterStage(ProcessingStage[AudioTask, AudioTask]):
         if self.performance_report_path is None:
             return
         report_fs, report_path = url_to_fs(self.performance_report_path)
+        shard_index = self._curator_slurm_array_shard_index
+        total_shards = self._curator_slurm_array_total_shards
+        if shard_index is not None and total_shards is not None:
+            report_path = _append_slurm_shard_suffix(report_path, shard_index, total_shards)
         iter_dicts = getattr(performance_records, "iter_dicts", None)
         record_dicts = (
-            iter_dicts()
-            if callable(iter_dicts)
-            else (record.to_extended_dict() for record in performance_records)
+            iter_dicts() if callable(iter_dicts) else (record.to_extended_dict() for record in performance_records)
         )
         write_json_file_streaming_array(
             report_path,
@@ -331,12 +374,17 @@ class ManifestWriterStage(ProcessingStage[AudioTask, AudioTask]):
                 "pipeline": self._curator_pipeline_metadata or {},
                 "wall_time_s": wall_time_s,
                 "record_count": len(performance_records),
+                "slurm_array": (
+                    {"shard_index": shard_index, "total_shards": total_shards}
+                    if shard_index is not None and total_shards is not None
+                    else None
+                ),
             },
             array_key="records",
             items=record_dicts,
             fs=report_fs,
         )
-        logger.info(f"ManifestWriterStage: wrote performance report to {self.performance_report_path}")
+        logger.info(f"ManifestWriterStage: wrote performance report to {report_path}")
 
     def num_workers(self) -> int | None:
         return 1

--- a/nemo_curator/stages/base.py
+++ b/nemo_curator/stages/base.py
@@ -122,6 +122,11 @@ class ProcessingStage(ABC, Generic[X, Y], metaclass=StageMeta):
     resources = Resources(cpus=1.0)
     batch_size = 1
     runtime_env: ClassVar[dict[str, Any] | None] = None
+    # Framework-owned execution identity populated by ``Pipeline``.
+    _curator_stage_id: str = ""
+    _curator_run_id: str = ""
+    _curator_executor: str = ""
+    _curator_pipeline_metadata: dict[str, Any] | None = None
 
     # Source / sink role flags. User-overridable on the stage class or
     # instance. If neither is set explicitly on any stage in the pipeline,
@@ -132,6 +137,9 @@ class ProcessingStage(ABC, Generic[X, Y], metaclass=StageMeta):
     # resumability layer to mark the counter-decrement boundary.
     is_source_stage: bool = False
     is_sink_stage: bool = False
+    # Opt-in backend identity and hardware sampling. Terminal performance
+    # consumers may independently request complete invocation collection.
+    extended_performance_metrics: bool = False
     # Whether this stage is safe to run under resumability (``checkpoint_path``).
     # Defaults to True; set False only on stages whose input→output mapping isn't
     # source-attributable (shuffle / fan-in, e.g. the dedup shuffle/LSH/connected-
@@ -336,6 +344,7 @@ class ProcessingStage(ABC, Generic[X, Y], metaclass=StageMeta):
         ray_stage_spec: dict[str, Any] | None = None,
         xenna_stage_spec: dict[str, Any] | None = None,
         num_workers: int | None | _UnsetType = _UNSET,
+        extended_performance_metrics: bool | None = None,
     ) -> ProcessingStage:
         """Apply configuration changes to this stage with overridden properties.
 
@@ -350,6 +359,7 @@ class ProcessingStage(ABC, Generic[X, Y], metaclass=StageMeta):
             xenna_stage_spec: Merge overrides into the Xenna stage spec. User-provided keys win.
                 Use num_workers instead of setting num_workers in xenna_stage_spec.
             num_workers: Override the num_workers() result. Passing None explicitly resets to executor default behavior.
+            extended_performance_metrics: Enable backend identity and hardware telemetry.
         """
         new_instance = copy.deepcopy(self)
 
@@ -385,6 +395,8 @@ class ProcessingStage(ABC, Generic[X, Y], metaclass=StageMeta):
 
         if num_workers is not _UNSET:
             new_instance.num_workers = _num_workers_method(cast("int | None", num_workers))
+        if extended_performance_metrics is not None:
+            new_instance.extended_performance_metrics = extended_performance_metrics
 
         return new_instance
 

--- a/nemo_curator/stages/base.py
+++ b/nemo_curator/stages/base.py
@@ -127,6 +127,8 @@ class ProcessingStage(ABC, Generic[X, Y], metaclass=StageMeta):
     _curator_run_id: str = ""
     _curator_executor: str = ""
     _curator_pipeline_metadata: dict[str, Any] | None = None
+    _curator_slurm_array_shard_index: int | None = None
+    _curator_slurm_array_total_shards: int | None = None
 
     # Source / sink role flags. User-overridable on the stage class or
     # instance. If neither is set explicitly on any stage in the pipeline,
@@ -480,6 +482,10 @@ class ProcessingStage(ABC, Generic[X, Y], metaclass=StageMeta):
         metrics: dict[str, float] = dict(self._custom_metrics)
         del self._custom_metrics
         return metrics
+
+    def requests_performance_records(self) -> bool:
+        """Return whether this stage requires a complete run-scoped record set."""
+        return False
 
 
 class CompositeStage(ProcessingStage[X, Y], ABC):

--- a/nemo_curator/stages/base.py
+++ b/nemo_curator/stages/base.py
@@ -139,9 +139,6 @@ class ProcessingStage(ABC, Generic[X, Y], metaclass=StageMeta):
     # resumability layer to mark the counter-decrement boundary.
     is_source_stage: bool = False
     is_sink_stage: bool = False
-    # Opt-in backend identity and hardware sampling. Terminal performance
-    # consumers may independently request complete invocation collection.
-    extended_performance_metrics: bool = False
     # Whether this stage is safe to run under resumability (``checkpoint_path``).
     # Defaults to True; set False only on stages whose input→output mapping isn't
     # source-attributable (shuffle / fan-in, e.g. the dedup shuffle/LSH/connected-
@@ -346,7 +343,6 @@ class ProcessingStage(ABC, Generic[X, Y], metaclass=StageMeta):
         ray_stage_spec: dict[str, Any] | None = None,
         xenna_stage_spec: dict[str, Any] | None = None,
         num_workers: int | None | _UnsetType = _UNSET,
-        extended_performance_metrics: bool | None = None,
     ) -> ProcessingStage:
         """Apply configuration changes to this stage with overridden properties.
 
@@ -361,7 +357,6 @@ class ProcessingStage(ABC, Generic[X, Y], metaclass=StageMeta):
             xenna_stage_spec: Merge overrides into the Xenna stage spec. User-provided keys win.
                 Use num_workers instead of setting num_workers in xenna_stage_spec.
             num_workers: Override the num_workers() result. Passing None explicitly resets to executor default behavior.
-            extended_performance_metrics: Enable backend identity and hardware telemetry.
         """
         new_instance = copy.deepcopy(self)
 
@@ -397,8 +392,6 @@ class ProcessingStage(ABC, Generic[X, Y], metaclass=StageMeta):
 
         if num_workers is not _UNSET:
             new_instance.num_workers = _num_workers_method(cast("int | None", num_workers))
-        if extended_performance_metrics is not None:
-            new_instance.extended_performance_metrics = extended_performance_metrics
 
         return new_instance
 

--- a/nemo_curator/tasks/audio_task.py
+++ b/nemo_curator/tasks/audio_task.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import json
 import os
 from dataclasses import dataclass, field
 
@@ -65,6 +66,10 @@ class AudioTask(Task[dict]):
     @property
     def num_items(self) -> int:
         return 1
+
+    def input_data_size_bytes(self) -> int:
+        """Return the UTF-8 JSON size of this manifest-row payload."""
+        return len(json.dumps(self.data, ensure_ascii=False, separators=(",", ":"), sort_keys=True).encode("utf-8"))
 
     def validate(self) -> bool:
         """Validate the task data."""

--- a/nemo_curator/tasks/tasks.py
+++ b/nemo_curator/tasks/tasks.py
@@ -69,6 +69,16 @@ class Task(ABC, Generic[T]):
     def num_items(self) -> int:
         """Get the number of items in this task."""
 
+    def input_data_size_bytes(self) -> int:
+        """Return the serialized payload size counted by performance telemetry.
+
+        Task types should override this when they have a stable, inexpensive
+        byte representation. Returning zero means that the task does not
+        provide a byte-size contract; it must never be replaced by an item
+        count because those units are not interchangeable.
+        """
+        return 0
+
     def add_stage_perf(self, perf_stats: StagePerfStats) -> None:
         """Add performance stats for a stage."""
         self._stage_perf.append(perf_stats)

--- a/nemo_curator/utils/atomic_io.py
+++ b/nemo_curator/utils/atomic_io.py
@@ -16,8 +16,9 @@ import contextlib
 import json
 import os
 import tempfile
+from collections.abc import Callable
 from pathlib import Path
-from typing import Any
+from typing import IO, Any
 
 
 def fsync_directory(path: Path) -> None:
@@ -104,6 +105,31 @@ def write_json_atomically(
         _fsync_directory_best_effort(path.parent)
     except Exception:
         _unlink_best_effort(tmp_path)
+        raise
+
+
+def write_text_atomically(path: Path, writer: Callable[[IO[str]], None]) -> None:
+    """Stream text through a fsynced temporary file and atomic rename."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp_path: Path | None = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            mode="w",
+            encoding="utf-8",
+            dir=path.parent,
+            prefix=f".{path.name}.",
+            suffix=".tmp",
+            delete=False,
+        ) as tmp:
+            tmp_path = Path(tmp.name)
+            writer(tmp)
+            tmp.flush()
+            os.fsync(tmp.fileno())
+        os.replace(tmp_path, path)
+        _fsync_directory_best_effort(path.parent)
+    except Exception:
+        if tmp_path is not None:
+            _unlink_best_effort(tmp_path)
         raise
 
 

--- a/nemo_curator/utils/file_utils.py
+++ b/nemo_curator/utils/file_utils.py
@@ -26,7 +26,7 @@ from fsspec.implementations.local import LocalFileSystem
 from fsspec.utils import infer_storage_options
 from loguru import logger
 
-from nemo_curator.utils.atomic_io import write_json_atomically
+from nemo_curator.utils.atomic_io import write_json_atomically, write_text_atomically
 from nemo_curator.utils.client_utils import is_remote_url
 
 if TYPE_CHECKING:
@@ -73,6 +73,45 @@ def write_json_file(path: str, payload: dict[str, Any], fs: fsspec.AbstractFileS
     if parent:
         fs.makedirs(parent, exist_ok=True)
     fs.write_text(path, f"{json.dumps(payload, sort_keys=True)}\n", encoding="utf-8")
+
+
+def write_json_file_streaming_array(
+    path: str,
+    payload: dict[str, Any],
+    *,
+    array_key: str,
+    items: Iterable[Any],
+    fs: fsspec.AbstractFileSystem,
+) -> None:
+    """Write one JSON array incrementally while keeping the surrounding object."""
+    if array_key in payload:
+        msg = f"{array_key!r} must not already exist in the JSON payload"
+        raise ValueError(msg)
+
+    def _write(output: Any) -> None:  # noqa: ANN401
+        output.write("{")
+        for index, (key, value) in enumerate(sorted(payload.items())):
+            if index:
+                output.write(",")
+            output.write(f"{json.dumps(key)}:{json.dumps(value, sort_keys=True)}")
+        if payload:
+            output.write(",")
+        output.write(f"{json.dumps(array_key)}:[")
+        for index, item in enumerate(items):
+            if index:
+                output.write(",")
+            json.dump(item, output, sort_keys=True)
+        output.write("]}\n")
+
+    if isinstance(fs, LocalFileSystem):
+        write_text_atomically(Path(path), _write)
+        return
+
+    parent = posixpath.dirname(path)
+    if parent:
+        fs.makedirs(parent, exist_ok=True)
+    with fs.open(path, "w", encoding="utf-8") as output:
+        _write(output)
 
 
 def is_not_empty(

--- a/nemo_curator/utils/performance_utils.py
+++ b/nemo_curator/utils/performance_utils.py
@@ -28,12 +28,6 @@ if TYPE_CHECKING:
     from nemo_curator.stages.base import ProcessingStage
 
 
-def norm_gpu_uuid(value: object) -> str:
-    """Normalize a GPU UUID for transport and topology comparisons."""
-    text = value.decode() if isinstance(value, bytes) else str(value)
-    return text.strip().lower().removeprefix("gpu-")
-
-
 @attrs.define
 class StagePerfStats:
     """Statistics for tracking stage performance metrics.
@@ -49,14 +43,6 @@ class StagePerfStats:
         invocation_id: Unique identifier for one ``process_batch`` call.
         window_start_s: Unix wall-clock timestamp immediately before the stage call.
         window_end_s: Unix wall-clock timestamp immediately after the stage call.
-        actor_id: Best-effort worker identity supplied by an optional backend.
-        node_id: Best-effort node identity supplied by an optional backend.
-        gpu_id: Best-effort display label for the assigned GPU.
-        physical_address: Backend-independent ``<host>:<gpu_indices>`` label.
-        pod_ip: Kubernetes pod IP when available.
-        hostname: Worker hostname when available.
-        gpu_indices: Physical GPU indices assigned to the worker.
-        gpu_uuids: Physical GPU UUIDs assigned to the worker.
     """
 
     stage_name: str
@@ -69,22 +55,9 @@ class StagePerfStats:
     invocation_id: str = ""
     window_start_s: float = 0.0
     window_end_s: float = 0.0
-    actor_id: str = ""
-    node_id: str = ""
-    gpu_id: str = ""
-    physical_address: str = ""
-    pod_ip: str = ""
-    hostname: str = ""
-    gpu_indices: list[int] = attrs.field(factory=list)
-    gpu_uuids: list[str] = attrs.field(factory=list)
 
     def __add__(self, other: StagePerfStats) -> StagePerfStats:
         """Add two StagePerfStats."""
-        same_worker = (
-            self.actor_id == other.actor_id
-            and self.node_id == other.node_id
-            and self.physical_address == other.physical_address
-        )
         return StagePerfStats(
             stage_name=self.stage_name,
             process_time=self.process_time + other.process_time,
@@ -101,14 +74,6 @@ class StagePerfStats:
             if self.window_start_s > 0 or other.window_start_s > 0
             else 0.0,
             window_end_s=max(self.window_end_s, other.window_end_s),
-            actor_id=self.actor_id if same_worker else "",
-            node_id=self.node_id if same_worker else "",
-            gpu_id=self.gpu_id if same_worker else "",
-            physical_address=self.physical_address if same_worker else "",
-            pod_ip=self.pod_ip if same_worker else "",
-            hostname=self.hostname if same_worker else "",
-            gpu_indices=list(self.gpu_indices) if same_worker else [],
-            gpu_uuids=list(self.gpu_uuids) if same_worker else [],
         )
 
     def __radd__(self, other: int | StagePerfStats) -> StagePerfStats:
@@ -131,14 +96,6 @@ class StagePerfStats:
         self.invocation_id = ""
         self.window_start_s = 0.0
         self.window_end_s = 0.0
-        self.actor_id = ""
-        self.node_id = ""
-        self.gpu_id = ""
-        self.physical_address = ""
-        self.pod_ip = ""
-        self.hostname = ""
-        self.gpu_indices = []
-        self.gpu_uuids = []
 
     def to_dict(self) -> dict[str, float | int]:
         """Convert numeric metrics to the legacy public dictionary."""

--- a/nemo_curator/utils/performance_utils.py
+++ b/nemo_curator/utils/performance_utils.py
@@ -41,7 +41,8 @@ class StagePerfStats:
         stage_name: Name of the processing stage.
         process_time: Total processing time in seconds.
         actor_idle_time: Time the actor spent idle in seconds.
-        input_data_size_mb: Size of input data in megabytes.
+        input_data_size_mb: Serialized input payload size in megabytes when
+            supplied by the task type's byte-size contract.
         num_items_processed: Number of items processed in this stage.
         custom_metrics: Custom metrics to track.
         stage_id: Stable per-plan identifier assigned by ``Pipeline.build()``.
@@ -193,11 +194,10 @@ class StageTimer:
         self._idle_time_s = 0.0
         self._startup_time_s = 0.0
 
-    def reinit(self, stage_input_size: int = 1) -> None:
+    def reinit(self, stage_input_size: int = 0) -> None:
         """Reinitialize the stage timer.
         Args:
-            stage: The stage to reinitialize the timer for.
-            stage_input_size: The size of the stage input.
+            stage_input_size: Serialized size of the stage input in bytes.
         """
         self._reset()
         self._input_data_size_b = stage_input_size

--- a/nemo_curator/utils/performance_utils.py
+++ b/nemo_curator/utils/performance_utils.py
@@ -28,6 +28,12 @@ if TYPE_CHECKING:
     from nemo_curator.stages.base import ProcessingStage
 
 
+def norm_gpu_uuid(value: object) -> str:
+    """Normalize a GPU UUID for transport and topology comparisons."""
+    text = value.decode() if isinstance(value, bytes) else str(value)
+    return text.strip().lower().removeprefix("gpu-")
+
+
 @attrs.define
 class StagePerfStats:
     """Statistics for tracking stage performance metrics.
@@ -38,6 +44,18 @@ class StagePerfStats:
         input_data_size_mb: Size of input data in megabytes.
         num_items_processed: Number of items processed in this stage.
         custom_metrics: Custom metrics to track.
+        stage_id: Stable per-plan identifier assigned by ``Pipeline.build()``.
+        invocation_id: Unique identifier for one ``process_batch`` call.
+        window_start_s: Unix wall-clock timestamp immediately before the stage call.
+        window_end_s: Unix wall-clock timestamp immediately after the stage call.
+        actor_id: Best-effort worker identity supplied by an optional backend.
+        node_id: Best-effort node identity supplied by an optional backend.
+        gpu_id: Best-effort display label for the assigned GPU.
+        physical_address: Backend-independent ``<host>:<gpu_indices>`` label.
+        pod_ip: Kubernetes pod IP when available.
+        hostname: Worker hostname when available.
+        gpu_indices: Physical GPU indices assigned to the worker.
+        gpu_uuids: Physical GPU UUIDs assigned to the worker.
     """
 
     stage_name: str
@@ -46,9 +64,26 @@ class StagePerfStats:
     input_data_size_mb: float = 0.0
     num_items_processed: int = 0
     custom_metrics: dict[str, float] = attrs.field(factory=dict)
+    stage_id: str = ""
+    invocation_id: str = ""
+    window_start_s: float = 0.0
+    window_end_s: float = 0.0
+    actor_id: str = ""
+    node_id: str = ""
+    gpu_id: str = ""
+    physical_address: str = ""
+    pod_ip: str = ""
+    hostname: str = ""
+    gpu_indices: list[int] = attrs.field(factory=list)
+    gpu_uuids: list[str] = attrs.field(factory=list)
 
     def __add__(self, other: StagePerfStats) -> StagePerfStats:
         """Add two StagePerfStats."""
+        same_worker = (
+            self.actor_id == other.actor_id
+            and self.node_id == other.node_id
+            and self.physical_address == other.physical_address
+        )
         return StagePerfStats(
             stage_name=self.stage_name,
             process_time=self.process_time + other.process_time,
@@ -59,6 +94,20 @@ class StagePerfStats:
                 key: self.custom_metrics.get(key, 0.0) + other.custom_metrics.get(key, 0.0)
                 for key in set(self.custom_metrics.keys()) | set(other.custom_metrics.keys())
             },
+            stage_id=self.stage_id if self.stage_id == other.stage_id else "",
+            invocation_id="",
+            window_start_s=min(value for value in (self.window_start_s, other.window_start_s) if value > 0)
+            if self.window_start_s > 0 or other.window_start_s > 0
+            else 0.0,
+            window_end_s=max(self.window_end_s, other.window_end_s),
+            actor_id=self.actor_id if same_worker else "",
+            node_id=self.node_id if same_worker else "",
+            gpu_id=self.gpu_id if same_worker else "",
+            physical_address=self.physical_address if same_worker else "",
+            pod_ip=self.pod_ip if same_worker else "",
+            hostname=self.hostname if same_worker else "",
+            gpu_indices=list(self.gpu_indices) if same_worker else [],
+            gpu_uuids=list(self.gpu_uuids) if same_worker else [],
         )
 
     def __radd__(self, other: int | StagePerfStats) -> StagePerfStats:
@@ -77,9 +126,32 @@ class StagePerfStats:
         self.input_data_size_mb = 0.0
         self.num_items_processed = 0
         self.custom_metrics = {}
+        self.stage_id = ""
+        self.invocation_id = ""
+        self.window_start_s = 0.0
+        self.window_end_s = 0.0
+        self.actor_id = ""
+        self.node_id = ""
+        self.gpu_id = ""
+        self.physical_address = ""
+        self.pod_ip = ""
+        self.hostname = ""
+        self.gpu_indices = []
+        self.gpu_uuids = []
 
     def to_dict(self) -> dict[str, float | int]:
-        """Convert the stats to a dictionary."""
+        """Convert numeric metrics to the legacy public dictionary."""
+        return {
+            "stage_name": self.stage_name,
+            "process_time": self.process_time,
+            "actor_idle_time": self.actor_idle_time,
+            "input_data_size_mb": self.input_data_size_mb,
+            "num_items_processed": self.num_items_processed,
+            "custom_metrics": dict(self.custom_metrics),
+        }
+
+    def to_extended_dict(self) -> dict[str, object]:
+        """Convert to the complete invocation-telemetry schema."""
         return attrs.asdict(self)
 
     def items(self) -> list[tuple[str, float | int]]:
@@ -107,6 +179,7 @@ class StageTimer:
             stage: The stage to track.
         """
         self._stage_name = str(stage.name)
+        self._stage_id = str(getattr(stage, "_curator_stage_id", "") or "")
         self._reset()
         self._last_active_time = time.time()
         self._initialized = False
@@ -173,6 +246,7 @@ class StageTimer:
 
         stage_perf_stats = StagePerfStats(
             stage_name=self._stage_name,
+            stage_id=self._stage_id,
             process_time=process_data_dur_s,
             actor_idle_time=idle_time_s,
             input_data_size_mb=input_data_size_mb,

--- a/nemo_curator/utils/stage_perf_collector.py
+++ b/nemo_curator/utils/stage_perf_collector.py
@@ -20,9 +20,10 @@ import contextlib
 import json
 import tempfile
 import uuid
-from dataclasses import dataclass
+import weakref
+from dataclasses import dataclass, field
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Self
 
 import ray
 from loguru import logger
@@ -55,12 +56,42 @@ class _StagePerfSpool:
         return self._path, self._record_count
 
 
+def _cleanup_spool_path(path: str) -> None:
+    """Remove one owned spool file and its now-empty temporary directory."""
+    if not path:
+        return
+    spool_path = Path(path)
+    with contextlib.suppress(OSError):
+        spool_path.unlink(missing_ok=True)
+    with contextlib.suppress(OSError):
+        spool_path.parent.rmdir()
+
+
 @dataclass
 class PerformanceRecordStore:
-    """Re-iterable, disk-backed stage-invocation records."""
+    """Re-iterable, disk-backed stage-invocation records.
+
+    The store owns its temporary spool until ``close()``/``cleanup()`` is
+    called or the last store reference is released. It can also be used as a
+    context manager for deterministic cleanup.
+    """
 
     path: str = ""
     record_count: int = 0
+    _finalizer: weakref.finalize | None = field(
+        init=False,
+        default=None,
+        repr=False,
+        compare=False,
+    )
+
+    def __post_init__(self) -> None:
+        if self.path:
+            self._finalizer = weakref.finalize(
+                self,
+                _cleanup_spool_path,
+                self.path,
+            )
 
     @classmethod
     def from_records(cls, records: Iterable[StagePerfStats]) -> PerformanceRecordStore:
@@ -83,6 +114,12 @@ class PerformanceRecordStore:
     def __len__(self) -> int:
         return self.record_count
 
+    def __enter__(self) -> Self:
+        return self
+
+    def __exit__(self, *_exc_info: object) -> None:
+        self.close()
+
     def iter_dicts(self) -> Iterator[dict[str, Any]]:
         """Yield complete invocation dictionaries one at a time."""
         if not self.path:
@@ -93,15 +130,16 @@ class PerformanceRecordStore:
 
     def cleanup(self) -> None:
         """Remove the run-scoped spool after its records are no longer needed."""
-        if not self.path:
-            return
-        spool_path = Path(self.path)
-        with contextlib.suppress(OSError):
-            spool_path.unlink(missing_ok=True)
-        with contextlib.suppress(OSError):
-            spool_path.parent.rmdir()
+        if self._finalizer is not None and self._finalizer.alive:
+            self._finalizer()
+        else:
+            _cleanup_spool_path(self.path)
         self.path = ""
         self.record_count = 0
+
+    def close(self) -> None:
+        """Release the owned spool explicitly."""
+        self.cleanup()
 
 
 @dataclass(frozen=True)

--- a/nemo_curator/utils/stage_perf_collector.py
+++ b/nemo_curator/utils/stage_perf_collector.py
@@ -36,6 +36,11 @@ if TYPE_CHECKING:
     from nemo_curator.utils.performance_utils import StagePerfStats
 
 COLLECTOR_NAME_ATTR = "_curator_stage_perf_collector_name"
+COLLECTOR_ACTOR_ATTR = "_curator_stage_perf_collector_actor"
+COLLECTOR_PENDING_ATTR = "_curator_stage_perf_pending_records"
+COLLECTOR_REQUIRED_ATTR = "_curator_stage_perf_report_required"
+MAX_PENDING_RECORDS = 64
+MAX_COLLECTOR_ERRORS = 10
 
 
 class _StagePerfSpool:
@@ -146,6 +151,7 @@ class PerformanceRecordStore:
 class _StagePerfCollectorHandle:
     actor: Any
     spool_path: str
+    report_required: bool
 
 
 def _new_spool_path() -> str:
@@ -157,22 +163,44 @@ def _new_spool_path() -> str:
 class _StagePerfCollector:
     def __init__(self, spool_path: str) -> None:
         self._spool = _StagePerfSpool(spool_path)
+        self._dropped_records = 0
+        self._errors: list[str] = []
 
     def ready(self) -> bool:
         return True
 
     def record(self, perf_stats: StagePerfStats, _attached_to_output: bool) -> None:
-        self._spool.record(perf_stats)
+        try:
+            self._spool.record(perf_stats)
+        except Exception as exc:  # noqa: BLE001
+            self._dropped_records += 1
+            if len(self._errors) < MAX_COLLECTOR_ERRORS:
+                self._errors.append(f"{type(exc).__name__}: {exc}")
 
-    def finish(self) -> tuple[str, int]:
-        return self._spool.finish()
+    def barrier(self) -> tuple[int, list[str]]:
+        """Acknowledge all record calls ordered before this actor call."""
+        return self._dropped_records, list(self._errors)
+
+    def finish(self) -> tuple[str, int, int, list[str]]:
+        path, record_count = self._spool.finish()
+        return path, record_count, self._dropped_records, list(self._errors)
+
+
+def performance_report_requested(stages: list[ProcessingStage]) -> bool:
+    """Return whether a terminal consumer explicitly requires a complete report."""
+    for stage in stages:
+        request_records = getattr(stage, "requests_performance_records", None)
+        if callable(request_records) and request_records():
+            return True
+        if bool(getattr(stage, "write_perf_stats", False)):
+            return True
+    return False
 
 
 def performance_collection_enabled(stages: list[ProcessingStage]) -> bool:
     """Return whether any stage or terminal consumer requests full collection."""
-    return any(
-        bool(getattr(stage, "extended_performance_metrics", False)) or bool(getattr(stage, "write_perf_stats", False))
-        for stage in stages
+    return performance_report_requested(stages) or any(
+        bool(getattr(stage, "extended_performance_metrics", False)) for stage in stages
     )
 
 
@@ -182,15 +210,27 @@ def start_stage_perf_collector(stages: list[ProcessingStage]) -> Any | None:  # 
         return None
     name = f"curator-stage-perf-{uuid.uuid4().hex}"
     spool_path = _new_spool_path()
-    driver_node_id = ray.get_runtime_context().get_node_id()
-    collector = _StagePerfCollector.options(
-        name=name,
-        scheduling_strategy=NodeAffinitySchedulingStrategy(driver_node_id, soft=False),
-    ).remote(spool_path)
-    handle = _StagePerfCollectorHandle(actor=collector, spool_path=spool_path)
-    ray.get(handle.actor.ready.remote())
+    report_required = performance_report_requested(stages)
+    collector = None
+    try:
+        driver_node_id = ray.get_runtime_context().get_node_id()
+        collector = _StagePerfCollector.options(
+            name=name,
+            scheduling_strategy=NodeAffinitySchedulingStrategy(driver_node_id, soft=False),
+        ).remote(spool_path)
+        handle = _StagePerfCollectorHandle(actor=collector, spool_path=spool_path, report_required=report_required)
+        ray.get(handle.actor.ready.remote())
+    except Exception:
+        if collector is not None:
+            with contextlib.suppress(Exception):
+                ray.kill(collector, no_restart=True)
+        _cleanup_spool_path(spool_path)
+        raise
     for stage in stages:
         setattr(stage, COLLECTOR_NAME_ATTR, name)
+        setattr(stage, COLLECTOR_ACTOR_ATTR, collector)
+        setattr(stage, COLLECTOR_PENDING_ATTR, [])
+        setattr(stage, COLLECTOR_REQUIRED_ATTR, report_required)
     return handle
 
 
@@ -200,37 +240,89 @@ def record_stage_perf(
     *,
     attached_to_output: bool,
 ) -> bool:
-    """Synchronously publish one record so the driver cannot drain too early."""
-    collector_name = str(getattr(stage, COLLECTOR_NAME_ATTR, "") or "")
-    if not collector_name:
-        return False
+    """Publish asynchronously, acknowledging records in bounded batches."""
+    collector = getattr(stage, COLLECTOR_ACTOR_ATTR, None)
+    if collector is None:
+        collector_name = str(getattr(stage, COLLECTOR_NAME_ATTR, "") or "")
+        if not collector_name:
+            return False
+    pending_records = getattr(stage, COLLECTOR_PENDING_ATTR, None)
+    if pending_records is None:
+        pending_records = []
+        setattr(stage, COLLECTOR_PENDING_ATTR, pending_records)
     try:
-        collector = ray.get_actor(collector_name)
-        ray.get(collector.record.remote(perf_stats, attached_to_output))
-    except Exception as exc:  # noqa: BLE001
+        if collector is None:
+            collector = ray.get_actor(collector_name)
+        pending_records.append(collector.record.remote(perf_stats, attached_to_output))
+        if len(pending_records) >= MAX_PENDING_RECORDS:
+            ray.get(pending_records)
+            pending_records.clear()
+    except Exception as exc:
+        pending_records.clear()
+        if bool(getattr(stage, COLLECTOR_REQUIRED_ATTR, False)):
+            msg = f"Required stage performance publication failed for {stage.name}: {exc}"
+            raise RuntimeError(msg) from exc
         logger.debug("Stage performance collector publish failed for {}: {}", stage.name, exc)
         return False
     return True
 
 
+def flush_stage_perf_records(stage: ProcessingStage) -> None:
+    """Wait for one producer's final asynchronous publication batch."""
+    pending_records = getattr(stage, COLLECTOR_PENDING_ATTR, None)
+    if not pending_records:
+        return
+    try:
+        ray.get(pending_records)
+    except Exception as exc:
+        if bool(getattr(stage, COLLECTOR_REQUIRED_ATTR, False)):
+            msg = f"Required stage performance publication flush failed for {stage.name}: {exc}"
+            raise RuntimeError(msg) from exc
+        logger.debug("Stage performance collector flush failed for {}: {}", stage.name, exc)
+    finally:
+        pending_records.clear()
+
+
 def stop_stage_perf_collector(
     collector: _StagePerfCollectorHandle | None,
     stages: list[ProcessingStage],
+    *,
+    raise_on_failure: bool = False,
 ) -> PerformanceRecordStore:
     """Drain and remove the collector, clearing its run-scoped routing."""
     if collector is None:
         return PerformanceRecordStore()
     try:
-        path, record_count = ray.get(collector.actor.finish.remote())
+        try:
+            ray.get(collector.actor.barrier.remote())
+            path, record_count, dropped_records, errors = ray.get(collector.actor.finish.remote())
+        except Exception as exc:
+            logger.debug("Stage performance collector finish failed: {}", exc)
+            failed_store = PerformanceRecordStore(path=collector.spool_path)
+            failed_store.cleanup()
+            if raise_on_failure:
+                msg = f"Required stage performance collector finish failed: {exc}"
+                raise RuntimeError(msg) from exc
+            return PerformanceRecordStore()
+        if dropped_records:
+            details = "; ".join(errors) or "unknown collector error"
+            msg = f"Stage performance collector dropped {dropped_records} record(s): {details}"
+            failed_store = PerformanceRecordStore(path=path, record_count=record_count)
+            failed_store.cleanup()
+            if raise_on_failure:
+                raise RuntimeError(msg)
+            logger.warning(msg)
+            return PerformanceRecordStore()
         return PerformanceRecordStore(path=path, record_count=record_count)
-    except Exception as exc:  # noqa: BLE001
-        logger.debug("Stage performance collector finish failed: {}", exc)
-        failed_store = PerformanceRecordStore(path=collector.spool_path)
-        failed_store.cleanup()
-        return PerformanceRecordStore()
     finally:
         for stage in stages:
-            with contextlib.suppress(AttributeError):
-                delattr(stage, COLLECTOR_NAME_ATTR)
+            for attr_name in (
+                COLLECTOR_NAME_ATTR,
+                COLLECTOR_ACTOR_ATTR,
+                COLLECTOR_PENDING_ATTR,
+                COLLECTOR_REQUIRED_ATTR,
+            ):
+                with contextlib.suppress(AttributeError):
+                    delattr(stage, attr_name)
         with contextlib.suppress(Exception):
             ray.kill(collector.actor, no_restart=True)

--- a/nemo_curator/utils/stage_perf_collector.py
+++ b/nemo_curator/utils/stage_perf_collector.py
@@ -169,7 +169,7 @@ class _StagePerfCollector:
     def ready(self) -> bool:
         return True
 
-    def record(self, perf_stats: StagePerfStats, _attached_to_output: bool) -> None:
+    def record(self, perf_stats: StagePerfStats) -> None:
         try:
             self._spool.record(perf_stats)
         except Exception as exc:  # noqa: BLE001
@@ -191,8 +191,6 @@ def performance_report_requested(stages: list[ProcessingStage]) -> bool:
     for stage in stages:
         request_records = getattr(stage, "requests_performance_records", None)
         if callable(request_records) and request_records():
-            return True
-        if bool(getattr(stage, "write_perf_stats", False)):
             return True
     return False
 
@@ -235,8 +233,6 @@ def start_stage_perf_collector(stages: list[ProcessingStage]) -> Any | None:  # 
 def record_stage_perf(
     stage: ProcessingStage,
     perf_stats: StagePerfStats,
-    *,
-    attached_to_output: bool,
 ) -> bool:
     """Publish asynchronously, acknowledging records in bounded batches."""
     collector = getattr(stage, COLLECTOR_ACTOR_ATTR, None)
@@ -251,7 +247,7 @@ def record_stage_perf(
     try:
         if collector is None:
             collector = ray.get_actor(collector_name)
-        pending_records.append(collector.record.remote(perf_stats, attached_to_output))
+        pending_records.append(collector.record.remote(perf_stats))
         if len(pending_records) >= MAX_PENDING_RECORDS:
             ray.get(pending_records)
             pending_records.clear()

--- a/nemo_curator/utils/stage_perf_collector.py
+++ b/nemo_curator/utils/stage_perf_collector.py
@@ -1,0 +1,105 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Run-scoped transport for stage invocations, including zero-output calls."""
+
+from __future__ import annotations
+
+import contextlib
+import uuid
+from typing import TYPE_CHECKING, Any
+
+import ray
+from loguru import logger
+
+if TYPE_CHECKING:
+    from nemo_curator.stages.base import ProcessingStage
+    from nemo_curator.utils.performance_utils import StagePerfStats
+
+COLLECTOR_NAME_ATTR = "_curator_stage_perf_collector_name"
+
+
+@ray.remote(num_cpus=0)
+class _StagePerfCollector:
+    def __init__(self) -> None:
+        self._records: list[tuple[StagePerfStats, bool]] = []
+
+    def ready(self) -> bool:
+        return True
+
+    def record(self, perf_stats: StagePerfStats, attached_to_output: bool) -> None:
+        self._records.append((perf_stats, attached_to_output))
+
+    def drain(self) -> list[tuple[StagePerfStats, bool]]:
+        records, self._records = self._records, []
+        return records
+
+
+def performance_collection_enabled(stages: list[ProcessingStage]) -> bool:
+    """Return whether any stage or terminal consumer requests full collection."""
+    return any(
+        bool(getattr(stage, "extended_performance_metrics", False)) or bool(getattr(stage, "write_perf_stats", False))
+        for stage in stages
+    )
+
+
+def start_stage_perf_collector(stages: list[ProcessingStage]) -> Any | None:  # noqa: ANN401
+    """Start one collector when extended metrics or a terminal consumer is enabled."""
+    if not performance_collection_enabled(stages):
+        return None
+    name = f"curator-stage-perf-{uuid.uuid4().hex}"
+    collector = _StagePerfCollector.options(name=name).remote()
+    ray.get(collector.ready.remote())
+    for stage in stages:
+        setattr(stage, COLLECTOR_NAME_ATTR, name)
+    return collector
+
+
+def record_stage_perf(
+    stage: ProcessingStage,
+    perf_stats: StagePerfStats,
+    *,
+    attached_to_output: bool,
+) -> bool:
+    """Synchronously publish one record so the driver cannot drain too early."""
+    collector_name = str(getattr(stage, COLLECTOR_NAME_ATTR, "") or "")
+    if not collector_name:
+        return False
+    try:
+        collector = ray.get_actor(collector_name)
+        ray.get(collector.record.remote(perf_stats, attached_to_output))
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("Stage performance collector publish failed for {}: {}", stage.name, exc)
+        return False
+    return True
+
+
+def stop_stage_perf_collector(
+    collector: Any | None,  # noqa: ANN401
+    stages: list[ProcessingStage],
+) -> list[tuple[StagePerfStats, bool]]:
+    """Drain and remove the collector, clearing its run-scoped routing."""
+    if collector is None:
+        return []
+    try:
+        return list(ray.get(collector.drain.remote()))
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("Stage performance collector drain failed: {}", exc)
+        return []
+    finally:
+        for stage in stages:
+            with contextlib.suppress(AttributeError):
+                delattr(stage, COLLECTOR_NAME_ATTR)
+        with contextlib.suppress(Exception):
+            ray.kill(collector, no_restart=True)

--- a/nemo_curator/utils/stage_perf_collector.py
+++ b/nemo_curator/utils/stage_perf_collector.py
@@ -17,33 +17,117 @@
 from __future__ import annotations
 
 import contextlib
+import json
+import tempfile
 import uuid
+from dataclasses import dataclass
+from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 import ray
 from loguru import logger
+from ray.util.scheduling_strategies import NodeAffinitySchedulingStrategy
 
 if TYPE_CHECKING:
+    from collections.abc import Iterable, Iterator
+
     from nemo_curator.stages.base import ProcessingStage
     from nemo_curator.utils.performance_utils import StagePerfStats
 
 COLLECTOR_NAME_ATTR = "_curator_stage_perf_collector_name"
 
 
+class _StagePerfSpool:
+    """Append invocation records to disk without retaining them in memory."""
+
+    def __init__(self, path: str) -> None:
+        self._path = path
+        self._record_count = 0
+        self._file = Path(path).open("w", encoding="utf-8")  # noqa: SIM115
+
+    def record(self, perf_stats: StagePerfStats) -> None:
+        json.dump(perf_stats.to_extended_dict(), self._file, sort_keys=True)
+        self._file.write("\n")
+        self._record_count += 1
+
+    def finish(self) -> tuple[str, int]:
+        self._file.close()
+        return self._path, self._record_count
+
+
+@dataclass
+class PerformanceRecordStore:
+    """Re-iterable, disk-backed stage-invocation records."""
+
+    path: str = ""
+    record_count: int = 0
+
+    @classmethod
+    def from_records(cls, records: Iterable[StagePerfStats]) -> PerformanceRecordStore:
+        """Spool an existing iterable without creating another in-memory copy."""
+        spool = _StagePerfSpool(_new_spool_path())
+        for record in records:
+            spool.record(record)
+        path, record_count = spool.finish()
+        store = cls(path=path, record_count=record_count)
+        if record_count == 0:
+            store.cleanup()
+        return store
+
+    def __iter__(self) -> Iterator[StagePerfStats]:
+        from nemo_curator.utils.performance_utils import StagePerfStats
+
+        for payload in self.iter_dicts():
+            yield StagePerfStats(**payload)
+
+    def __len__(self) -> int:
+        return self.record_count
+
+    def iter_dicts(self) -> Iterator[dict[str, Any]]:
+        """Yield complete invocation dictionaries one at a time."""
+        if not self.path:
+            return
+        with Path(self.path).open(encoding="utf-8") as records_file:
+            for line in records_file:
+                yield json.loads(line)
+
+    def cleanup(self) -> None:
+        """Remove the run-scoped spool after its records are no longer needed."""
+        if not self.path:
+            return
+        spool_path = Path(self.path)
+        with contextlib.suppress(OSError):
+            spool_path.unlink(missing_ok=True)
+        with contextlib.suppress(OSError):
+            spool_path.parent.rmdir()
+        self.path = ""
+        self.record_count = 0
+
+
+@dataclass(frozen=True)
+class _StagePerfCollectorHandle:
+    actor: Any
+    spool_path: str
+
+
+def _new_spool_path() -> str:
+    spool_dir = Path(tempfile.mkdtemp(prefix="curator-stage-perf-"))
+    return str(spool_dir / "records.jsonl")
+
+
 @ray.remote(num_cpus=0)
 class _StagePerfCollector:
-    def __init__(self) -> None:
-        self._records: list[tuple[StagePerfStats, bool]] = []
+    def __init__(self, spool_path: str) -> None:
+        self._spool = _StagePerfSpool(spool_path)
 
     def ready(self) -> bool:
         return True
 
-    def record(self, perf_stats: StagePerfStats, attached_to_output: bool) -> None:
-        self._records.append((perf_stats, attached_to_output))
+    def record(self, perf_stats: StagePerfStats, _attached_to_output: bool) -> None:
+        self._spool.record(perf_stats)
 
-    def drain(self) -> list[tuple[StagePerfStats, bool]]:
-        records, self._records = self._records, []
-        return records
+    def finish(self) -> tuple[str, int]:
+        return self._spool.finish()
 
 
 def performance_collection_enabled(stages: list[ProcessingStage]) -> bool:
@@ -59,11 +143,17 @@ def start_stage_perf_collector(stages: list[ProcessingStage]) -> Any | None:  # 
     if not performance_collection_enabled(stages):
         return None
     name = f"curator-stage-perf-{uuid.uuid4().hex}"
-    collector = _StagePerfCollector.options(name=name).remote()
-    ray.get(collector.ready.remote())
+    spool_path = _new_spool_path()
+    driver_node_id = ray.get_runtime_context().get_node_id()
+    collector = _StagePerfCollector.options(
+        name=name,
+        scheduling_strategy=NodeAffinitySchedulingStrategy(driver_node_id, soft=False),
+    ).remote(spool_path)
+    handle = _StagePerfCollectorHandle(actor=collector, spool_path=spool_path)
+    ray.get(handle.actor.ready.remote())
     for stage in stages:
         setattr(stage, COLLECTOR_NAME_ATTR, name)
-    return collector
+    return handle
 
 
 def record_stage_perf(
@@ -86,20 +176,23 @@ def record_stage_perf(
 
 
 def stop_stage_perf_collector(
-    collector: Any | None,  # noqa: ANN401
+    collector: _StagePerfCollectorHandle | None,
     stages: list[ProcessingStage],
-) -> list[tuple[StagePerfStats, bool]]:
+) -> PerformanceRecordStore:
     """Drain and remove the collector, clearing its run-scoped routing."""
     if collector is None:
-        return []
+        return PerformanceRecordStore()
     try:
-        return list(ray.get(collector.drain.remote()))
+        path, record_count = ray.get(collector.actor.finish.remote())
+        return PerformanceRecordStore(path=path, record_count=record_count)
     except Exception as exc:  # noqa: BLE001
-        logger.debug("Stage performance collector drain failed: {}", exc)
-        return []
+        logger.debug("Stage performance collector finish failed: {}", exc)
+        failed_store = PerformanceRecordStore(path=collector.spool_path)
+        failed_store.cleanup()
+        return PerformanceRecordStore()
     finally:
         for stage in stages:
             with contextlib.suppress(AttributeError):
                 delattr(stage, COLLECTOR_NAME_ATTR)
         with contextlib.suppress(Exception):
-            ray.kill(collector, no_restart=True)
+            ray.kill(collector.actor, no_restart=True)

--- a/nemo_curator/utils/stage_perf_collector.py
+++ b/nemo_curator/utils/stage_perf_collector.py
@@ -198,14 +198,12 @@ def performance_report_requested(stages: list[ProcessingStage]) -> bool:
 
 
 def performance_collection_enabled(stages: list[ProcessingStage]) -> bool:
-    """Return whether any stage or terminal consumer requests full collection."""
-    return performance_report_requested(stages) or any(
-        bool(getattr(stage, "extended_performance_metrics", False)) for stage in stages
-    )
+    """Return whether a terminal consumer requests complete invocation records."""
+    return performance_report_requested(stages)
 
 
 def start_stage_perf_collector(stages: list[ProcessingStage]) -> Any | None:  # noqa: ANN401
-    """Start one collector when extended metrics or a terminal consumer is enabled."""
+    """Start one collector when a terminal consumer requests complete records."""
     if not performance_collection_enabled(stages):
         return None
     name = f"curator-stage-perf-{uuid.uuid4().hex}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,6 +84,10 @@ cv2 = [
 ]
 vllm = ["vllm>=0.14.1; (platform_machine == 'x86_64' and platform_system != 'Darwin')"]
 
+cloud_filesystems = [
+    "s3fs>=2024.12.0",
+]
+
 # Inference Server (Ray Serve + vLLM) - for serving LLMs alongside Curator pipelines
 inference_server = [
     "nemo_curator[cuda12]",

--- a/tests/backends/test_performance_transport.py
+++ b/tests/backends/test_performance_transport.py
@@ -16,10 +16,9 @@ from unittest.mock import patch
 
 import pytest
 
-from nemo_curator.backends.base import BaseExecutor, BaseStageAdapter, WorkerMetadata
+from nemo_curator.backends.base import BaseExecutor, BaseStageAdapter
 from nemo_curator.stages.base import ProcessingStage
 from nemo_curator.tasks import AudioTask, EmptyTask, Task
-from nemo_curator.utils.performance_utils import StagePerfStats
 
 
 class _Stage(ProcessingStage[Task, Task]):
@@ -27,17 +26,6 @@ class _Stage(ProcessingStage[Task, Task]):
 
     def process(self, task: Task) -> Task:
         return task
-
-
-class _Adapter(BaseStageAdapter):
-    def _setup_performance_telemetry(self, worker_metadata: WorkerMetadata | None) -> None:
-        self.setup_metadata = worker_metadata
-
-    def _enrich_stage_perf_record(self, stats: StagePerfStats, _results: list[Task]) -> None:
-        stats.actor_id = "actor-1"
-
-    def _teardown_performance_telemetry(self) -> None:
-        self.telemetry_closed = True
 
 
 class _Executor(BaseExecutor):
@@ -50,25 +38,19 @@ class _RequiredReportStage(_Stage):
         return True
 
 
-def test_adapter_hooks_enrich_one_collector_record() -> None:
+def test_adapter_publishes_one_collector_record() -> None:
     stage = _Stage()
     stage._curator_stage_id = "000:stage"
     stage._curator_stage_perf_collector_name = "collector"
-    adapter = _Adapter(stage)
-    metadata = WorkerMetadata(worker_id="worker-1")
+    adapter = BaseStageAdapter(stage)
 
     with patch("nemo_curator.utils.stage_perf_collector.record_stage_perf", return_value=True) as publish:
-        adapter.setup(metadata)
         [result] = adapter.process_batch([EmptyTask()])
-        adapter.teardown()
 
     [perf] = result._stage_perf
-    assert adapter.setup_metadata is metadata
-    assert adapter.telemetry_closed is True
     assert perf.stage_id == "000:stage"
     assert perf.invocation_id
     assert perf.window_end_s >= perf.window_start_s > 0
-    assert perf.actor_id == "actor-1"
     publish.assert_called_once()
     assert publish.call_args.kwargs["attached_to_output"] is True
 
@@ -87,7 +69,7 @@ def test_required_collector_start_failure_is_not_silenced() -> None:
 def test_audio_input_byte_count_is_independent_of_item_count() -> None:
     stage = _Stage()
     stage._curator_stage_perf_collector_name = "collector"
-    adapter = _Adapter(stage)
+    adapter = BaseStageAdapter(stage)
     small = AudioTask(dataset_name="test", data={"text": "a"})
     large = AudioTask(dataset_name="test", data={"text": "a" * 1_000})
 

--- a/tests/backends/test_performance_transport.py
+++ b/tests/backends/test_performance_transport.py
@@ -1,0 +1,61 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from unittest.mock import patch
+
+from nemo_curator.backends.base import BaseStageAdapter, WorkerMetadata
+from nemo_curator.stages.base import ProcessingStage
+from nemo_curator.tasks import EmptyTask, Task
+from nemo_curator.utils.performance_utils import StagePerfStats
+
+
+class _Stage(ProcessingStage[Task, Task]):
+    name = "stage"
+
+    def process(self, task: Task) -> Task:
+        return task
+
+
+class _Adapter(BaseStageAdapter):
+    def _setup_performance_telemetry(self, worker_metadata: WorkerMetadata | None) -> None:
+        self.setup_metadata = worker_metadata
+
+    def _enrich_stage_perf_record(self, stats: StagePerfStats, _results: list[Task]) -> None:
+        stats.actor_id = "actor-1"
+
+    def _teardown_performance_telemetry(self) -> None:
+        self.telemetry_closed = True
+
+
+def test_adapter_hooks_enrich_one_collector_record() -> None:
+    stage = _Stage()
+    stage._curator_stage_id = "000:stage"
+    stage._curator_stage_perf_collector_name = "collector"
+    adapter = _Adapter(stage)
+    metadata = WorkerMetadata(worker_id="worker-1")
+
+    with patch("nemo_curator.utils.stage_perf_collector.record_stage_perf", return_value=True) as publish:
+        adapter.setup(metadata)
+        [result] = adapter.process_batch([EmptyTask()])
+        adapter.teardown()
+
+    [perf] = result._stage_perf
+    assert adapter.setup_metadata is metadata
+    assert adapter.telemetry_closed is True
+    assert perf.stage_id == "000:stage"
+    assert perf.invocation_id
+    assert perf.window_end_s >= perf.window_start_s > 0
+    assert perf.actor_id == "actor-1"
+    publish.assert_called_once()
+    assert publish.call_args.kwargs["attached_to_output"] is True

--- a/tests/backends/test_performance_transport.py
+++ b/tests/backends/test_performance_transport.py
@@ -14,9 +14,11 @@
 
 from unittest.mock import patch
 
-from nemo_curator.backends.base import BaseStageAdapter, WorkerMetadata
+import pytest
+
+from nemo_curator.backends.base import BaseExecutor, BaseStageAdapter, WorkerMetadata
 from nemo_curator.stages.base import ProcessingStage
-from nemo_curator.tasks import EmptyTask, Task
+from nemo_curator.tasks import AudioTask, EmptyTask, Task
 from nemo_curator.utils.performance_utils import StagePerfStats
 
 
@@ -36,6 +38,16 @@ class _Adapter(BaseStageAdapter):
 
     def _teardown_performance_telemetry(self) -> None:
         self.telemetry_closed = True
+
+
+class _Executor(BaseExecutor):
+    def execute(self, stages: list[ProcessingStage], initial_tasks: list[Task] | None = None) -> None:
+        return None
+
+
+class _RequiredReportStage(_Stage):
+    def requests_performance_records(self) -> bool:
+        return True
 
 
 def test_adapter_hooks_enrich_one_collector_record() -> None:
@@ -59,3 +71,31 @@ def test_adapter_hooks_enrich_one_collector_record() -> None:
     assert perf.actor_id == "actor-1"
     publish.assert_called_once()
     assert publish.call_args.kwargs["attached_to_output"] is True
+
+
+def test_required_collector_start_failure_is_not_silenced() -> None:
+    with (
+        patch(
+            "nemo_curator.utils.stage_perf_collector.start_stage_perf_collector",
+            side_effect=OSError("start failed"),
+        ),
+        pytest.raises(RuntimeError, match="Required stage performance collector failed to start"),
+    ):
+        _Executor._start_stage_perf_collector([_RequiredReportStage()])
+
+
+def test_audio_input_byte_count_is_independent_of_item_count() -> None:
+    stage = _Stage()
+    stage._curator_stage_perf_collector_name = "collector"
+    adapter = _Adapter(stage)
+    small = AudioTask(dataset_name="test", data={"text": "a"})
+    large = AudioTask(dataset_name="test", data={"text": "a" * 1_000})
+
+    with patch("nemo_curator.utils.stage_perf_collector.record_stage_perf", return_value=True):
+        [small_result] = adapter.process_batch([small])
+        [large_result] = adapter.process_batch([large])
+
+    small_perf = small_result._stage_perf[-1]
+    large_perf = large_result._stage_perf[-1]
+    assert small_perf.num_items_processed == large_perf.num_items_processed == 1
+    assert large_perf.input_data_size_mb > small_perf.input_data_size_mb > 0

--- a/tests/backends/test_performance_transport.py
+++ b/tests/backends/test_performance_transport.py
@@ -38,7 +38,7 @@ class _RequiredReportStage(_Stage):
         return True
 
 
-def test_adapter_publishes_one_collector_record() -> None:
+def test_adapter_publishes_one_collector_record_without_task_duplication() -> None:
     stage = _Stage()
     stage._curator_stage_id = "000:stage"
     stage._curator_stage_perf_collector_name = "collector"
@@ -47,12 +47,19 @@ def test_adapter_publishes_one_collector_record() -> None:
     with patch("nemo_curator.utils.stage_perf_collector.record_stage_perf", return_value=True) as publish:
         [result] = adapter.process_batch([EmptyTask()])
 
-    [perf] = result._stage_perf
+    assert result._stage_perf == []
+    perf = publish.call_args.args[1]
     assert perf.stage_id == "000:stage"
     assert perf.invocation_id
     assert perf.window_end_s >= perf.window_start_s > 0
     publish.assert_called_once()
-    assert publish.call_args.kwargs["attached_to_output"] is True
+
+
+def test_adapter_preserves_task_attached_perf_without_collector() -> None:
+    [result] = BaseStageAdapter(_Stage()).process_batch([EmptyTask()])
+
+    assert len(result._stage_perf) == 1
+    assert result._stage_perf[0].stage_name == "stage"
 
 
 def test_required_collector_start_failure_is_not_silenced() -> None:
@@ -73,11 +80,12 @@ def test_audio_input_byte_count_is_independent_of_item_count() -> None:
     small = AudioTask(dataset_name="test", data={"text": "a"})
     large = AudioTask(dataset_name="test", data={"text": "a" * 1_000})
 
-    with patch("nemo_curator.utils.stage_perf_collector.record_stage_perf", return_value=True):
+    with patch("nemo_curator.utils.stage_perf_collector.record_stage_perf", return_value=True) as publish:
         [small_result] = adapter.process_batch([small])
         [large_result] = adapter.process_batch([large])
 
-    small_perf = small_result._stage_perf[-1]
-    large_perf = large_result._stage_perf[-1]
+    assert small_result._stage_perf == large_result._stage_perf == []
+    small_perf = publish.call_args_list[0].args[1]
+    large_perf = publish.call_args_list[1].args[1]
     assert small_perf.num_items_processed == large_perf.num_items_processed == 1
     assert large_perf.input_data_size_mb > small_perf.input_data_size_mb > 0

--- a/tests/config/test_performance_transport_config.py
+++ b/tests/config/test_performance_transport_config.py
@@ -1,0 +1,40 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from omegaconf import OmegaConf
+
+from nemo_curator.config.run import create_executor_from_yaml, create_pipeline_from_yaml
+
+
+def test_yaml_applies_extended_metrics_and_executor_config() -> None:
+    cfg = OmegaConf.create(
+        {
+            "backend": "ray_data",
+            "executor_config": {"pipeline_hardware_sampler_enabled": True},
+            "stages": [
+                {
+                    "_target_": "nemo_curator.stages.file_partitioning.FilePartitioningStage",
+                    "file_paths": "./data",
+                    "extended_performance_metrics": True,
+                }
+            ],
+        }
+    )
+
+    pipeline = create_pipeline_from_yaml(cfg, log_config=False)
+    executor = create_executor_from_yaml(cfg)
+
+    assert pipeline.stages[0].extended_performance_metrics is True
+    assert executor is not None
+    assert executor.config["pipeline_hardware_sampler_enabled"] is True

--- a/tests/config/test_performance_transport_config.py
+++ b/tests/config/test_performance_transport_config.py
@@ -12,8 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import tomllib
 from pathlib import Path
+from unittest.mock import MagicMock, patch
 
+import pytest
 from omegaconf import OmegaConf
 
 from nemo_curator.config.run import create_executor_from_yaml, create_pipeline_from_yaml
@@ -42,6 +45,51 @@ def test_yaml_applies_extended_metrics_and_executor_config() -> None:
     assert executor.config["pipeline_hardware_sampler_enabled"] is True
 
 
+def test_yaml_propagates_extended_metrics_through_manifest_reader_composite(tmp_path: Path) -> None:
+    cfg = OmegaConf.create(
+        {
+            "stages": [
+                {
+                    "_target_": "nemo_curator.stages.audio.common.ManifestReader",
+                    "manifest_path": str(tmp_path / "input.jsonl"),
+                    "extended_performance_metrics": True,
+                }
+            ]
+        }
+    )
+
+    pipeline = create_pipeline_from_yaml(cfg, log_config=False)
+    assert pipeline.stages[0].extended_performance_metrics is True
+
+    pipeline.build()
+
+    assert [stage.name for stage in pipeline.stages] == ["file_partitioning", "manifest_reader_stage"]
+    assert all(stage.extended_performance_metrics for stage in pipeline.stages)
+
+
+@pytest.mark.parametrize("nested_mode", ["bogus", "invalid"])
+@patch("hydra.utils.get_class")
+def test_xenna_rejects_invalid_nested_execution_mode(mock_get_class: MagicMock, nested_mode: str) -> None:
+    cfg = OmegaConf.create({"backend": "xenna", "executor_config": {"execution_mode": nested_mode}})
+
+    with pytest.raises(ValueError, match="Unknown Xenna execution mode"):
+        create_executor_from_yaml(cfg)
+
+    mock_get_class.assert_called_once()
+
+
+@patch("hydra.utils.get_class")
+def test_xenna_rejects_conflicting_execution_modes(mock_get_class: MagicMock) -> None:
+    cfg = OmegaConf.create(
+        {"backend": "xenna", "execution_mode": "streaming", "executor_config": {"execution_mode": "batch"}}
+    )
+
+    with pytest.raises(ValueError, match="Conflicting Xenna execution modes"):
+        create_executor_from_yaml(cfg)
+
+    mock_get_class.assert_called_once()
+
+
 def test_qwen_tutorial_writes_complete_performance_report() -> None:
     config_path = Path(__file__).parents[2] / "tutorials/audio/qwen_omni_inprocess/pipeline.yaml"
     cfg = OmegaConf.load(config_path)
@@ -49,3 +97,13 @@ def test_qwen_tutorial_writes_complete_performance_report() -> None:
     assert cfg.performance_report_path == "./qwen_omni_performance.json"
     assert cfg.stages[2].extended_performance_metrics is True
     assert cfg.stages[3].performance_report_path == cfg.performance_report_path
+
+
+def test_qwen_tutorial_install_includes_advertised_s3_filesystem_extra() -> None:
+    repository_root = Path(__file__).parents[2]
+    with (repository_root / "pyproject.toml").open("rb") as pyproject_file:
+        optional_dependencies = tomllib.load(pyproject_file)["project"]["optional-dependencies"]
+    readme = (repository_root / "tutorials/audio/qwen_omni_inprocess/README.md").read_text(encoding="utf-8")
+
+    assert any(dependency.startswith("s3fs") for dependency in optional_dependencies["cloud_filesystems"])
+    assert "--extra cloud_filesystems" in readme

--- a/tests/config/test_performance_transport_config.py
+++ b/tests/config/test_performance_transport_config.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from pathlib import Path
+
 from omegaconf import OmegaConf
 
 from nemo_curator.config.run import create_executor_from_yaml, create_pipeline_from_yaml
@@ -38,3 +40,12 @@ def test_yaml_applies_extended_metrics_and_executor_config() -> None:
     assert pipeline.stages[0].extended_performance_metrics is True
     assert executor is not None
     assert executor.config["pipeline_hardware_sampler_enabled"] is True
+
+
+def test_qwen_tutorial_writes_complete_performance_report() -> None:
+    config_path = Path(__file__).parents[2] / "tutorials/audio/qwen_omni_inprocess/pipeline.yaml"
+    cfg = OmegaConf.load(config_path)
+
+    assert cfg.performance_report_path == "./qwen_omni_performance.json"
+    assert cfg.stages[2].extended_performance_metrics is True
+    assert cfg.stages[3].performance_report_path == cfg.performance_report_path

--- a/tests/config/test_performance_transport_config.py
+++ b/tests/config/test_performance_transport_config.py
@@ -14,80 +14,8 @@
 
 import tomllib
 from pathlib import Path
-from unittest.mock import MagicMock, patch
 
-import pytest
 from omegaconf import OmegaConf
-
-from nemo_curator.config.run import create_executor_from_yaml, create_pipeline_from_yaml
-
-
-def test_yaml_applies_extended_metrics_and_executor_config() -> None:
-    cfg = OmegaConf.create(
-        {
-            "backend": "ray_data",
-            "executor_config": {"pipeline_hardware_sampler_enabled": True},
-            "stages": [
-                {
-                    "_target_": "nemo_curator.stages.file_partitioning.FilePartitioningStage",
-                    "file_paths": "./data",
-                    "extended_performance_metrics": True,
-                }
-            ],
-        }
-    )
-
-    pipeline = create_pipeline_from_yaml(cfg, log_config=False)
-    executor = create_executor_from_yaml(cfg)
-
-    assert pipeline.stages[0].extended_performance_metrics is True
-    assert executor is not None
-    assert executor.config["pipeline_hardware_sampler_enabled"] is True
-
-
-def test_yaml_propagates_extended_metrics_through_manifest_reader_composite(tmp_path: Path) -> None:
-    cfg = OmegaConf.create(
-        {
-            "stages": [
-                {
-                    "_target_": "nemo_curator.stages.audio.common.ManifestReader",
-                    "manifest_path": str(tmp_path / "input.jsonl"),
-                    "extended_performance_metrics": True,
-                }
-            ]
-        }
-    )
-
-    pipeline = create_pipeline_from_yaml(cfg, log_config=False)
-    assert pipeline.stages[0].extended_performance_metrics is True
-
-    pipeline.build()
-
-    assert [stage.name for stage in pipeline.stages] == ["file_partitioning", "manifest_reader_stage"]
-    assert all(stage.extended_performance_metrics for stage in pipeline.stages)
-
-
-@pytest.mark.parametrize("nested_mode", ["bogus", "invalid"])
-@patch("hydra.utils.get_class")
-def test_xenna_rejects_invalid_nested_execution_mode(mock_get_class: MagicMock, nested_mode: str) -> None:
-    cfg = OmegaConf.create({"backend": "xenna", "executor_config": {"execution_mode": nested_mode}})
-
-    with pytest.raises(ValueError, match="Unknown Xenna execution mode"):
-        create_executor_from_yaml(cfg)
-
-    mock_get_class.assert_called_once()
-
-
-@patch("hydra.utils.get_class")
-def test_xenna_rejects_conflicting_execution_modes(mock_get_class: MagicMock) -> None:
-    cfg = OmegaConf.create(
-        {"backend": "xenna", "execution_mode": "streaming", "executor_config": {"execution_mode": "batch"}}
-    )
-
-    with pytest.raises(ValueError, match="Conflicting Xenna execution modes"):
-        create_executor_from_yaml(cfg)
-
-    mock_get_class.assert_called_once()
 
 
 def test_qwen_tutorial_writes_complete_performance_report() -> None:
@@ -95,7 +23,6 @@ def test_qwen_tutorial_writes_complete_performance_report() -> None:
     cfg = OmegaConf.load(config_path)
 
     assert cfg.performance_report_path == "./qwen_omni_performance.json"
-    assert cfg.stages[2].extended_performance_metrics is True
     assert cfg.stages[3].performance_report_path == cfg.performance_report_path
 
 

--- a/tests/pipelines/test_performance_reporting.py
+++ b/tests/pipelines/test_performance_reporting.py
@@ -12,9 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import json
+from pathlib import Path
+
+import pytest
+
+from nemo_curator.backends.ray_data import RayDataExecutor
+from nemo_curator.backends.xenna import XennaExecutor
 from nemo_curator.pipeline import Pipeline
+from nemo_curator.stages.audio.common import ManifestWriterStage
 from nemo_curator.stages.base import ProcessingStage
-from nemo_curator.tasks import Task
+from nemo_curator.tasks import AudioTask, Task
 from nemo_curator.utils.performance_utils import StagePerfStats
 
 
@@ -82,3 +90,29 @@ def test_pipeline_assigns_stable_ids_and_fans_out_one_record_drain() -> None:
     assert len(records) == 1
     assert wall_time_s >= 0.0
     assert executor.records == []
+
+
+@pytest.mark.parametrize(
+    "executor",
+    [
+        pytest.param(RayDataExecutor(), id="ray-data"),
+        pytest.param(XennaExecutor(config={"execution_mode": "batch"}), id="xenna"),
+    ],
+)
+@pytest.mark.usefixtures("shared_ray_client")
+def test_report_path_alone_collects_records_end_to_end(executor: object, tmp_path: Path) -> None:
+    report_path = tmp_path / "performance.json"
+    writer = ManifestWriterStage(
+        output_path=str(tmp_path / "manifest.jsonl"),
+        performance_report_path=str(report_path),
+    )
+    pipeline = Pipeline(name="path-only", stages=[writer])
+
+    pipeline.run(
+        executor=executor,  # type: ignore[arg-type]
+        initial_tasks=[AudioTask(dataset_name="test", data={"text": "payload"})],
+    )
+
+    report = json.loads(report_path.read_text(encoding="utf-8"))
+    assert report["record_count"] >= 1
+    assert report["records"]

--- a/tests/pipelines/test_performance_reporting.py
+++ b/tests/pipelines/test_performance_reporting.py
@@ -1,0 +1,94 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+from pathlib import Path
+
+from nemo_curator.pipeline import Pipeline
+from nemo_curator.stages.base import ProcessingStage
+from nemo_curator.tasks import Task
+from nemo_curator.utils.performance_utils import StagePerfStats
+
+
+class _TerminalConsumer(ProcessingStage[Task, Task]):
+    name = "duplicate"
+
+    def __init__(self) -> None:
+        self.prepared = False
+        self.finalized: tuple[list[Task], list[StagePerfStats], float] | None = None
+
+    def process(self, task: Task) -> Task:
+        return task
+
+    def prepare_performance_report(self) -> None:
+        self.prepared = True
+
+    def finalize_performance_report(
+        self,
+        tasks: list[Task],
+        *,
+        performance_records: list[StagePerfStats],
+        wall_time_s: float,
+    ) -> None:
+        self.finalized = (tasks, performance_records, wall_time_s)
+
+
+class _Executor:
+    def __init__(self) -> None:
+        self.records = [
+            StagePerfStats(
+                stage_name="duplicate",
+                invocation_id="invocation-1",
+                process_time=1.0,
+            )
+        ]
+
+    def execute(self, _stages: list[ProcessingStage], initial_tasks: list[Task] | None = None) -> list[Task]:
+        return list(initial_tasks or [])
+
+    def consume_external_perf_records(self) -> list[StagePerfStats]:
+        records, self.records = self.records, []
+        return records
+
+
+def test_pipeline_assigns_stable_ids_and_fans_out_one_record_drain(tmp_path: Path) -> None:
+    first = _TerminalConsumer()
+    terminal = _TerminalConsumer()
+    executor = _Executor()
+    report_path = tmp_path / "raw-performance.json"
+    pipeline = Pipeline(name="performance", stages=[first, terminal])
+
+    result = pipeline.run(
+        executor=executor,  # type: ignore[arg-type]
+        initial_tasks=[],
+        performance_report_path=report_path,
+    )
+
+    assert result == []
+    assert first._curator_stage_id == "000:duplicate"
+    assert terminal._curator_stage_id == "001:duplicate"
+    assert first.prepared is False
+    assert terminal.prepared is True
+    assert terminal.finalized is not None
+    tasks, records, wall_time_s = terminal.finalized
+    assert tasks == []
+    assert records is pipeline.performance_records
+    assert len(records) == 1
+    assert wall_time_s >= 0.0
+    assert executor.records == []
+
+    report = json.loads(report_path.read_text())
+    assert report["schema_version"] == 1
+    assert report["record_count"] == 1
+    assert report["records"][0]["invocation_id"] == "invocation-1"

--- a/tests/pipelines/test_performance_reporting.py
+++ b/tests/pipelines/test_performance_reporting.py
@@ -24,6 +24,7 @@ from nemo_curator.stages.audio.common import ManifestWriterStage
 from nemo_curator.stages.base import ProcessingStage
 from nemo_curator.tasks import AudioTask, Task
 from nemo_curator.utils.performance_utils import StagePerfStats
+from nemo_curator.utils.stage_perf_collector import PerformanceRecordStore
 
 
 class _TerminalConsumer(ProcessingStage[Task, Task]):
@@ -51,19 +52,22 @@ class _TerminalConsumer(ProcessingStage[Task, Task]):
 
 class _Executor:
     def __init__(self) -> None:
-        self.records = [
-            StagePerfStats(
-                stage_name="duplicate",
-                invocation_id="invocation-1",
-                process_time=1.0,
-            )
-        ]
+        self.records: PerformanceRecordStore | None = PerformanceRecordStore.from_records(
+            [
+                StagePerfStats(
+                    stage_name="duplicate",
+                    invocation_id="invocation-1",
+                    process_time=1.0,
+                )
+            ]
+        )
 
     def execute(self, _stages: list[ProcessingStage], initial_tasks: list[Task] | None = None) -> list[Task]:
         return list(initial_tasks or [])
 
-    def consume_external_perf_records(self) -> list[StagePerfStats]:
-        records, self.records = self.records, []
+    def consume_external_perf_records(self) -> PerformanceRecordStore:
+        records, self.records = self.records, None
+        assert records is not None
         return records
 
 
@@ -89,7 +93,7 @@ def test_pipeline_assigns_stable_ids_and_fans_out_one_record_drain() -> None:
     assert records is pipeline.performance_records
     assert len(records) == 1
     assert wall_time_s >= 0.0
-    assert executor.records == []
+    assert executor.records is None
 
 
 @pytest.mark.parametrize(

--- a/tests/pipelines/test_performance_reporting.py
+++ b/tests/pipelines/test_performance_reporting.py
@@ -12,9 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import json
-from pathlib import Path
-
 from nemo_curator.pipeline import Pipeline
 from nemo_curator.stages.base import ProcessingStage
 from nemo_curator.tasks import Task
@@ -62,17 +59,15 @@ class _Executor:
         return records
 
 
-def test_pipeline_assigns_stable_ids_and_fans_out_one_record_drain(tmp_path: Path) -> None:
+def test_pipeline_assigns_stable_ids_and_fans_out_one_record_drain() -> None:
     first = _TerminalConsumer()
     terminal = _TerminalConsumer()
     executor = _Executor()
-    report_path = tmp_path / "raw-performance.json"
     pipeline = Pipeline(name="performance", stages=[first, terminal])
 
     result = pipeline.run(
         executor=executor,  # type: ignore[arg-type]
         initial_tasks=[],
-        performance_report_path=report_path,
     )
 
     assert result == []
@@ -87,8 +82,3 @@ def test_pipeline_assigns_stable_ids_and_fans_out_one_record_drain(tmp_path: Pat
     assert len(records) == 1
     assert wall_time_s >= 0.0
     assert executor.records == []
-
-    report = json.loads(report_path.read_text())
-    assert report["schema_version"] == 1
-    assert report["record_count"] == 1
-    assert report["records"][0]["invocation_id"] == "invocation-1"

--- a/tests/stages/audio/io/test_manifest_writer_performance_report.py
+++ b/tests/stages/audio/io/test_manifest_writer_performance_report.py
@@ -1,0 +1,58 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+
+from fsspec.core import url_to_fs
+
+from nemo_curator.stages.audio.common import ManifestWriterStage
+from nemo_curator.utils.performance_utils import StagePerfStats
+
+
+def test_manifest_writer_persists_all_performance_records_through_fsspec() -> None:
+    report_path = "memory://performance/qwen.json"
+    writer = ManifestWriterStage(
+        output_path="memory://performance/qwen.jsonl",
+        performance_report_path=report_path,
+    )
+    writer._curator_run_id = "run-1"
+    writer._curator_executor = "RayDataExecutor"
+    writer._curator_pipeline_metadata = {
+        "pipeline_name": "qwen-omni",
+        "stages": [{"stage_id": "002:ASR"}],
+    }
+    records = [
+        StagePerfStats(
+            stage_name="ASR",
+            stage_id="002:ASR",
+            invocation_id="invocation-1",
+            process_time=1.5,
+            custom_metrics={"audio_duration_s": 12.0},
+            gpu_indices=[0, 1],
+        )
+    ]
+
+    writer.finalize_performance_report([], performance_records=records, wall_time_s=2.0)
+
+    fs, resolved_path = url_to_fs(report_path)
+    with fs.open(resolved_path, encoding="utf-8") as report_file:
+        report = json.load(report_file)
+
+    assert report["schema_version"] == 1
+    assert report["run_id"] == "run-1"
+    assert report["executor"] == "RayDataExecutor"
+    assert report["wall_time_s"] == 2.0
+    assert report["record_count"] == 1
+    assert report["records"][0]["custom_metrics"] == {"audio_duration_s": 12.0}
+    assert report["records"][0]["gpu_indices"] == [0, 1]

--- a/tests/stages/audio/io/test_manifest_writer_performance_report.py
+++ b/tests/stages/audio/io/test_manifest_writer_performance_report.py
@@ -15,12 +15,52 @@
 import json
 import tracemalloc
 from pathlib import Path
+from unittest.mock import MagicMock, patch
 
+import pytest
 from fsspec.core import url_to_fs
 
-from nemo_curator.stages.audio.common import ManifestWriterStage
+from nemo_curator.stages.audio.common import ManifestWriterStage, _append_slurm_shard_suffix
 from nemo_curator.utils.performance_utils import StagePerfStats
-from nemo_curator.utils.stage_perf_collector import PerformanceRecordStore
+from nemo_curator.utils.stage_perf_collector import PerformanceRecordStore, performance_collection_enabled
+
+
+def test_manifest_writer_rejects_equivalent_local_manifest_and_report_paths(tmp_path: Path) -> None:
+    output_path = tmp_path / "shared.json"
+
+    with pytest.raises(ValueError, match="must not resolve to the manifest output_path"):
+        ManifestWriterStage(
+            output_path=str(output_path),
+            performance_report_path=output_path.as_uri(),
+        )
+
+
+def test_manifest_writer_rejects_same_mocked_remote_destination() -> None:
+    remote_fs = MagicMock()
+    remote_fs.protocol = "s3"
+    remote_fs.storage_options = {"endpoint_url": "https://example.test"}
+
+    with (
+        patch(
+            "nemo_curator.stages.audio.common.url_to_fs",
+            side_effect=[(remote_fs, "bucket/shared.json"), (remote_fs, "bucket/shared.json")],
+        ),
+        pytest.raises(ValueError, match="must not resolve to the manifest output_path"),
+    ):
+        ManifestWriterStage(
+            output_path="s3://bucket/manifest.json",
+            performance_report_path="s3://bucket/performance.json",
+        )
+
+
+def test_manifest_writer_report_path_automatically_requests_collection(tmp_path: Path) -> None:
+    writer = ManifestWriterStage(
+        output_path=str(tmp_path / "manifest.jsonl"),
+        performance_report_path=str(tmp_path / "performance.json"),
+    )
+
+    assert writer.requests_performance_records() is True
+    assert performance_collection_enabled([writer]) is True
 
 
 def test_manifest_writer_persists_all_performance_records_through_fsspec() -> None:
@@ -90,3 +130,22 @@ def test_manifest_writer_streams_high_cardinality_record_store(tmp_path: Path) -
     assert report["record_count"] == 50_000
     assert len(report["records"]) == 50_000
     record_store.cleanup()
+
+
+def test_manifest_writer_derives_unique_slurm_shard_destination(tmp_path: Path) -> None:
+    report_path = tmp_path / "performance.json"
+    writer = ManifestWriterStage(
+        output_path=str(tmp_path / "manifest.jsonl"),
+        performance_report_path=str(report_path),
+    )
+    writer._curator_slurm_array_shard_index = 7
+    writer._curator_slurm_array_total_shards = 20
+    record_store = PerformanceRecordStore()
+
+    writer.finalize_performance_report([], performance_records=record_store, wall_time_s=1.0)
+
+    sharded_report_path = Path(_append_slurm_shard_suffix(str(report_path), 7, 20))
+    assert not report_path.exists()
+    assert sharded_report_path.is_file()
+    report = json.loads(sharded_report_path.read_text(encoding="utf-8"))
+    assert report["slurm_array"] == {"shard_index": 7, "total_shards": 20}

--- a/tests/stages/audio/io/test_manifest_writer_performance_report.py
+++ b/tests/stages/audio/io/test_manifest_writer_performance_report.py
@@ -82,7 +82,6 @@ def test_manifest_writer_persists_all_performance_records_through_fsspec() -> No
             invocation_id="invocation-1",
             process_time=1.5,
             custom_metrics={"audio_duration_s": 12.0},
-            gpu_indices=[0, 1],
         )
     ]
 
@@ -99,7 +98,6 @@ def test_manifest_writer_persists_all_performance_records_through_fsspec() -> No
     assert report["wall_time_s"] == 2.0
     assert report["record_count"] == 1
     assert report["records"][0]["custom_metrics"] == {"audio_duration_s": 12.0}
-    assert report["records"][0]["gpu_indices"] == [0, 1]
     record_store.cleanup()
 
 

--- a/tests/stages/audio/io/test_manifest_writer_performance_report.py
+++ b/tests/stages/audio/io/test_manifest_writer_performance_report.py
@@ -13,11 +13,14 @@
 # limitations under the License.
 
 import json
+import tracemalloc
+from pathlib import Path
 
 from fsspec.core import url_to_fs
 
 from nemo_curator.stages.audio.common import ManifestWriterStage
 from nemo_curator.utils.performance_utils import StagePerfStats
+from nemo_curator.utils.stage_perf_collector import PerformanceRecordStore
 
 
 def test_manifest_writer_persists_all_performance_records_through_fsspec() -> None:
@@ -43,7 +46,8 @@ def test_manifest_writer_persists_all_performance_records_through_fsspec() -> No
         )
     ]
 
-    writer.finalize_performance_report([], performance_records=records, wall_time_s=2.0)
+    record_store = PerformanceRecordStore.from_records(records)
+    writer.finalize_performance_report([], performance_records=record_store, wall_time_s=2.0)
 
     fs, resolved_path = url_to_fs(report_path)
     with fs.open(resolved_path, encoding="utf-8") as report_file:
@@ -56,3 +60,33 @@ def test_manifest_writer_persists_all_performance_records_through_fsspec() -> No
     assert report["record_count"] == 1
     assert report["records"][0]["custom_metrics"] == {"audio_duration_s": 12.0}
     assert report["records"][0]["gpu_indices"] == [0, 1]
+    record_store.cleanup()
+
+
+def test_manifest_writer_streams_high_cardinality_record_store(tmp_path: Path) -> None:
+    report_path = tmp_path / "performance.json"
+    writer = ManifestWriterStage(
+        output_path=str(tmp_path / "output.jsonl"),
+        performance_report_path=str(report_path),
+    )
+    record = StagePerfStats(
+        stage_name="ASR",
+        invocation_id="invocation",
+        process_time=1.5,
+        custom_metrics={"audio_duration_s": 12.0},
+    )
+    record_store = PerformanceRecordStore.from_records(record for _ in range(50_000))
+
+    tracemalloc.start()
+    try:
+        writer.finalize_performance_report([], performance_records=record_store, wall_time_s=2.0)
+        _current_bytes, peak_bytes = tracemalloc.get_traced_memory()
+    finally:
+        tracemalloc.stop()
+
+    assert peak_bytes < 2 * 1024 * 1024
+    with report_path.open(encoding="utf-8") as report_file:
+        report = json.load(report_file)
+    assert report["record_count"] == 50_000
+    assert len(report["records"]) == 50_000
+    record_store.cleanup()

--- a/tests/utils/test_performance_transport.py
+++ b/tests/utils/test_performance_transport.py
@@ -1,0 +1,81 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from nemo_curator.utils.performance_utils import StagePerfStats, norm_gpu_uuid
+
+
+def test_gpu_uuid_normalization() -> None:
+    assert norm_gpu_uuid(" GPU-ABC123 ") == "abc123"
+    assert norm_gpu_uuid(b"GPU-DEF456") == "def456"
+
+
+def test_legacy_and_extended_serialization_are_separate() -> None:
+    perf = StagePerfStats(
+        stage_name="gpu-stage",
+        process_time=1.5,
+        custom_metrics={"io": 2.0},
+        stage_id="002:gpu-stage",
+        invocation_id="invocation-1",
+        actor_id="actor-1",
+        gpu_indices=[0, 1],
+    )
+
+    legacy = perf.to_dict()
+    extended = perf.to_extended_dict()
+
+    assert "stage_id" not in legacy
+    assert "invocation_id" not in legacy
+    assert "actor_id" not in legacy
+    assert legacy["custom_metrics"] == {"io": 2.0}
+    assert extended["stage_id"] == "002:gpu-stage"
+    assert extended["invocation_id"] == "invocation-1"
+    assert extended["actor_id"] == "actor-1"
+    assert extended["gpu_indices"] == [0, 1]
+
+
+def test_aggregate_retains_identity_only_for_one_worker() -> None:
+    first = StagePerfStats(
+        stage_name="stage",
+        process_time=1.0,
+        stage_id="001:stage",
+        invocation_id="first",
+        window_start_s=10.0,
+        window_end_s=11.0,
+        actor_id="actor-a",
+        node_id="node-a",
+        physical_address="host-a:0",
+        gpu_indices=[0],
+    )
+    second = StagePerfStats(
+        stage_name="stage",
+        process_time=2.0,
+        stage_id="001:stage",
+        invocation_id="second",
+        window_start_s=11.0,
+        window_end_s=13.0,
+        actor_id="actor-b",
+        node_id="node-b",
+        physical_address="host-b:0",
+        gpu_indices=[0],
+    )
+
+    combined = first + second
+
+    assert combined.process_time == 3.0
+    assert combined.stage_id == "001:stage"
+    assert combined.invocation_id == ""
+    assert combined.window_start_s == 10.0
+    assert combined.window_end_s == 13.0
+    assert combined.actor_id == ""
+    assert combined.gpu_indices == []

--- a/tests/utils/test_performance_transport.py
+++ b/tests/utils/test_performance_transport.py
@@ -12,23 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from nemo_curator.utils.performance_utils import StagePerfStats, norm_gpu_uuid
-
-
-def test_gpu_uuid_normalization() -> None:
-    assert norm_gpu_uuid(" GPU-ABC123 ") == "abc123"
-    assert norm_gpu_uuid(b"GPU-DEF456") == "def456"
+from nemo_curator.utils.performance_utils import StagePerfStats
 
 
 def test_legacy_and_extended_serialization_are_separate() -> None:
     perf = StagePerfStats(
-        stage_name="gpu-stage",
+        stage_name="stage",
         process_time=1.5,
         custom_metrics={"io": 2.0},
-        stage_id="002:gpu-stage",
+        stage_id="002:stage",
         invocation_id="invocation-1",
-        actor_id="actor-1",
-        gpu_indices=[0, 1],
     )
 
     legacy = perf.to_dict()
@@ -36,15 +29,12 @@ def test_legacy_and_extended_serialization_are_separate() -> None:
 
     assert "stage_id" not in legacy
     assert "invocation_id" not in legacy
-    assert "actor_id" not in legacy
     assert legacy["custom_metrics"] == {"io": 2.0}
-    assert extended["stage_id"] == "002:gpu-stage"
+    assert extended["stage_id"] == "002:stage"
     assert extended["invocation_id"] == "invocation-1"
-    assert extended["actor_id"] == "actor-1"
-    assert extended["gpu_indices"] == [0, 1]
 
 
-def test_aggregate_retains_identity_only_for_one_worker() -> None:
+def test_aggregate_retains_stage_and_window_but_not_invocation() -> None:
     first = StagePerfStats(
         stage_name="stage",
         process_time=1.0,
@@ -52,10 +42,6 @@ def test_aggregate_retains_identity_only_for_one_worker() -> None:
         invocation_id="first",
         window_start_s=10.0,
         window_end_s=11.0,
-        actor_id="actor-a",
-        node_id="node-a",
-        physical_address="host-a:0",
-        gpu_indices=[0],
     )
     second = StagePerfStats(
         stage_name="stage",
@@ -64,10 +50,6 @@ def test_aggregate_retains_identity_only_for_one_worker() -> None:
         invocation_id="second",
         window_start_s=11.0,
         window_end_s=13.0,
-        actor_id="actor-b",
-        node_id="node-b",
-        physical_address="host-b:0",
-        gpu_indices=[0],
     )
 
     combined = first + second
@@ -77,5 +59,3 @@ def test_aggregate_retains_identity_only_for_one_worker() -> None:
     assert combined.invocation_id == ""
     assert combined.window_start_s == 10.0
     assert combined.window_end_s == 13.0
-    assert combined.actor_id == ""
-    assert combined.gpu_indices == []

--- a/tests/utils/test_stage_perf_collector.py
+++ b/tests/utils/test_stage_perf_collector.py
@@ -12,12 +12,21 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import tracemalloc
+from pathlib import Path
 from unittest.mock import MagicMock, patch
+
+import pytest
 
 from nemo_curator.stages.base import ProcessingStage
 from nemo_curator.tasks import Task
 from nemo_curator.utils.performance_utils import StagePerfStats
-from nemo_curator.utils.stage_perf_collector import record_stage_perf
+from nemo_curator.utils.stage_perf_collector import (
+    _StagePerfSpool,
+    record_stage_perf,
+    start_stage_perf_collector,
+    stop_stage_perf_collector,
+)
 
 
 class _Stage(ProcessingStage):
@@ -60,3 +69,51 @@ def test_record_stage_perf_waits_for_collector_ack() -> None:
     get_actor.assert_called_once_with("collector")
     collector.record.remote.assert_called_once()
     ray_get.assert_called_once_with(record_ref)
+
+
+@pytest.mark.usefixtures("shared_ray_client")
+def test_collector_returns_disk_backed_record_store() -> None:
+    stage = _Stage()
+    stage.extended_performance_metrics = True
+    collector = start_stage_perf_collector([stage])
+    assert collector is not None
+
+    assert record_stage_perf(
+        stage,
+        StagePerfStats(stage_name="stage", invocation_id="invocation-1"),
+        attached_to_output=False,
+    )
+    record_store = stop_stage_perf_collector(collector, [stage])
+
+    assert len(record_store) == 1
+    assert record_store.path
+    assert [record.invocation_id for record in record_store] == ["invocation-1"]
+    record_store.cleanup()
+
+
+def test_high_cardinality_spool_has_bounded_memory(tmp_path: Path) -> None:
+    spool = _StagePerfSpool(str(tmp_path / "records.jsonl"))
+    record = StagePerfStats(
+        stage_name="ASR",
+        invocation_id="invocation",
+        process_time=1.0,
+        custom_metrics={"audio_duration_s": 12.0},
+    )
+
+    tracemalloc.start()
+    try:
+        for _ in range(1_000):
+            spool.record(record)
+        baseline_bytes, _ = tracemalloc.get_traced_memory()
+        for _ in range(49_000):
+            spool.record(record)
+        current_bytes, peak_bytes = tracemalloc.get_traced_memory()
+    finally:
+        tracemalloc.stop()
+    path, record_count = spool.finish()
+
+    assert record_count == 50_000
+    assert current_bytes - baseline_bytes < 512 * 1024
+    assert peak_bytes < 2 * 1024 * 1024
+    with Path(path).open(encoding="utf-8") as records_file:
+        assert sum(1 for _ in records_file) == record_count

--- a/tests/utils/test_stage_perf_collector.py
+++ b/tests/utils/test_stage_perf_collector.py
@@ -12,6 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import gc
+import subprocess
+import sys
 import tracemalloc
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -22,6 +25,7 @@ from nemo_curator.stages.base import ProcessingStage
 from nemo_curator.tasks import Task
 from nemo_curator.utils.performance_utils import StagePerfStats
 from nemo_curator.utils.stage_perf_collector import (
+    PerformanceRecordStore,
     _StagePerfSpool,
     record_stage_perf,
     start_stage_perf_collector,
@@ -89,6 +93,57 @@ def test_collector_returns_disk_backed_record_store() -> None:
     assert record_store.path
     assert [record.invocation_id for record in record_store] == ["invocation-1"]
     record_store.cleanup()
+
+
+def test_record_store_cleans_spool_when_last_owner_is_released() -> None:
+    record_store = PerformanceRecordStore.from_records([StagePerfStats(stage_name="stage")])
+    spool_path = Path(record_store.path)
+
+    assert spool_path.is_file()
+    del record_store
+    gc.collect()
+
+    assert not spool_path.exists()
+    assert not spool_path.parent.exists()
+
+
+def test_record_store_context_manager_preserves_iteration_until_close() -> None:
+    with PerformanceRecordStore.from_records(
+        [StagePerfStats(stage_name="stage", invocation_id="invocation-1")]
+    ) as record_store:
+        spool_path = Path(record_store.path)
+        assert [record.invocation_id for record in record_store] == ["invocation-1"]
+        assert [record.invocation_id for record in record_store] == ["invocation-1"]
+
+    assert not spool_path.exists()
+    assert not spool_path.parent.exists()
+    assert record_store.path == ""
+    assert len(record_store) == 0
+
+
+def test_record_store_cleans_spool_at_normal_process_exit(tmp_path: Path) -> None:
+    path_record = tmp_path / "spool-path.txt"
+    script = """
+from pathlib import Path
+import sys
+
+from nemo_curator.utils.performance_utils import StagePerfStats
+from nemo_curator.utils.stage_perf_collector import PerformanceRecordStore
+
+store = PerformanceRecordStore.from_records(
+    StagePerfStats(stage_name="stage") for _ in range(50_000)
+)
+Path(sys.argv[1]).write_text(store.path, encoding="utf-8")
+"""
+
+    subprocess.run(  # noqa: S603
+        [sys.executable, "-c", script, str(path_record)],
+        check=True,
+    )
+    spool_path = Path(path_record.read_text(encoding="utf-8"))
+
+    assert not spool_path.exists()
+    assert not spool_path.parent.exists()
 
 
 def test_high_cardinality_spool_has_bounded_memory(tmp_path: Path) -> None:

--- a/tests/utils/test_stage_perf_collector.py
+++ b/tests/utils/test_stage_perf_collector.py
@@ -57,7 +57,6 @@ def test_record_stage_perf_is_noop_without_collector() -> None:
         record_stage_perf(
             _Stage(),
             StagePerfStats(stage_name="stage"),
-            attached_to_output=False,
         )
         is False
     )
@@ -75,13 +74,12 @@ def test_record_stage_perf_batches_acknowledgements_and_caches_actor_handle() ->
         side_effect=lambda refs: acknowledged_batches.append(list(refs)),
     ) as ray_get:
         for _ in range(MAX_PENDING_RECORDS - 1):
-            assert record_stage_perf(stage, StagePerfStats(stage_name="stage"), attached_to_output=True)
+            assert record_stage_perf(stage, StagePerfStats(stage_name="stage"))
         ray_get.assert_not_called()
         assert (
             record_stage_perf(
                 stage,
                 StagePerfStats(stage_name="stage"),
-                attached_to_output=True,
             )
             is True
         )
@@ -113,7 +111,7 @@ def test_required_publish_failure_is_not_silenced() -> None:
     setattr(stage, COLLECTOR_REQUIRED_ATTR, True)
 
     with pytest.raises(RuntimeError, match="Required stage performance publication failed"):
-        record_stage_perf(stage, StagePerfStats(stage_name="stage"), attached_to_output=False)
+        record_stage_perf(stage, StagePerfStats(stage_name="stage"))
 
 
 def test_required_finish_failure_is_not_silenced(tmp_path: Path) -> None:
@@ -164,7 +162,6 @@ def test_collector_returns_disk_backed_record_store() -> None:
     assert record_stage_perf(
         stage,
         StagePerfStats(stage_name="stage", invocation_id="invocation-1"),
-        attached_to_output=False,
     )
     record_store = stop_stage_perf_collector(collector, [stage])
 

--- a/tests/utils/test_stage_perf_collector.py
+++ b/tests/utils/test_stage_perf_collector.py
@@ -47,6 +47,11 @@ class _Stage(ProcessingStage):
         return task
 
 
+class _ReportStage(_Stage):
+    def requests_performance_records(self) -> bool:
+        return True
+
+
 def test_record_stage_perf_is_noop_without_collector() -> None:
     assert (
         record_stage_perf(
@@ -134,8 +139,7 @@ def test_collector_start_failure_cleans_created_spool(tmp_path: Path) -> None:
     spool_dir = tmp_path / "spool"
     spool_dir.mkdir()
     spool_path = spool_dir / "records.jsonl"
-    stage = _Stage()
-    stage.extended_performance_metrics = True
+    stage = _ReportStage()
     runtime_context = MagicMock()
     runtime_context.get_node_id.return_value = "a" * 56
 
@@ -153,8 +157,7 @@ def test_collector_start_failure_cleans_created_spool(tmp_path: Path) -> None:
 
 @pytest.mark.usefixtures("shared_ray_client")
 def test_collector_returns_disk_backed_record_store() -> None:
-    stage = _Stage()
-    stage.extended_performance_metrics = True
+    stage = _ReportStage()
     collector = start_stage_perf_collector([stage])
     assert collector is not None
 

--- a/tests/utils/test_stage_perf_collector.py
+++ b/tests/utils/test_stage_perf_collector.py
@@ -1,0 +1,62 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from unittest.mock import MagicMock, patch
+
+from nemo_curator.stages.base import ProcessingStage
+from nemo_curator.tasks import Task
+from nemo_curator.utils.performance_utils import StagePerfStats
+from nemo_curator.utils.stage_perf_collector import record_stage_perf
+
+
+class _Stage(ProcessingStage):
+    name = "stage"
+
+    def process(self, task: Task) -> Task:
+        return task
+
+
+def test_record_stage_perf_is_noop_without_collector() -> None:
+    assert (
+        record_stage_perf(
+            _Stage(),
+            StagePerfStats(stage_name="stage"),
+            attached_to_output=False,
+        )
+        is False
+    )
+
+
+def test_record_stage_perf_waits_for_collector_ack() -> None:
+    stage = _Stage()
+    stage._curator_stage_perf_collector_name = "collector"
+    collector = MagicMock()
+    record_ref = collector.record.remote.return_value
+
+    with (
+        patch("nemo_curator.utils.stage_perf_collector.ray.get_actor", return_value=collector) as get_actor,
+        patch("nemo_curator.utils.stage_perf_collector.ray.get") as ray_get,
+    ):
+        assert (
+            record_stage_perf(
+                stage,
+                StagePerfStats(stage_name="stage"),
+                attached_to_output=True,
+            )
+            is True
+        )
+
+    get_actor.assert_called_once_with("collector")
+    collector.record.remote.assert_called_once()
+    ray_get.assert_called_once_with(record_ref)

--- a/tests/utils/test_stage_perf_collector.py
+++ b/tests/utils/test_stage_perf_collector.py
@@ -25,8 +25,15 @@ from nemo_curator.stages.base import ProcessingStage
 from nemo_curator.tasks import Task
 from nemo_curator.utils.performance_utils import StagePerfStats
 from nemo_curator.utils.stage_perf_collector import (
+    COLLECTOR_ACTOR_ATTR,
+    COLLECTOR_PENDING_ATTR,
+    COLLECTOR_REQUIRED_ATTR,
+    MAX_PENDING_RECORDS,
     PerformanceRecordStore,
+    _StagePerfCollector,
+    _StagePerfCollectorHandle,
     _StagePerfSpool,
+    flush_stage_perf_records,
     record_stage_perf,
     start_stage_perf_collector,
     stop_stage_perf_collector,
@@ -51,16 +58,20 @@ def test_record_stage_perf_is_noop_without_collector() -> None:
     )
 
 
-def test_record_stage_perf_waits_for_collector_ack() -> None:
+def test_record_stage_perf_batches_acknowledgements_and_caches_actor_handle() -> None:
     stage = _Stage()
-    stage._curator_stage_perf_collector_name = "collector"
     collector = MagicMock()
-    record_ref = collector.record.remote.return_value
+    setattr(stage, COLLECTOR_ACTOR_ATTR, collector)
+    setattr(stage, COLLECTOR_PENDING_ATTR, [])
+    acknowledged_batches: list[list[object]] = []
 
-    with (
-        patch("nemo_curator.utils.stage_perf_collector.ray.get_actor", return_value=collector) as get_actor,
-        patch("nemo_curator.utils.stage_perf_collector.ray.get") as ray_get,
-    ):
+    with patch(
+        "nemo_curator.utils.stage_perf_collector.ray.get",
+        side_effect=lambda refs: acknowledged_batches.append(list(refs)),
+    ) as ray_get:
+        for _ in range(MAX_PENDING_RECORDS - 1):
+            assert record_stage_perf(stage, StagePerfStats(stage_name="stage"), attached_to_output=True)
+        ray_get.assert_not_called()
         assert (
             record_stage_perf(
                 stage,
@@ -70,9 +81,74 @@ def test_record_stage_perf_waits_for_collector_ack() -> None:
             is True
         )
 
-    get_actor.assert_called_once_with("collector")
-    collector.record.remote.assert_called_once()
-    ray_get.assert_called_once_with(record_ref)
+    assert collector.record.remote.call_count == MAX_PENDING_RECORDS
+    assert len(acknowledged_batches) == 1
+    assert len(acknowledged_batches[0]) == MAX_PENDING_RECORDS
+    assert getattr(stage, COLLECTOR_PENDING_ATTR) == []
+
+
+def test_flush_stage_perf_records_waits_for_partial_batch() -> None:
+    stage = _Stage()
+    pending = [object(), object()]
+    setattr(stage, COLLECTOR_PENDING_ATTR, pending)
+
+    with patch("nemo_curator.utils.stage_perf_collector.ray.get") as ray_get:
+        flush_stage_perf_records(stage)
+
+    ray_get.assert_called_once()
+    assert pending == []
+
+
+def test_required_publish_failure_is_not_silenced() -> None:
+    stage = _Stage()
+    collector = MagicMock()
+    collector.record.remote.side_effect = OSError("publish failed")
+    setattr(stage, COLLECTOR_ACTOR_ATTR, collector)
+    setattr(stage, COLLECTOR_PENDING_ATTR, [])
+    setattr(stage, COLLECTOR_REQUIRED_ATTR, True)
+
+    with pytest.raises(RuntimeError, match="Required stage performance publication failed"):
+        record_stage_perf(stage, StagePerfStats(stage_name="stage"), attached_to_output=False)
+
+
+def test_required_finish_failure_is_not_silenced(tmp_path: Path) -> None:
+    spool_dir = tmp_path / "spool"
+    spool_dir.mkdir()
+    spool_path = spool_dir / "records.jsonl"
+    spool_path.write_text("", encoding="utf-8")
+    actor = MagicMock()
+    actor.finish.remote.side_effect = OSError("finish failed")
+    handle = _StagePerfCollectorHandle(actor=actor, spool_path=str(spool_path), report_required=True)
+
+    with (
+        patch("nemo_curator.utils.stage_perf_collector.ray.get", side_effect=lambda value: value),
+        patch("nemo_curator.utils.stage_perf_collector.ray.kill"),
+        pytest.raises(RuntimeError, match="Required stage performance collector finish failed"),
+    ):
+        stop_stage_perf_collector(handle, [_Stage()], raise_on_failure=True)
+
+    assert not spool_path.exists()
+
+
+def test_collector_start_failure_cleans_created_spool(tmp_path: Path) -> None:
+    spool_dir = tmp_path / "spool"
+    spool_dir.mkdir()
+    spool_path = spool_dir / "records.jsonl"
+    stage = _Stage()
+    stage.extended_performance_metrics = True
+    runtime_context = MagicMock()
+    runtime_context.get_node_id.return_value = "a" * 56
+
+    with (
+        patch("nemo_curator.utils.stage_perf_collector._new_spool_path", return_value=str(spool_path)),
+        patch("nemo_curator.utils.stage_perf_collector.ray.get_runtime_context", return_value=runtime_context),
+        patch.object(_StagePerfCollector, "options", side_effect=OSError("start failed")),
+        pytest.raises(OSError, match="start failed"),
+    ):
+        start_stage_perf_collector([stage])
+
+    assert not spool_path.exists()
+    assert not spool_dir.exists()
 
 
 @pytest.mark.usefixtures("shared_ray_client")

--- a/tutorials/audio/qwen_omni_inprocess/README.md
+++ b/tutorials/audio/qwen_omni_inprocess/README.md
@@ -14,6 +14,9 @@ executor and passes it to `Pipeline.run()`.
 The run also writes every collected stage invocation to
 `qwen_omni_performance.json`. This raw report is independent of manifest rows:
 it retains calls that emit no output and does not aggregate records.
+While this run-scoped collection is active, invocation records are kept in the
+collector instead of being copied onto every output task; this prevents fan-out
+stages from multiplying one call's metrics by their output cardinality.
 
 ## Requirements
 

--- a/tutorials/audio/qwen_omni_inprocess/README.md
+++ b/tutorials/audio/qwen_omni_inprocess/README.md
@@ -28,7 +28,7 @@ under `resampled_audio_dir` before inference starts on those rows.
 From the Curator repository root, install the optional Qwen stack:
 
 ```bash
-uv sync --extra audio_cuda12 --extra vllm
+uv sync --extra audio_cuda12 --extra vllm --extra cloud_filesystems
 source .venv/bin/activate
 ```
 
@@ -89,9 +89,9 @@ The Qwen ASR stage enables `extended_performance_metrics`, which starts one
 run-scoped collector for the whole pipeline. The JSON at
 `performance_report_path` therefore contains the complete invocation records
 from the reader, resampler, ASR, and manifest writer stages. Each record
-includes its stable stage and invocation IDs, timing window, item and byte
-counts, custom metrics, and any worker or GPU identity supplied by the active
-backend.
+includes its stable stage and invocation IDs, timing window, item count,
+serialized manifest-payload byte count, custom metrics, and any worker or GPU
+identity supplied by the active backend.
 
 Override the destination like any other Hydra value:
 

--- a/tutorials/audio/qwen_omni_inprocess/README.md
+++ b/tutorials/audio/qwen_omni_inprocess/README.md
@@ -85,13 +85,12 @@ single GPU-count setting and the stage derives tensor parallelism from it.
 
 ## Raw performance report
 
-The Qwen ASR stage enables `extended_performance_metrics`, which starts one
-run-scoped collector for the whole pipeline. The JSON at
-`performance_report_path` therefore contains the complete invocation records
+Setting `performance_report_path` on the terminal manifest writer starts one
+run-scoped collector for the whole pipeline. The resulting JSON therefore
+contains the complete invocation records
 from the reader, resampler, ASR, and manifest writer stages. Each record
 includes its stable stage and invocation IDs, timing window, item count,
-serialized manifest-payload byte count, custom metrics, and any worker or GPU
-identity supplied by the active backend.
+serialized manifest-payload byte count, and custom metrics.
 
 Override the destination like any other Hydra value:
 

--- a/tutorials/audio/qwen_omni_inprocess/README.md
+++ b/tutorials/audio/qwen_omni_inprocess/README.md
@@ -11,6 +11,10 @@ tutorial-specific Python runner is needed. The YAML selects the executor
 backend and, for Xenna, its execution mode; the generic runner constructs that
 executor and passes it to `Pipeline.run()`.
 
+The run also writes every collected stage invocation to
+`qwen_omni_performance.json`. This raw report is independent of manifest rows:
+it retains calls that emit no output and does not aggregate records.
+
 ## Requirements
 
 - x86_64 Linux with CUDA
@@ -78,6 +82,32 @@ live under `adapter_kwargs.sampling_kwargs`. They are forwarded to Curator's
 shared vLLM construction path and vLLM's `SamplingParams`, respectively.
 Do not put `tensor_parallel_size` in `vllm_kwargs`: `gpus_per_actor` is the
 single GPU-count setting and the stage derives tensor parallelism from it.
+
+## Raw performance report
+
+The Qwen ASR stage enables `extended_performance_metrics`, which starts one
+run-scoped collector for the whole pipeline. The JSON at
+`performance_report_path` therefore contains the complete invocation records
+from the reader, resampler, ASR, and manifest writer stages. Each record
+includes its stable stage and invocation IDs, timing window, item and byte
+counts, custom metrics, and any worker or GPU identity supplied by the active
+backend.
+
+Override the destination like any other Hydra value:
+
+```bash
+python nemo_curator/config/run.py \
+  --config-path ../../tutorials/audio/qwen_omni_inprocess \
+  --config-name pipeline \
+  manifest_path=/data/input.jsonl \
+  performance_report_path=s3://bucket/runs/qwen/performance.json
+```
+
+`ManifestWriterStage` uses Curator's existing fsspec JSON write utility, so
+local paths and configured remote filesystems share the same schema. The
+driver asks the terminal manifest writer to write the report after a successful
+pipeline execution, including an empty `records` list when no invocations were
+collected.
 
 ## Select the executor
 

--- a/tutorials/audio/qwen_omni_inprocess/pipeline.yaml
+++ b/tutorials/audio/qwen_omni_inprocess/pipeline.yaml
@@ -45,7 +45,6 @@ stages:
 
   - _target_: nemo_curator.stages.audio.inference.asr.stage.ASRStage
     adapter_target: nemo_curator.models.asr.qwen_omni.QwenOmniASRAdapter
-    extended_performance_metrics: true
     model_id: ${model_id}
     default_language: ${default_language}
     supported_language_codes: ${supported_language_codes}

--- a/tutorials/audio/qwen_omni_inprocess/pipeline.yaml
+++ b/tutorials/audio/qwen_omni_inprocess/pipeline.yaml
@@ -18,6 +18,7 @@ hydra:
 
 manifest_path: ???
 output_path: ./qwen_omni_output.jsonl
+performance_report_path: ./qwen_omni_performance.json
 workspace_dir: /tmp/qwen_omni_workspace
 resampled_audio_dir: ${workspace_dir}/audio_resampled
 model_id: Qwen/Qwen3-Omni-30B-A3B-Instruct
@@ -44,6 +45,7 @@ stages:
 
   - _target_: nemo_curator.stages.audio.inference.asr.stage.ASRStage
     adapter_target: nemo_curator.models.asr.qwen_omni.QwenOmniASRAdapter
+    extended_performance_metrics: true
     model_id: ${model_id}
     default_language: ${default_language}
     supported_language_codes: ${supported_language_codes}
@@ -81,3 +83,4 @@ stages:
 
   - _target_: nemo_curator.stages.audio.common.ManifestWriterStage
     output_path: ${output_path}
+    performance_report_path: ${performance_report_path}

--- a/uv.lock
+++ b/uv.lock
@@ -5237,6 +5237,9 @@ audio-cuda12 = [
     { name = "transformers" },
     { name = "whisperx", marker = "platform_machine == 'x86_64' and sys_platform != 'darwin'" },
 ]
+cloud-filesystems = [
+    { name = "s3fs" },
+]
 cuda12 = [
     { name = "gpustat" },
     { name = "nvidia-ml-py" },
@@ -5636,6 +5639,7 @@ requires-dist = [
     { name = "ray", extras = ["llm", "serve"], marker = "extra == 'inference-server'", specifier = ">=2.55.1" },
     { name = "requests", marker = "extra == 'translation-nmt'" },
     { name = "resiliparse", marker = "extra == 'text-cpu'" },
+    { name = "s3fs", marker = "extra == 'cloud-filesystems'", specifier = ">=2024.12.0" },
     { name = "s3fs", marker = "extra == 'interleaved-cpu'", specifier = ">=2024.12.0" },
     { name = "s5cmd", marker = "extra == 'text-cpu'" },
     { name = "sacrebleu", marker = "extra == 'translation-metrics'", specifier = ">=2.6.0" },
@@ -5675,7 +5679,7 @@ requires-dist = [
     { name = "warcio", marker = "extra == 'text-cpu'" },
     { name = "whisperx", marker = "platform_machine == 'x86_64' and sys_platform != 'darwin' and extra == 'audio-common'", specifier = ">=3.8.4" },
 ]
-provides-extras = ["cuda12", "cv2", "vllm", "inference-server", "deduplication-cuda12", "audio-common", "audio-cpu", "audio-cuda12", "image-cpu", "image-cuda12", "translation-common", "translation-metrics", "translation-segmentation", "translation-aws", "translation-google", "translation-nmt", "translation-all", "text-cpu", "lance", "text-cuda12", "video-cpu", "video-cuda12", "video-media", "math-cpu", "math-cuda12", "interleaved-cpu", "interleaved-cuda12", "sdg-cpu", "sdg-cuda12", "all"]
+provides-extras = ["cuda12", "cv2", "vllm", "cloud-filesystems", "inference-server", "deduplication-cuda12", "audio-common", "audio-cpu", "audio-cuda12", "image-cpu", "image-cuda12", "translation-common", "translation-metrics", "translation-segmentation", "translation-aws", "translation-google", "translation-nmt", "translation-all", "text-cpu", "lance", "text-cuda12", "video-cpu", "video-cuda12", "video-media", "math-cpu", "math-cuda12", "interleaved-cpu", "interleaved-cuda12", "sdg-cpu", "sdg-cuda12", "all"]
 
 [package.metadata.requires-dev]
 build = [


### PR DESCRIPTION
## Executive summary

This PR adds the backend-neutral path for collecting **one authoritative performance record per stage invocation** and writing the complete run to an optional terminal JSON report. It does not add GPU/worker telemetry or audio-specific aggregation; those remain owned by follow-up PRs.

| Feature | Before this PR | Accessible after merge |
|---|---|---|
| Collection activation | Performance data existed only on output tasks that survived a stage. | Setting `ManifestWriterStage.performance_report_path` requests collection for the whole planned pipeline. |
| Invocation coverage | Zero-output calls disappeared, and fan-out could duplicate one call's metrics across many output tasks. | Every requested `process_batch` invocation is published exactly once, including zero-output and fan-out calls. Collector-active runs do not copy the new record onto every output task. |
| Run and stage identity | Stage names alone did not identify duplicate stage names, run membership, or planned order. | Each `Pipeline.run()` creates a Curator-owned run ID; decomposed stages receive ordered IDs such as `000:file_partitioning`; every call receives a stable invocation ID and timing window. |
| Quantities and units | The timer could treat input item count as bytes and then label the derived value as MiB. | Input bytes and input items are measured and stored separately; duration, idle time, output count, and numeric custom metrics remain explicit. |
| Transport and ownership | There was no run-scoped authoritative record set independent of task outputs. | A bounded Ray collector spools records to driver-local JSONL, then hands one `PerformanceRecordStore` to the pipeline and cleans temporary state. |
| Executor lifecycle | Executors did not expose a strict one-shot performance-record handoff. | `BaseExecutor.consume_external_perf_records()` is the shared contract: consume once, clear the executor slot, and return an empty store when no report was requested. Ray Data and Xenna use it. |
| Terminal persistence | The manifest writer wrote output rows but not the complete raw invocation set. | The existing fsspec writer path emits the raw performance JSON to local or remote storage; local writes are atomic and Slurm array runs use shard-qualified report paths. |
| Pipeline timing | No terminal report exposed executor end-to-end wall time. | The report includes monotonic executor wall time plus per-invocation monotonic windows. Wall time is elapsed executor latency, not a sum of stage durations. |
| Legacy behavior | Task-attached `_stage_perf` was the only path. | When no report is requested, the legacy task-attached behavior is preserved. When collection is active, the run-scoped store is authoritative and avoids fan-out duplication. |

## Configuration and scope

`performance_report_path` is configured on the terminal performance consumer, currently `ManifestWriterStage` (it may be exposed as a top-level Hydra value and interpolated into that stage). The request originates at that stage, while collection scope is pipeline-wide: the executor installs the collector on every decomposed stage for that run.

Example:

```yaml
performance_report_path: /output/qwen_omni_performance.json
```

The report contains pipeline/executor context, ordered stage metadata, run/stage/invocation IDs, timing windows, byte/item/output counters, and stage-supplied numeric custom metrics. JSON array arrival order is not treated as a global execution schedule; planned stage order comes from the indexed stage metadata and concurrent activity is interpreted from timing windows.

## Ownership across the performance PRs

1. **#2279 (this PR):** generic invocation collection and transport, Curator-owned run/stage/invocation identity, timing windows, correct byte/item accounting, executor wall time and one-shot drain, Slurm report sharding, and persistence through the existing writer.
2. **#2223:** audio/Qwen metric production and terminal audio aggregation.
3. **#2262:** GPU/worker identity schema, backend enrichment hooks, `extended_performance_metrics`, hardware configuration, Ray/Xenna identity, and NVML sampling.

This PR deliberately contains no actor/node/host/GPU fields, no NVML sampler, no backend enrichment hooks, and no extended-metrics switch.

## Current revision

- head: `acb29e3e2a1935d0e05639c5f32503b189e70f44`
- diff versus current main: **23 files, +1,490 / -26**
- no Fern changes
- DCO signoff present

## Validation

- focused transport/config/pipeline/writer suite: **28 passed**
- additional legacy backend and I/O suite: **32 passed**; pytest reported completion before the command wrapper reached its teardown timeout
- Ruff lint and formatting checks passed on every changed Python file
- `git diff --check` passed

## Checklist

- [x] Remains draft.
- [x] Uses existing writer infrastructure.
- [x] Preserves task-attached metrics when no report is requested.
- [x] Avoids per-output invocation duplication when collection is active.
- [x] Excludes backend/GPU and audio-summary ownership.
- [x] Contains no Fern changes.
