### PR TITLE
Bump min required uv version

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -48,7 +48,7 @@ repos:
     # Use the latest version
     # Note: These hooks will block commits if uv fails
     # To bypass if strictly needed (change not related to dependencies), use: git commit --no-verify
-    rev: 0.12.2
+    rev: 0.12.1
     hooks:
       - id: uv-lock
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -48,7 +48,7 @@ repos:
     # Use the latest version
     # Note: These hooks will block commits if uv fails
     # To bypass if strictly needed (change not related to dependencies), use: git commit --no-verify
-    rev: 0.9.2
+    rev: 0.12.2
     hooks:
       - id: uv-lock
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -52,7 +52,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 WORKDIR /opt
 
 # Install uv
-ENV UV_VERSION="0.12.0"
+ENV UV_VERSION="0.12.2"
 RUN curl -LsSf https://astral.sh/uv/${UV_VERSION}/install.sh | sh
 ENV PATH="/root/.local/bin:$PATH"
 ENV UV_PROJECT_ENVIRONMENT=/opt/venv

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -52,7 +52,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 WORKDIR /opt
 
 # Install uv
-ENV UV_VERSION="0.8.22"
+ENV UV_VERSION="0.12.0"
 RUN curl -LsSf https://astral.sh/uv/${UV_VERSION}/install.sh | sh
 ENV PATH="/root/.local/bin:$PATH"
 ENV UV_PROJECT_ENVIRONMENT=/opt/venv

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -52,7 +52,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 WORKDIR /opt
 
 # Install uv
-ENV UV_VERSION="0.12.2"
+ENV UV_VERSION="0.12.1"
 RUN curl -LsSf https://astral.sh/uv/${UV_VERSION}/install.sh | sh
 ENV PATH="/root/.local/bin:$PATH"
 ENV UV_PROJECT_ENVIRONMENT=/opt/venv

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -329,7 +329,7 @@ test = [
 ]
 
 [tool.uv]
-required-version = ">=0.7.0"
+required-version = ">=0.12.0"
 package = true
 managed = true
 default-groups = ["dev", "test"]


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
Helps avoid large lockfile diffs between dependabot/Ci prs like #2289 since lockfile generation changed in version 0.11.25 or around then.

Users/devs can update with `uv self update`

## Usage
<!-- Potentially add a usage example below -->
```python
# Add snippet demonstrating usage
```
## Checklist
<!--
Note: All commits need to be signed and signed off. This can be done via `-sS` flags while commiting
`git commit -sS -m "...."
-->
- [X] I am familiar with the [Contributing Guide](https://github.com/NVIDIA-NeMo/Curator/blob/main/CONTRIBUTING.md).
- [X] New or Existing tests cover these changes.
- [] The documentation is up to date with these changes.
