### PR TITLE
feat(text): bound vLLM embedding generation

### DIFF
--- a/benchmarking/scripts/embedding_generation_benchmark.py
+++ b/benchmarking/scripts/embedding_generation_benchmark.py
@@ -78,6 +78,7 @@ def _create_embedding_stages(
     model_inference_batch_size: int,
     max_seq_length: int,
     embedding_pooling: str,
+    metadata_fields: list[str] | None = None,
     cache_dir: str | None = None,
 ) -> list:
     """Create the embedding stage(s) for the given model variation."""
@@ -113,6 +114,8 @@ def _create_embedding_stages(
                 model_identifier=model_identifier,
                 text_field="text",
                 embedding_field="embeddings",
+                metadata_fields=metadata_fields,
+                model_inference_batch_size=model_inference_batch_size,
                 pretokenize=model_variation == EmbeddingModelVariation.VLLM_TEXT_PRETOKENIZED,
                 vllm_init_kwargs=vllm_init_kwargs,
                 cache_dir=cache_dir,
@@ -134,6 +137,7 @@ def run_embedding_generation_benchmark(
     embedding_pooling: str,
     input_format: str = "parquet",
     cache_dir: str | None = None,
+    metadata_fields: list[str] | None = None,
     **kwargs: Any,  # noqa: ANN401, ARG001
 ) -> dict[str, Any]:
     """Run the embedding generation benchmark and collect comprehensive metrics."""
@@ -156,6 +160,9 @@ def run_embedding_generation_benchmark(
 
     run_start_time = time.perf_counter()
 
+    metadata_fields = list(dict.fromkeys(metadata_fields or []))
+    input_fields = list(dict.fromkeys(["text", *metadata_fields]))
+    output_fields = [*metadata_fields, "embeddings"]
     keep_ext = "jsonl" if input_format == "jsonl" else "parquet"
     input_files = load_dataset_files(input_path, dataset_size_gb, keep_extensions=keep_ext)
     executor_obj = setup_executor(executor)
@@ -166,15 +173,16 @@ def run_embedding_generation_benchmark(
         model_inference_batch_size=model_inference_batch_size,
         max_seq_length=max_seq_length,
         embedding_pooling=embedding_pooling,
+        metadata_fields=metadata_fields,
         cache_dir=cache_dir,
     )
 
     if input_format == "jsonl":
-        reader = JsonlReader(file_paths=input_files, files_per_partition=1, fields=["text"], _generate_ids=False)
-        writer = JsonlWriter(path=str(output_path), fields=["embeddings"])
+        reader = JsonlReader(file_paths=input_files, files_per_partition=1, fields=input_fields, _generate_ids=False)
+        writer = JsonlWriter(path=str(output_path), fields=output_fields)
     else:
-        reader = ParquetReader(file_paths=input_files, files_per_partition=1, fields=["text"], _generate_ids=False)
-        writer = ParquetWriter(path=str(output_path), fields=["embeddings"])
+        reader = ParquetReader(file_paths=input_files, files_per_partition=1, fields=input_fields, _generate_ids=False)
+        writer = ParquetWriter(path=str(output_path), fields=output_fields)
 
     pipeline = Pipeline(
         name="embedding_generation_pipeline",
@@ -239,6 +247,13 @@ def main() -> int:
         "--cache-dir",
         default=None,
         help="HuggingFace cache directory for model weights (uses default HF cache if not set)",
+    )
+    parser.add_argument(
+        "--metadata-field",
+        dest="metadata_fields",
+        action="append",
+        default=None,
+        help="Input metadata field to preserve in output; may be repeated",
     )
 
     args = parser.parse_args()

--- a/nemo_curator/stages/text/deduplication/semantic.py
+++ b/nemo_curator/stages/text/deduplication/semantic.py
@@ -278,6 +278,7 @@ class TextSemanticDeduplicationWorkflow:
             model_identifier=self.model_identifier,
             text_field=self.text_field,
             embedding_field=self.embedding_field,
+            metadata_fields=list(dict.fromkeys([self.id_field, *(self.metadata_fields or [])])),
             max_chars=self.embedding_max_chars,
             pretokenize=self.embedding_pretokenize,
             vllm_init_kwargs=self.embedding_vllm_init_kwargs,

--- a/nemo_curator/stages/text/embedders/vllm.py
+++ b/nemo_curator/stages/text/embedders/vllm.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 import gc
 import time
 from concurrent.futures import ThreadPoolExecutor
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
 import pyarrow as pa
@@ -184,13 +184,11 @@ class VLLMEmbeddingModelStage(ProcessingStage[DocumentBatch, DocumentBatch]):
 
         from vllm.inputs import TokensPrompt
 
-        tokenizer = cast("AutoTokenizer", self.tokenizer)
-        model = cast("LLM", self.model)
         t0 = time.perf_counter()
-        tokenized_data = tokenizer.batch_encode_plus(
+        tokenized_data = self.tokenizer.batch_encode_plus(
             input_data,
             truncation=True,
-            max_length=model.model_config.max_model_len,
+            max_length=self.model.model_config.max_model_len,
         )
         prompts = [TokensPrompt(prompt_token_ids=ids) for ids in tokenized_data.input_ids]
         return prompts, time.perf_counter() - t0
@@ -238,9 +236,8 @@ class VLLMEmbeddingModelStage(ProcessingStage[DocumentBatch, DocumentBatch]):
             yield pending_offset, pending_chunk_size, input_data, tokenization_time
 
     def _embed_chunk(self, input_data: list[Any], expected_size: int) -> tuple[np.ndarray, dict[str, float]]:
-        model = cast("LLM", self.model)
         t0 = time.perf_counter()
-        vllm_output = model.embed(
+        vllm_output = self.model.embed(
             input_data,
             tokenization_kwargs={"truncate_prompt_tokens": -1},
             use_tqdm=self.verbose,
@@ -296,7 +293,7 @@ class VLLMEmbeddingModelStage(ProcessingStage[DocumentBatch, DocumentBatch]):
             embedding_matrix[offset : offset + chunk_size] = chunk_embedding_matrix
             del chunk_embedding_matrix
 
-        return cast("np.ndarray", embedding_matrix), {
+        return embedding_matrix, {
             "tokenization_time": tokenization_time,
             "vllm_embedding_time": vllm_embedding_time,
             "input_tokens": input_tokens,

--- a/nemo_curator/stages/text/embedders/vllm.py
+++ b/nemo_curator/stages/text/embedders/vllm.py
@@ -67,7 +67,7 @@ class VLLMEmbeddingModelStage(ProcessingStage[DocumentBatch, DocumentBatch]):
         verbose: bool = False,
         *,
         metadata_fields: list[str] | None = None,
-        model_inference_batch_size: int = 10_000,
+        model_inference_batch_size: int | None = 8192,
     ):
         self.model_identifier = model_identifier
         self.vllm_init_kwargs = vllm_init_kwargs or {}
@@ -75,13 +75,13 @@ class VLLMEmbeddingModelStage(ProcessingStage[DocumentBatch, DocumentBatch]):
         self.text_field = text_field
         self.pretokenize = pretokenize
         self.embedding_field = embedding_field
-        self.metadata_fields = list(dict.fromkeys(metadata_fields)) if metadata_fields is not None else None
-        if (
+        self.metadata_fields = list(dict.fromkeys(metadata_fields or []))
+        if model_inference_batch_size is not None and (
             isinstance(model_inference_batch_size, bool)
             or not isinstance(model_inference_batch_size, int)
             or model_inference_batch_size <= 0
         ):
-            msg = f"model_inference_batch_size must be a positive integer, got {model_inference_batch_size}"
+            msg = f"model_inference_batch_size must be a positive integer or None, got {model_inference_batch_size}"
             raise ValueError(msg)
         self.model_inference_batch_size = model_inference_batch_size
         self.max_chars = max_chars
@@ -104,7 +104,7 @@ class VLLMEmbeddingModelStage(ProcessingStage[DocumentBatch, DocumentBatch]):
         return ["data"], [self.text_field]
 
     def outputs(self) -> tuple[list[str], list[str]]:
-        output_fields = list(self.metadata_fields) if self.metadata_fields is not None else [self.text_field]
+        output_fields = list(self.metadata_fields)
         if self.embedding_field not in output_fields:
             output_fields.append(self.embedding_field)
         return ["data"], output_fields
@@ -205,10 +205,17 @@ class VLLMEmbeddingModelStage(ProcessingStage[DocumentBatch, DocumentBatch]):
     def _iter_prepared_chunks(
         self, text_column: pa.ChunkedArray, num_rows: int
     ) -> Iterator[tuple[int, int, list[Any], float]]:
-        """Prepare one chunk ahead while the caller embeds the current chunk."""
+        """Prepare one chunk ahead while the caller embeds the current chunk.
+
+        The sole executor worker tokenizes only the next chunk. ``Future.result``
+        blocks until that work is ready, so this generator does not poll or spin.
+        While the caller embeds a yielded chunk on the GPU, the worker prepares
+        the following chunk on the CPU.
+        """
+        inference_batch_size = self.model_inference_batch_size or num_rows
         chunk_specs = iter(
-            (offset, min(self.model_inference_batch_size, num_rows - offset))
-            for offset in range(0, num_rows, self.model_inference_batch_size)
+            (offset, min(inference_batch_size, num_rows - offset))
+            for offset in range(0, num_rows, inference_batch_size)
         )
         pending_offset, pending_chunk_size = next(chunk_specs)
 
@@ -219,26 +226,22 @@ class VLLMEmbeddingModelStage(ProcessingStage[DocumentBatch, DocumentBatch]):
                 pending_offset,
                 pending_chunk_size,
             )
-            while True:
+            for next_offset, next_chunk_size in chunk_specs:
                 input_data, tokenization_time = pending_input.result()
-                try:
-                    next_offset, next_chunk_size = next(chunk_specs)
-                except StopIteration:
-                    next_input = None
-                else:
-                    next_input = executor.submit(
-                        self._prepare_input_chunk,
-                        text_column,
-                        next_offset,
-                        next_chunk_size,
-                    )
+                next_input = executor.submit(
+                    self._prepare_input_chunk,
+                    text_column,
+                    next_offset,
+                    next_chunk_size,
+                )
 
                 yield pending_offset, pending_chunk_size, input_data, tokenization_time
-                if next_input is None:
-                    break
                 pending_offset = next_offset
                 pending_chunk_size = next_chunk_size
                 pending_input = next_input
+
+            input_data, tokenization_time = pending_input.result()
+            yield pending_offset, pending_chunk_size, input_data, tokenization_time
 
     def _embed_chunk(self, input_data: list[Any], expected_size: int) -> tuple[np.ndarray, dict[str, float]]:
         if self.model is None:
@@ -274,44 +277,35 @@ class VLLMEmbeddingModelStage(ProcessingStage[DocumentBatch, DocumentBatch]):
             msg = f"Input batch is missing required text field {self.text_field!r}"
             raise ValueError(msg)
 
-        metadata_fields = self.metadata_fields if self.metadata_fields is not None else input_table.column_names
-        missing_fields = [field for field in metadata_fields if field not in input_table.column_names]
+        missing_fields = [field for field in self.metadata_fields if field not in input_table.column_names]
         if missing_fields:
             msg = f"Input batch is missing metadata fields: {missing_fields}"
             raise ValueError(msg)
-        return input_table.select(metadata_fields)
+        return input_table.select(self.metadata_fields)
 
     def _collect_embeddings(self, text_column: pa.ChunkedArray, num_rows: int) -> tuple[np.ndarray, dict[str, float]]:
         """Embed bounded chunks and assemble one ordered float32 matrix."""
-        embedding_matrix: np.ndarray | None = None
-        tokenization_time = 0.0
-        vllm_embedding_time = 0.0
-        input_tokens = 0.0
+        prepared_chunks = iter(self._iter_prepared_chunks(text_column, num_rows))
+        first_offset, first_chunk_size, first_input_data, tokenization_time = next(prepared_chunks)
+        first_embedding_matrix, first_metrics = self._embed_chunk(first_input_data, first_chunk_size)
+        embedding_matrix = np.empty(
+            (num_rows, first_embedding_matrix.shape[1]),
+            dtype=np.float32,
+        )
+        embedding_matrix[first_offset : first_offset + first_chunk_size] = first_embedding_matrix
+        del first_embedding_matrix
 
-        for offset, chunk_size, input_data, chunk_tokenization_time in self._iter_prepared_chunks(
-            text_column, num_rows
-        ):
+        vllm_embedding_time = first_metrics["vllm_embedding_time"]
+        input_tokens = first_metrics["input_tokens"]
+
+        for offset, chunk_size, input_data, chunk_tokenization_time in prepared_chunks:
             tokenization_time += chunk_tokenization_time
             chunk_embedding_matrix, chunk_metrics = self._embed_chunk(input_data, chunk_size)
             vllm_embedding_time += chunk_metrics["vllm_embedding_time"]
             input_tokens += chunk_metrics["input_tokens"]
-            if embedding_matrix is None:
-                embedding_matrix = np.empty(
-                    (num_rows, chunk_embedding_matrix.shape[1]),
-                    dtype=np.float32,
-                )
-            elif embedding_matrix.shape[1] != chunk_embedding_matrix.shape[1]:
-                msg = (
-                    f"vLLM embedding dimension changed from {embedding_matrix.shape[1]} "
-                    f"to {chunk_embedding_matrix.shape[1]}"
-                )
-                raise ValueError(msg)
             embedding_matrix[offset : offset + chunk_size] = chunk_embedding_matrix
             del chunk_embedding_matrix
 
-        if embedding_matrix is None:
-            msg = "vLLM did not return embeddings for a non-empty document batch"
-            raise RuntimeError(msg)
         return embedding_matrix, {
             "tokenization_time": tokenization_time,
             "vllm_embedding_time": vllm_embedding_time,

--- a/nemo_curator/stages/text/embedders/vllm.py
+++ b/nemo_curator/stages/text/embedders/vllm.py
@@ -67,6 +67,7 @@ class VLLMEmbeddingModelStage(ProcessingStage[DocumentBatch, DocumentBatch]):
         *,
         metadata_fields: list[str] | None = None,
         model_inference_batch_size: int | None = 8192,
+        # Keep float32 when feeding semantic dedup; cuDF cannot read nested Float16 Parquet as numeric list values.
         embedding_output_dtype: Literal["float16", "float32", "float64"] = "float32",
     ):
         self.model_identifier = model_identifier

--- a/nemo_curator/stages/text/embedders/vllm.py
+++ b/nemo_curator/stages/text/embedders/vllm.py
@@ -50,6 +50,7 @@ if TYPE_CHECKING:
     from nemo_curator.backends.base import NodeInfo, WorkerMetadata
 
 _VLLM_INSTALL_HINT = "vLLM is required for VLLMEmbeddingModelStage. Install with: pip install nemo_curator[vllm]"
+_MAX_LIST_ARRAY_VALUES = np.iinfo(np.int32).max
 
 
 class VLLMEmbeddingModelStage(ProcessingStage[DocumentBatch, DocumentBatch]):
@@ -197,9 +198,7 @@ class VLLMEmbeddingModelStage(ProcessingStage[DocumentBatch, DocumentBatch]):
         prompts = [TokensPrompt(prompt_token_ids=ids) for ids in tokenized_data.input_ids]
         return prompts, time.perf_counter() - t0
 
-    def _iter_prepared_chunks(
-        self, text_column: pa.ChunkedArray, num_rows: int
-    ) -> Iterator[tuple[int, int, list[Any], float]]:
+    def _iter_prepared_chunks(self, text_column: pa.ChunkedArray, num_rows: int) -> Iterator[tuple[list[Any], float]]:
         """Prepare one chunk ahead while the caller embeds the current chunk.
 
         One worker is intentional: this is a single-producer prefetch pipeline,
@@ -231,13 +230,13 @@ class VLLMEmbeddingModelStage(ProcessingStage[DocumentBatch, DocumentBatch]):
                     next_chunk_size,
                 )
 
-                yield pending_offset, pending_chunk_size, input_data, tokenization_time
+                yield input_data, tokenization_time
                 pending_offset = next_offset
                 pending_chunk_size = next_chunk_size
                 pending_input = next_input
 
             input_data, tokenization_time = pending_input.result()
-            yield pending_offset, pending_chunk_size, input_data, tokenization_time
+            yield input_data, tokenization_time
 
     def _embed_chunk(self, input_data: list[Any]) -> tuple[np.ndarray, dict[str, float]]:
         t0 = time.perf_counter()
@@ -268,57 +267,49 @@ class VLLMEmbeddingModelStage(ProcessingStage[DocumentBatch, DocumentBatch]):
             raise ValueError(msg)
         return input_table.select(self.metadata_fields)
 
-    def _collect_embeddings(self, text_column: pa.ChunkedArray, num_rows: int) -> tuple[np.ndarray, dict[str, float]]:
-        """Embed bounded chunks and assemble one ordered matrix."""
-        embedding_matrix: np.ndarray | None = None
+    def _collect_embeddings(
+        self, text_column: pa.ChunkedArray, num_rows: int
+    ) -> tuple[pa.ChunkedArray, dict[str, float]]:
+        """Embed bounded chunks and assemble one ordered Arrow array."""
+        embedding_chunks: list[pa.Array] = []
         tokenization_time = 0.0
         vllm_embedding_time = 0.0
         input_tokens = 0
 
-        for offset, chunk_size, input_data, chunk_tokenization_time in self._iter_prepared_chunks(
-            text_column, num_rows
-        ):
+        for input_data, chunk_tokenization_time in self._iter_prepared_chunks(text_column, num_rows):
             tokenization_time += chunk_tokenization_time
             chunk_embedding_matrix, chunk_metrics = self._embed_chunk(input_data)
             vllm_embedding_time += chunk_metrics["vllm_embedding_time"]
             input_tokens += chunk_metrics["input_tokens"]
-            if embedding_matrix is None:
-                embedding_matrix = np.empty(
-                    (num_rows, chunk_embedding_matrix.shape[1]),
-                    dtype=self.embedding_output_dtype,
-                )
-            embedding_matrix[offset : offset + chunk_size] = chunk_embedding_matrix
+            embedding_chunks.extend(self._to_arrow_embeddings(chunk_embedding_matrix).chunks)
             del chunk_embedding_matrix
 
-        return embedding_matrix, {
+        return pa.chunked_array(embedding_chunks), {
             "tokenization_time": tokenization_time,
             "vllm_embedding_time": vllm_embedding_time,
             "input_tokens": input_tokens,
         }
 
     @staticmethod
-    def _to_arrow_embeddings(embedding_matrix: np.ndarray) -> pa.ListArray:
-        """Convert a dense matrix to an Arrow list array with the same dtype."""
-        embedding_values = pa.array(
-            embedding_matrix.reshape(-1),
-            type=pa.from_numpy_dtype(embedding_matrix.dtype),
-            from_pandas=False,
-        )
-        embedding_offsets = pa.array(
-            np.arange(
-                0,
-                (embedding_matrix.shape[0] + 1) * embedding_matrix.shape[1],
-                embedding_matrix.shape[1],
-                dtype=np.int64,
+    def _to_arrow_embeddings(embedding_matrix: np.ndarray) -> pa.ChunkedArray:
+        """Convert a dense matrix to bounded Arrow list-array chunks."""
+        embedding_dim = embedding_matrix.shape[1]
+        rows_per_chunk = _MAX_LIST_ARRAY_VALUES // embedding_dim
+        value_type = pa.from_numpy_dtype(embedding_matrix.dtype)
+        chunks = []
+        for offset in range(0, embedding_matrix.shape[0], rows_per_chunk):
+            matrix_chunk = embedding_matrix[offset : offset + rows_per_chunk]
+            values = pa.array(matrix_chunk.reshape(-1), type=value_type, from_pandas=False)
+            offsets = pa.array(
+                np.arange(0, matrix_chunk.size + 1, embedding_dim, dtype=np.int32),
             )
-        )
-        return pa.ListArray.from_arrays(embedding_offsets, embedding_values)
+            chunks.append(pa.ListArray.from_arrays(offsets, values))
+        return pa.chunked_array(chunks, type=pa.list_(value_type))
 
     def process(self, batch: DocumentBatch) -> DocumentBatch:
         input_table = batch.to_pyarrow()
         output_table = self._select_output_table(input_table)
-        embedding_matrix, metrics = self._collect_embeddings(input_table[self.text_field], input_table.num_rows)
-        embedding_array = self._to_arrow_embeddings(embedding_matrix)
+        embedding_array, metrics = self._collect_embeddings(input_table[self.text_field], input_table.num_rows)
         if self.embedding_field in output_table.column_names:
             embedding_index = output_table.column_names.index(self.embedding_field)
             output_table = output_table.set_column(embedding_index, self.embedding_field, embedding_array)

--- a/nemo_curator/stages/text/embedders/vllm.py
+++ b/nemo_curator/stages/text/embedders/vllm.py
@@ -50,7 +50,6 @@ if TYPE_CHECKING:
     from nemo_curator.backends.base import NodeInfo, WorkerMetadata
 
 _VLLM_INSTALL_HINT = "vLLM is required for VLLMEmbeddingModelStage. Install with: pip install nemo_curator[vllm]"
-_EMBEDDING_MATRIX_NDIM = 2
 
 
 class VLLMEmbeddingModelStage(ProcessingStage[DocumentBatch, DocumentBatch]):
@@ -78,8 +77,8 @@ class VLLMEmbeddingModelStage(ProcessingStage[DocumentBatch, DocumentBatch]):
         # Retained columns are opt-in so large source-text columns are not carried
         # alongside embeddings unless a caller explicitly requests them.
         self.metadata_fields = list(dict.fromkeys(metadata_fields or []))
-        if model_inference_batch_size is not None and model_inference_batch_size <= 0:
-            msg = f"model_inference_batch_size must be a positive integer or None, got {model_inference_batch_size}"
+        if model_inference_batch_size is not None and model_inference_batch_size < 0:
+            msg = f"model_inference_batch_size must be a non-negative integer or None, got {model_inference_batch_size}"
             raise ValueError(msg)
         self.model_inference_batch_size = model_inference_batch_size
         self.max_chars = max_chars
@@ -235,7 +234,7 @@ class VLLMEmbeddingModelStage(ProcessingStage[DocumentBatch, DocumentBatch]):
             input_data, tokenization_time = pending_input.result()
             yield pending_offset, pending_chunk_size, input_data, tokenization_time
 
-    def _embed_chunk(self, input_data: list[Any], expected_size: int) -> tuple[np.ndarray, dict[str, float]]:
+    def _embed_chunk(self, input_data: list[Any]) -> tuple[np.ndarray, dict[str, float]]:
         t0 = time.perf_counter()
         vllm_output = self.model.embed(
             input_data,
@@ -243,17 +242,10 @@ class VLLMEmbeddingModelStage(ProcessingStage[DocumentBatch, DocumentBatch]):
             use_tqdm=self.verbose,
         )
         elapsed = time.perf_counter() - t0
-        if len(vllm_output) != expected_size:
-            msg = f"vLLM returned {len(vllm_output)} embeddings for a {expected_size}-row input chunk"
-            raise ValueError(msg)
-
         chunk_embedding_matrix = np.asarray(
             [output.outputs.embedding for output in vllm_output],
             dtype=np.float32,
         )
-        if chunk_embedding_matrix.ndim != _EMBEDDING_MATRIX_NDIM:
-            msg = f"Expected a two-dimensional embedding matrix, got shape {chunk_embedding_matrix.shape}"
-            raise ValueError(msg)
         return chunk_embedding_matrix, {
             "vllm_embedding_time": elapsed,
             "input_tokens": sum(len(output.prompt_token_ids) for output in vllm_output),
@@ -282,7 +274,7 @@ class VLLMEmbeddingModelStage(ProcessingStage[DocumentBatch, DocumentBatch]):
             text_column, num_rows
         ):
             tokenization_time += chunk_tokenization_time
-            chunk_embedding_matrix, chunk_metrics = self._embed_chunk(input_data, chunk_size)
+            chunk_embedding_matrix, chunk_metrics = self._embed_chunk(input_data)
             vllm_embedding_time += chunk_metrics["vllm_embedding_time"]
             input_tokens += chunk_metrics["input_tokens"]
             if embedding_matrix is None:
@@ -315,10 +307,6 @@ class VLLMEmbeddingModelStage(ProcessingStage[DocumentBatch, DocumentBatch]):
 
     def process(self, batch: DocumentBatch) -> DocumentBatch:
         input_table = batch.to_pyarrow()
-        if input_table.num_rows == 0:
-            msg = "Cannot generate embeddings for an empty document batch"
-            raise ValueError(msg)
-
         output_table = self._select_output_table(input_table)
         embedding_matrix, metrics = self._collect_embeddings(input_table[self.text_field], input_table.num_rows)
         embedding_array = self._to_arrow_embeddings(embedding_matrix)

--- a/nemo_curator/stages/text/embedders/vllm.py
+++ b/nemo_curator/stages/text/embedders/vllm.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 import gc
 import time
 from concurrent.futures import ThreadPoolExecutor
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Literal
 
 import numpy as np
 import pyarrow as pa
@@ -67,6 +67,7 @@ class VLLMEmbeddingModelStage(ProcessingStage[DocumentBatch, DocumentBatch]):
         *,
         metadata_fields: list[str] | None = None,
         model_inference_batch_size: int | None = 8192,
+        embedding_output_dtype: Literal["float16", "float32", "float64"] = "float32",
     ):
         self.model_identifier = model_identifier
         self.vllm_init_kwargs = vllm_init_kwargs or {}
@@ -74,11 +75,14 @@ class VLLMEmbeddingModelStage(ProcessingStage[DocumentBatch, DocumentBatch]):
         self.text_field = text_field
         self.pretokenize = pretokenize
         self.embedding_field = embedding_field
+        self.embedding_output_dtype = embedding_output_dtype
         # Retained columns are opt-in so large source-text columns are not carried
         # alongside embeddings unless a caller explicitly requests them.
         self.metadata_fields = list(dict.fromkeys(metadata_fields or []))
         if model_inference_batch_size is not None and model_inference_batch_size < 0:
-            msg = f"model_inference_batch_size must be a non-negative integer or None, got {model_inference_batch_size}"
+            msg = (
+                f"model_inference_batch_size must be a non-negative integer or None, got {model_inference_batch_size}"
+            )
             raise ValueError(msg)
         self.model_inference_batch_size = model_inference_batch_size
         self.max_chars = max_chars
@@ -244,7 +248,7 @@ class VLLMEmbeddingModelStage(ProcessingStage[DocumentBatch, DocumentBatch]):
         elapsed = time.perf_counter() - t0
         chunk_embedding_matrix = np.asarray(
             [output.outputs.embedding for output in vllm_output],
-            dtype=np.float32,
+            dtype=self.embedding_output_dtype,
         )
         return chunk_embedding_matrix, {
             "vllm_embedding_time": elapsed,
@@ -264,7 +268,7 @@ class VLLMEmbeddingModelStage(ProcessingStage[DocumentBatch, DocumentBatch]):
         return input_table.select(self.metadata_fields)
 
     def _collect_embeddings(self, text_column: pa.ChunkedArray, num_rows: int) -> tuple[np.ndarray, dict[str, float]]:
-        """Embed bounded chunks and assemble one ordered float32 matrix."""
+        """Embed bounded chunks and assemble one ordered matrix."""
         embedding_matrix: np.ndarray | None = None
         tokenization_time = 0.0
         vllm_embedding_time = 0.0
@@ -280,7 +284,7 @@ class VLLMEmbeddingModelStage(ProcessingStage[DocumentBatch, DocumentBatch]):
             if embedding_matrix is None:
                 embedding_matrix = np.empty(
                     (num_rows, chunk_embedding_matrix.shape[1]),
-                    dtype=np.float32,
+                    dtype=self.embedding_output_dtype,
                 )
             embedding_matrix[offset : offset + chunk_size] = chunk_embedding_matrix
             del chunk_embedding_matrix
@@ -293,8 +297,12 @@ class VLLMEmbeddingModelStage(ProcessingStage[DocumentBatch, DocumentBatch]):
 
     @staticmethod
     def _to_arrow_embeddings(embedding_matrix: np.ndarray) -> pa.ListArray:
-        """Convert a dense float32 matrix to an Arrow list array."""
-        embedding_values = pa.array(embedding_matrix.reshape(-1), type=pa.float32(), from_pandas=False)
+        """Convert a dense matrix to an Arrow list array with the same dtype."""
+        embedding_values = pa.array(
+            embedding_matrix.reshape(-1),
+            type=pa.from_numpy_dtype(embedding_matrix.dtype),
+            from_pandas=False,
+        )
         embedding_offsets = pa.array(
             np.arange(
                 0,

--- a/nemo_curator/stages/text/embedders/vllm.py
+++ b/nemo_curator/stages/text/embedders/vllm.py
@@ -75,12 +75,10 @@ class VLLMEmbeddingModelStage(ProcessingStage[DocumentBatch, DocumentBatch]):
         self.text_field = text_field
         self.pretokenize = pretokenize
         self.embedding_field = embedding_field
+        # Retained columns are opt-in so large source-text columns are not carried
+        # alongside embeddings unless a caller explicitly requests them.
         self.metadata_fields = list(dict.fromkeys(metadata_fields or []))
-        if model_inference_batch_size is not None and (
-            isinstance(model_inference_batch_size, bool)
-            or not isinstance(model_inference_batch_size, int)
-            or model_inference_batch_size <= 0
-        ):
+        if model_inference_batch_size is not None and model_inference_batch_size <= 0:
             msg = f"model_inference_batch_size must be a positive integer or None, got {model_inference_batch_size}"
             raise ValueError(msg)
         self.model_inference_batch_size = model_inference_batch_size
@@ -184,20 +182,15 @@ class VLLMEmbeddingModelStage(ProcessingStage[DocumentBatch, DocumentBatch]):
         if not self.pretokenize:
             return input_data, 0.0
 
-        if self.tokenizer is None:
-            msg = "Tokenizer is not initialized. Please call setup() before processing or set pretokenize to False."
-            raise ValueError(msg)
-        if self.model is None:
-            msg = "vLLM model is not initialized. Please call setup() before processing."
-            raise ValueError(msg)
-
         from vllm.inputs import TokensPrompt
 
+        tokenizer = cast("AutoTokenizer", self.tokenizer)
+        model = cast("LLM", self.model)
         t0 = time.perf_counter()
-        tokenized_data = self.tokenizer.batch_encode_plus(
+        tokenized_data = tokenizer.batch_encode_plus(
             input_data,
             truncation=True,
-            max_length=self.model.model_config.max_model_len,
+            max_length=model.model_config.max_model_len,
         )
         prompts = [TokensPrompt(prompt_token_ids=ids) for ids in tokenized_data.input_ids]
         return prompts, time.perf_counter() - t0
@@ -207,10 +200,11 @@ class VLLMEmbeddingModelStage(ProcessingStage[DocumentBatch, DocumentBatch]):
     ) -> Iterator[tuple[int, int, list[Any], float]]:
         """Prepare one chunk ahead while the caller embeds the current chunk.
 
-        The sole executor worker tokenizes only the next chunk. ``Future.result``
-        blocks until that work is ready, so this generator does not poll or spin.
-        While the caller embeds a yielded chunk on the GPU, the worker prepares
-        the following chunk on the CPU.
+        One worker is intentional: this is a single-producer prefetch pipeline,
+        not parallel tokenization. While the caller embeds the current chunk on
+        the GPU, that worker prepares only the immediately following chunk on the
+        CPU. This overlaps CPU and GPU work without allowing an unbounded queue of
+        prepared chunks. ``Future.result`` blocks, so the generator never polls.
         """
         inference_batch_size = self.model_inference_batch_size or num_rows
         chunk_specs = iter(
@@ -244,12 +238,9 @@ class VLLMEmbeddingModelStage(ProcessingStage[DocumentBatch, DocumentBatch]):
             yield pending_offset, pending_chunk_size, input_data, tokenization_time
 
     def _embed_chunk(self, input_data: list[Any], expected_size: int) -> tuple[np.ndarray, dict[str, float]]:
-        if self.model is None:
-            msg = "vLLM model is not initialized. Please call setup() before processing."
-            raise ValueError(msg)
-
+        model = cast("LLM", self.model)
         t0 = time.perf_counter()
-        vllm_output = self.model.embed(
+        vllm_output = model.embed(
             input_data,
             tokenization_kwargs={"truncate_prompt_tokens": -1},
             use_tqdm=self.verbose,
@@ -268,7 +259,7 @@ class VLLMEmbeddingModelStage(ProcessingStage[DocumentBatch, DocumentBatch]):
             raise ValueError(msg)
         return chunk_embedding_matrix, {
             "vllm_embedding_time": elapsed,
-            "input_tokens": float(sum(len(output.prompt_token_ids) for output in vllm_output)),
+            "input_tokens": sum(len(output.prompt_token_ids) for output in vllm_output),
         }
 
     def _select_output_table(self, input_table: pa.Table) -> pa.Table:
@@ -288,7 +279,7 @@ class VLLMEmbeddingModelStage(ProcessingStage[DocumentBatch, DocumentBatch]):
         embedding_matrix: np.ndarray | None = None
         tokenization_time = 0.0
         vllm_embedding_time = 0.0
-        input_tokens = 0.0
+        input_tokens = 0
 
         for offset, chunk_size, input_data, chunk_tokenization_time in self._iter_prepared_chunks(
             text_column, num_rows
@@ -326,9 +317,6 @@ class VLLMEmbeddingModelStage(ProcessingStage[DocumentBatch, DocumentBatch]):
         return pa.ListArray.from_arrays(embedding_offsets, embedding_values)
 
     def process(self, batch: DocumentBatch) -> DocumentBatch:
-        if self.model is None:
-            msg = "vLLM model is not initialized. Please call setup() before processing."
-            raise ValueError(msg)
         input_table = batch.to_pyarrow()
         if input_table.num_rows == 0:
             msg = "Cannot generate embeddings for an empty document batch"

--- a/nemo_curator/stages/text/embedders/vllm.py
+++ b/nemo_curator/stages/text/embedders/vllm.py
@@ -12,10 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import gc
 import time
+from concurrent.futures import ThreadPoolExecutor
 from typing import TYPE_CHECKING, Any
 
+import numpy as np
+import pyarrow as pa
 import torch
 from huggingface_hub import snapshot_download
 
@@ -30,16 +35,22 @@ except ImportError:
         pass
 
 
-from nemo_curator.backends.base import NodeInfo, WorkerMetadata
 from nemo_curator.stages.base import ProcessingStage
 from nemo_curator.stages.resources import Resources
 from nemo_curator.stages.text.models.utils import format_name_with_suffix
 from nemo_curator.tasks import DocumentBatch
+from nemo_curator.utils.vllm_utils import create_vllm_llm_with_retry
 
 if TYPE_CHECKING:
+    from collections.abc import Iterator
+    from concurrent.futures import Future
+
     from transformers import AutoTokenizer
 
+    from nemo_curator.backends.base import NodeInfo, WorkerMetadata
+
 _VLLM_INSTALL_HINT = "vLLM is required for VLLMEmbeddingModelStage. Install with: pip install nemo_curator[vllm]"
+_EMBEDDING_MATRIX_NDIM = 2
 
 
 class VLLMEmbeddingModelStage(ProcessingStage[DocumentBatch, DocumentBatch]):
@@ -54,6 +65,9 @@ class VLLMEmbeddingModelStage(ProcessingStage[DocumentBatch, DocumentBatch]):
         cache_dir: str | None = None,
         hf_token: str | None = None,
         verbose: bool = False,
+        *,
+        metadata_fields: list[str] | None = None,
+        model_inference_batch_size: int = 10_000,
     ):
         self.model_identifier = model_identifier
         self.vllm_init_kwargs = vllm_init_kwargs or {}
@@ -61,6 +75,15 @@ class VLLMEmbeddingModelStage(ProcessingStage[DocumentBatch, DocumentBatch]):
         self.text_field = text_field
         self.pretokenize = pretokenize
         self.embedding_field = embedding_field
+        self.metadata_fields = list(dict.fromkeys(metadata_fields)) if metadata_fields is not None else None
+        if (
+            isinstance(model_inference_batch_size, bool)
+            or not isinstance(model_inference_batch_size, int)
+            or model_inference_batch_size <= 0
+        ):
+            msg = f"model_inference_batch_size must be a positive integer, got {model_inference_batch_size}"
+            raise ValueError(msg)
+        self.model_inference_batch_size = model_inference_batch_size
         self.max_chars = max_chars
 
         self.cache_dir = cache_dir
@@ -81,7 +104,10 @@ class VLLMEmbeddingModelStage(ProcessingStage[DocumentBatch, DocumentBatch]):
         return ["data"], [self.text_field]
 
     def outputs(self) -> tuple[list[str], list[str]]:
-        return ["data"], [self.text_field, self.embedding_field]
+        output_fields = list(self.metadata_fields) if self.metadata_fields is not None else [self.text_field]
+        if self.embedding_field not in output_fields:
+            output_fields.append(self.embedding_field)
+        return ["data"], output_fields
 
     def _initialize_vllm(self, local_files_only: bool) -> None:
         """Download (or locate) the model and initialize vLLM.
@@ -115,7 +141,7 @@ class VLLMEmbeddingModelStage(ProcessingStage[DocumentBatch, DocumentBatch]):
         if not self.verbose and "disable_log_stats" not in vllm_init_kwargs:
             vllm_init_kwargs["disable_log_stats"] = True
 
-        self.model = LLM(model=model_path, **vllm_init_kwargs)
+        self.model = create_vllm_llm_with_retry(model=model_path, **vllm_init_kwargs)
 
     def setup_on_node(self, node_info: NodeInfo | None = None, worker_metadata: WorkerMetadata | None = None) -> None:  # noqa: ARG002
         if not self.verbose:
@@ -149,27 +175,75 @@ class VLLMEmbeddingModelStage(ProcessingStage[DocumentBatch, DocumentBatch]):
                 local_files_only=True,
             )
 
-    def process(self, batch: DocumentBatch) -> DocumentBatch:
-        df = batch.to_pandas()
+    def _prepare_input_chunk(
+        self, text_column: pa.ChunkedArray, offset: int, chunk_size: int
+    ) -> tuple[list[Any], float]:
+        input_data = text_column.slice(offset, chunk_size).to_pylist()
         if self.max_chars is not None:
-            df[self.text_field] = df[self.text_field].str.slice(0, self.max_chars)
-        input_data = df[self.text_field].tolist()
-        metrics = {}
+            input_data = [text[: self.max_chars] if text is not None else None for text in input_data]
+        if not self.pretokenize:
+            return input_data, 0.0
 
-        if self.pretokenize:
-            from vllm.inputs import TokensPrompt
+        if self.tokenizer is None:
+            msg = "Tokenizer is not initialized. Please call setup() before processing or set pretokenize to False."
+            raise ValueError(msg)
+        if self.model is None:
+            msg = "vLLM model is not initialized. Please call setup() before processing."
+            raise ValueError(msg)
 
-            if self.tokenizer is None:
-                msg = (
-                    "Tokenizer is not initialized. Please call setup() before processing or set pretokenize to False."
-                )
-                raise ValueError(msg)
+        from vllm.inputs import TokensPrompt
 
-            t0 = time.perf_counter()
-            max_model_len = self.model.model_config.max_model_len
-            tokenized_data = self.tokenizer.batch_encode_plus(input_data, truncation=True, max_length=max_model_len)
-            input_data = [TokensPrompt(prompt_token_ids=ids) for ids in tokenized_data.input_ids]
-            metrics["tokenization_time"] = time.perf_counter() - t0
+        t0 = time.perf_counter()
+        tokenized_data = self.tokenizer.batch_encode_plus(
+            input_data,
+            truncation=True,
+            max_length=self.model.model_config.max_model_len,
+        )
+        prompts = [TokensPrompt(prompt_token_ids=ids) for ids in tokenized_data.input_ids]
+        return prompts, time.perf_counter() - t0
+
+    def _iter_prepared_chunks(
+        self, text_column: pa.ChunkedArray, num_rows: int
+    ) -> Iterator[tuple[int, int, list[Any], float]]:
+        """Prepare one chunk ahead while the caller embeds the current chunk."""
+        chunk_specs = iter(
+            (offset, min(self.model_inference_batch_size, num_rows - offset))
+            for offset in range(0, num_rows, self.model_inference_batch_size)
+        )
+        pending_offset, pending_chunk_size = next(chunk_specs)
+
+        with ThreadPoolExecutor(max_workers=1, thread_name_prefix="vllm-tokenizer") as executor:
+            pending_input: Future[tuple[list[Any], float]] = executor.submit(
+                self._prepare_input_chunk,
+                text_column,
+                pending_offset,
+                pending_chunk_size,
+            )
+            while True:
+                input_data, tokenization_time = pending_input.result()
+                try:
+                    next_offset, next_chunk_size = next(chunk_specs)
+                except StopIteration:
+                    next_input = None
+                else:
+                    next_input = executor.submit(
+                        self._prepare_input_chunk,
+                        text_column,
+                        next_offset,
+                        next_chunk_size,
+                    )
+
+                yield pending_offset, pending_chunk_size, input_data, tokenization_time
+                if next_input is None:
+                    break
+                pending_offset = next_offset
+                pending_chunk_size = next_chunk_size
+                pending_input = next_input
+
+    def _embed_chunk(self, input_data: list[Any], expected_size: int) -> tuple[np.ndarray, dict[str, float]]:
+        if self.model is None:
+            msg = "vLLM model is not initialized. Please call setup() before processing."
+            raise ValueError(msg)
 
         t0 = time.perf_counter()
         vllm_output = self.model.embed(
@@ -177,15 +251,110 @@ class VLLMEmbeddingModelStage(ProcessingStage[DocumentBatch, DocumentBatch]):
             tokenization_kwargs={"truncate_prompt_tokens": -1},
             use_tqdm=self.verbose,
         )
-        metrics["vllm_embedding_time"] = time.perf_counter() - t0
+        elapsed = time.perf_counter() - t0
+        if len(vllm_output) != expected_size:
+            msg = f"vLLM returned {len(vllm_output)} embeddings for a {expected_size}-row input chunk"
+            raise ValueError(msg)
 
-        df[self.embedding_field] = [e.outputs.embedding for e in vllm_output]
+        chunk_embedding_matrix = np.asarray(
+            [output.outputs.embedding for output in vllm_output],
+            dtype=np.float32,
+        )
+        if chunk_embedding_matrix.ndim != _EMBEDDING_MATRIX_NDIM:
+            msg = f"Expected a two-dimensional embedding matrix, got shape {chunk_embedding_matrix.shape}"
+            raise ValueError(msg)
+        return chunk_embedding_matrix, {
+            "vllm_embedding_time": elapsed,
+            "input_tokens": float(sum(len(output.prompt_token_ids) for output in vllm_output)),
+        }
+
+    def _select_output_table(self, input_table: pa.Table) -> pa.Table:
+        """Validate the input and select columns retained beside embeddings."""
+        if self.text_field not in input_table.column_names:
+            msg = f"Input batch is missing required text field {self.text_field!r}"
+            raise ValueError(msg)
+
+        metadata_fields = self.metadata_fields if self.metadata_fields is not None else input_table.column_names
+        missing_fields = [field for field in metadata_fields if field not in input_table.column_names]
+        if missing_fields:
+            msg = f"Input batch is missing metadata fields: {missing_fields}"
+            raise ValueError(msg)
+        return input_table.select(metadata_fields)
+
+    def _collect_embeddings(self, text_column: pa.ChunkedArray, num_rows: int) -> tuple[np.ndarray, dict[str, float]]:
+        """Embed bounded chunks and assemble one ordered float32 matrix."""
+        embedding_matrix: np.ndarray | None = None
+        tokenization_time = 0.0
+        vllm_embedding_time = 0.0
+        input_tokens = 0.0
+
+        for offset, chunk_size, input_data, chunk_tokenization_time in self._iter_prepared_chunks(
+            text_column, num_rows
+        ):
+            tokenization_time += chunk_tokenization_time
+            chunk_embedding_matrix, chunk_metrics = self._embed_chunk(input_data, chunk_size)
+            vllm_embedding_time += chunk_metrics["vllm_embedding_time"]
+            input_tokens += chunk_metrics["input_tokens"]
+            if embedding_matrix is None:
+                embedding_matrix = np.empty(
+                    (num_rows, chunk_embedding_matrix.shape[1]),
+                    dtype=np.float32,
+                )
+            elif embedding_matrix.shape[1] != chunk_embedding_matrix.shape[1]:
+                msg = (
+                    f"vLLM embedding dimension changed from {embedding_matrix.shape[1]} "
+                    f"to {chunk_embedding_matrix.shape[1]}"
+                )
+                raise ValueError(msg)
+            embedding_matrix[offset : offset + chunk_size] = chunk_embedding_matrix
+            del chunk_embedding_matrix
+
+        if embedding_matrix is None:
+            msg = "vLLM did not return embeddings for a non-empty document batch"
+            raise RuntimeError(msg)
+        return embedding_matrix, {
+            "tokenization_time": tokenization_time,
+            "vllm_embedding_time": vllm_embedding_time,
+            "input_tokens": input_tokens,
+        }
+
+    @staticmethod
+    def _to_arrow_embeddings(embedding_matrix: np.ndarray) -> pa.ListArray:
+        """Convert a dense float32 matrix to an Arrow list array."""
+        embedding_values = pa.array(embedding_matrix.reshape(-1), type=pa.float32(), from_pandas=False)
+        embedding_offsets = pa.array(
+            np.arange(
+                0,
+                (embedding_matrix.shape[0] + 1) * embedding_matrix.shape[1],
+                embedding_matrix.shape[1],
+                dtype=np.int64,
+            )
+        )
+        return pa.ListArray.from_arrays(embedding_offsets, embedding_values)
+
+    def process(self, batch: DocumentBatch) -> DocumentBatch:
+        if self.model is None:
+            msg = "vLLM model is not initialized. Please call setup() before processing."
+            raise ValueError(msg)
+        input_table = batch.to_pyarrow()
+        if input_table.num_rows == 0:
+            msg = "Cannot generate embeddings for an empty document batch"
+            raise ValueError(msg)
+
+        output_table = self._select_output_table(input_table)
+        embedding_matrix, metrics = self._collect_embeddings(input_table[self.text_field], input_table.num_rows)
+        embedding_array = self._to_arrow_embeddings(embedding_matrix)
+        if self.embedding_field in output_table.column_names:
+            embedding_index = output_table.column_names.index(self.embedding_field)
+            output_table = output_table.set_column(embedding_index, self.embedding_field, embedding_array)
+        else:
+            output_table = output_table.append_column(self.embedding_field, embedding_array)
 
         self._log_metrics(metrics)
 
         return DocumentBatch(
             dataset_name=batch.dataset_name,
-            data=df,
+            data=output_table,
             _metadata=batch._metadata,
             _stage_perf=batch._stage_perf,
         )

--- a/nemo_curator/stages/text/embedders/vllm.py
+++ b/nemo_curator/stages/text/embedders/vllm.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 import gc
 import time
 from concurrent.futures import ThreadPoolExecutor
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 import numpy as np
 import pyarrow as pa
@@ -285,28 +285,27 @@ class VLLMEmbeddingModelStage(ProcessingStage[DocumentBatch, DocumentBatch]):
 
     def _collect_embeddings(self, text_column: pa.ChunkedArray, num_rows: int) -> tuple[np.ndarray, dict[str, float]]:
         """Embed bounded chunks and assemble one ordered float32 matrix."""
-        prepared_chunks = iter(self._iter_prepared_chunks(text_column, num_rows))
-        first_offset, first_chunk_size, first_input_data, tokenization_time = next(prepared_chunks)
-        first_embedding_matrix, first_metrics = self._embed_chunk(first_input_data, first_chunk_size)
-        embedding_matrix = np.empty(
-            (num_rows, first_embedding_matrix.shape[1]),
-            dtype=np.float32,
-        )
-        embedding_matrix[first_offset : first_offset + first_chunk_size] = first_embedding_matrix
-        del first_embedding_matrix
+        embedding_matrix: np.ndarray | None = None
+        tokenization_time = 0.0
+        vllm_embedding_time = 0.0
+        input_tokens = 0.0
 
-        vllm_embedding_time = first_metrics["vllm_embedding_time"]
-        input_tokens = first_metrics["input_tokens"]
-
-        for offset, chunk_size, input_data, chunk_tokenization_time in prepared_chunks:
+        for offset, chunk_size, input_data, chunk_tokenization_time in self._iter_prepared_chunks(
+            text_column, num_rows
+        ):
             tokenization_time += chunk_tokenization_time
             chunk_embedding_matrix, chunk_metrics = self._embed_chunk(input_data, chunk_size)
             vllm_embedding_time += chunk_metrics["vllm_embedding_time"]
             input_tokens += chunk_metrics["input_tokens"]
+            if embedding_matrix is None:
+                embedding_matrix = np.empty(
+                    (num_rows, chunk_embedding_matrix.shape[1]),
+                    dtype=np.float32,
+                )
             embedding_matrix[offset : offset + chunk_size] = chunk_embedding_matrix
             del chunk_embedding_matrix
 
-        return embedding_matrix, {
+        return cast("np.ndarray", embedding_matrix), {
             "tokenization_time": tokenization_time,
             "vllm_embedding_time": vllm_embedding_time,
             "input_tokens": input_tokens,

--- a/nemo_curator/utils/vllm_utils.py
+++ b/nemo_curator/utils/vllm_utils.py
@@ -161,12 +161,6 @@ def create_vllm_llm(  # noqa: PLR0913
         (e.g. ``gpu_memory_utilization``, ``max_num_batched_tokens``). Keys here
         override the explicit defaults above when they collide.
     """
-    import os
-    import random
-    import time
-
-    from vllm import LLM
-
     if limit_mm_per_prompt is None:
         limit_mm_per_prompt = {"image": 1}
 
@@ -179,6 +173,17 @@ def create_vllm_llm(  # noqa: PLR0913
         "enforce_eager": enforce_eager,
         **extra_engine_kwargs,
     }
+
+    return create_vllm_llm_with_retry(max_port_retries=max_port_retries, **engine_kwargs)
+
+
+def create_vllm_llm_with_retry(*, max_port_retries: int = 3, **engine_kwargs: object) -> "vllm.LLM":  # noqa: F821,UP037
+    """Create a vLLM engine with port-collision retries and no added defaults."""
+    import os
+    import random
+    import time
+
+    from vllm import LLM
 
     for attempt in range(1, max_port_retries + 1):
         free_port = pick_free_port()

--- a/tests/stages/text/deduplication/test_semantic.py
+++ b/tests/stages/text/deduplication/test_semantic.py
@@ -104,6 +104,7 @@ def test_embedding_reader_extensions_default_to_input_filetype(
     workflow._run_embedding_generation(executor=object())
 
     assert captured_stages[0].file_extensions == expected_extensions
+    assert captured_stages[1].metadata_fields == [workflow.id_field]
 
 
 @pytest.mark.gpu

--- a/tests/stages/text/embedders/test_vllm.py
+++ b/tests/stages/text/embedders/test_vllm.py
@@ -184,9 +184,9 @@ class TestVLLMEmbeddingModelStage:
         class _RecordingStage(VLLMEmbeddingModelStage):
             embedded_chunk_sizes: list[int]
 
-            def _embed_chunk(self, input_data: list[Any], expected_size: int) -> tuple[np.ndarray, dict[str, float]]:
-                self.embedded_chunk_sizes.append(expected_size)
-                return super()._embed_chunk(input_data, expected_size)
+            def _embed_chunk(self, input_data: list[Any]) -> tuple[np.ndarray, dict[str, float]]:
+                self.embedded_chunk_sizes.append(len(input_data))
+                return super()._embed_chunk(input_data)
 
         input_table = sample_data.to_pyarrow()
         texts = input_table["text"].to_pylist()

--- a/tests/stages/text/embedders/test_vllm.py
+++ b/tests/stages/text/embedders/test_vllm.py
@@ -174,6 +174,19 @@ class TestVLLMEmbeddingModelStage:
             with pytest.raises(ValueError, match=message):
                 stage.process(DocumentBatch(dataset_name="test_dataset", data=table))
 
+    def test_arrow_embeddings_split_before_list_offset_limit(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        import nemo_curator.stages.text.embedders.vllm as _vllm_mod
+
+        monkeypatch.setattr(_vllm_mod, "_MAX_LIST_ARRAY_VALUES", 7)
+        embedding_matrix = np.arange(12, dtype=np.float32).reshape(4, 3)
+
+        embeddings = VLLMEmbeddingModelStage._to_arrow_embeddings(embedding_matrix)
+
+        assert isinstance(embeddings, pa.ChunkedArray)
+        assert [len(chunk) for chunk in embeddings.chunks] == [2, 2]
+        assert embeddings.type == pa.list_(pa.float32())
+        assert embeddings.to_pylist() == embedding_matrix.tolist()
+
     @pytest.mark.parametrize(
         "embedding_case",
         [(True, "float16", pa.float16()), (False, "float32", pa.float32())],
@@ -221,6 +234,7 @@ class TestVLLMEmbeddingModelStage:
             unbatched_result = vllm_stage.process(sample_data).to_pyarrow()
             unbatched_metrics = vllm_stage._consume_custom_metrics()
             assert vllm_stage.embedded_chunk_sizes == [5]
+            assert unbatched_result["embeddings"].num_chunks == 1
 
             unbatched_embeddings = np.asarray(unbatched_result["embeddings"].to_pylist())
             reference_embeddings = reference_model.encode(texts)
@@ -238,6 +252,7 @@ class TestVLLMEmbeddingModelStage:
                 metrics = vllm_stage._consume_custom_metrics()
 
                 assert vllm_stage.embedded_chunk_sizes == expected_chunk_sizes
+                assert result["embeddings"].num_chunks == len(expected_chunk_sizes)
                 assert result.column_names == ["id", "nested", "embeddings"]
                 for field_name in ["id", "nested"]:
                     assert result.schema.field(field_name).equals(input_table.schema.field(field_name))

--- a/tests/stages/text/embedders/test_vllm.py
+++ b/tests/stages/text/embedders/test_vllm.py
@@ -14,6 +14,7 @@
 
 from contextlib import suppress
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Any
 
 import pytest
@@ -25,12 +26,57 @@ with suppress(ImportError):
 
 import numpy as np
 import pandas as pd
+import pyarrow as pa
 import torch
 
 from nemo_curator.tasks import DocumentBatch
 
 # Test model that works with both VLLM and SentenceTransformer
 TEST_MODEL = "sentence-transformers/all-MiniLM-L6-v2"
+
+
+class _FakeTokenizer:
+    def __init__(self) -> None:
+        self.calls: list[list[str]] = []
+
+    def batch_encode_plus(
+        self,
+        input_data: list[str],
+        *,
+        truncation: bool,
+        max_length: int,
+    ) -> SimpleNamespace:
+        assert truncation is True
+        assert max_length == 512
+        self.calls.append(input_data)
+        return SimpleNamespace(input_ids=[[int(text), int(text) + 100] for text in input_data])
+
+
+class _FakeEmbeddingModel:
+    def __init__(self) -> None:
+        self.calls: list[list[int]] = []
+        self.model_config = SimpleNamespace(max_model_len=512)
+
+    def embed(
+        self,
+        input_data: list[Any],
+        *,
+        tokenization_kwargs: dict[str, int],
+        use_tqdm: bool,
+    ) -> list[SimpleNamespace]:
+        assert tokenization_kwargs == {"truncate_prompt_tokens": -1}
+        assert use_tqdm is False
+        row_ids = [
+            int(prompt["prompt_token_ids"][0]) if isinstance(prompt, dict) else int(prompt) for prompt in input_data
+        ]
+        self.calls.append(row_ids)
+        return [
+            SimpleNamespace(
+                prompt_token_ids=[row_id, row_id + 100],
+                outputs=SimpleNamespace(embedding=[float(row_id), 1.0]),
+            )
+            for row_id in row_ids
+        ]
 
 
 @pytest.fixture
@@ -58,6 +104,8 @@ class TestVLLMEmbeddingModelStage:
         assert stage.model_identifier == TEST_MODEL
         assert stage.text_field == "text"
         assert stage.embedding_field == "embeddings"
+        assert stage.metadata_fields is None
+        assert stage.model_inference_batch_size == 10_000
         assert stage.pretokenize is True
         assert stage.verbose is False
         assert stage.model is None
@@ -72,6 +120,8 @@ class TestVLLMEmbeddingModelStage:
             model_identifier=TEST_MODEL,
             text_field="content",
             embedding_field="emb",
+            metadata_fields=["id", "content", "id"],
+            model_inference_batch_size=17,
             pretokenize=True,
             cache_dir="/tmp/cache",  # noqa: S108
             hf_token="test-token",  # noqa: S106
@@ -81,16 +131,40 @@ class TestVLLMEmbeddingModelStage:
         assert stage.model_identifier == TEST_MODEL
         assert stage.text_field == "content"
         assert stage.embedding_field == "emb"
+        assert stage.metadata_fields == ["id", "content"]
+        assert stage.model_inference_batch_size == 17
         assert stage.pretokenize is True
         assert stage.cache_dir == "/tmp/cache"  # noqa: S108
         assert stage.hf_token == "test-token"  # noqa: S105
         assert stage.verbose is True
 
         assert stage.inputs() == (["data"], ["content"])
-        assert stage.outputs() == (["data"], ["content", "emb"])
+        assert stage.outputs() == (["data"], ["id", "content", "emb"])
 
         assert stage.resources.gpus == 1
         assert stage.resources.cpus == 1
+
+    def test_new_options_preserve_existing_positional_arguments(self) -> None:
+        stage = VLLMEmbeddingModelStage(
+            TEST_MODEL,
+            {"gpu_memory_utilization": 0.5},
+            "content",
+            False,
+            "vector",
+            123,
+            "/tmp/cache",  # noqa: S108
+            "test-token",
+            True,
+        )
+
+        assert stage.vllm_init_kwargs == {"gpu_memory_utilization": 0.5}
+        assert stage.text_field == "content"
+        assert stage.pretokenize is False
+        assert stage.embedding_field == "vector"
+        assert stage.max_chars == 123
+        assert stage.cache_dir == "/tmp/cache"  # noqa: S108
+        assert stage.hf_token == "test-token"  # noqa: S105
+        assert stage.verbose is True
 
     def test_llm_uses_cache_dir_for_download(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
         """Ensure vLLM receives download_dir so weights reuse snapshot cache."""
@@ -123,14 +197,14 @@ class TestVLLMEmbeddingModelStage:
             )
             return f"/resolved/snapshots/{model_identifier}"
 
-        class _FakeLLM:
-            def __init__(self, model: str, **kwargs: Any) -> None:  # noqa: ANN401
-                captured["llm"] = {"model": model, "kwargs": kwargs}
+        def _fake_create_vllm_llm_with_retry(*, model: str, **kwargs: Any) -> object:  # noqa: ANN401
+            captured["llm"] = {"model": model, "kwargs": kwargs}
+            return object()
 
         import nemo_curator.stages.text.embedders.vllm as _vllm_mod
 
         monkeypatch.setattr(_vllm_mod, "snapshot_download", _fake_snapshot_download)
-        monkeypatch.setattr(_vllm_mod, "LLM", _FakeLLM)
+        monkeypatch.setattr(_vllm_mod, "create_vllm_llm_with_retry", _fake_create_vllm_llm_with_retry)
 
         stage.setup_on_node()
 
@@ -143,6 +217,317 @@ class TestVLLMEmbeddingModelStage:
         # vLLM receives the resolved snapshot path (not the repo ID)
         assert captured["llm"]["model"] == f"/resolved/snapshots/{TEST_MODEL}"
         assert captured["llm"]["kwargs"]["download_dir"] == str(cache_dir)
+
+    @pytest.mark.parametrize("batch_size", [None, True, 1.5, 0, -1])
+    def test_rejects_invalid_model_inference_batch_size(self, batch_size: Any) -> None:  # noqa: ANN401
+        with pytest.raises(ValueError, match="model_inference_batch_size must be a positive integer"):
+            VLLMEmbeddingModelStage(
+                model_identifier=TEST_MODEL,
+                model_inference_batch_size=batch_size,
+            )
+
+    @pytest.mark.parametrize("pretokenize", [True, False])
+    def test_process_rejects_uninitialized_model(self, pretokenize: bool) -> None:
+        stage = VLLMEmbeddingModelStage(model_identifier=TEST_MODEL, pretokenize=pretokenize)
+        batch = DocumentBatch(dataset_name="test_dataset", data=pa.table({"text": ["first"]}))
+
+        with pytest.raises(ValueError, match="vLLM model is not initialized"):
+            stage.process(batch)
+
+    def test_process_rejects_empty_batch(self) -> None:
+        stage = VLLMEmbeddingModelStage(model_identifier=TEST_MODEL, pretokenize=False)
+        stage.model = SimpleNamespace()
+        batch = DocumentBatch(
+            dataset_name="test_dataset",
+            data=pa.table({"text": pa.array([], type=pa.string())}),
+        )
+
+        with pytest.raises(ValueError, match="empty document batch"):
+            stage.process(batch)
+
+    def test_process_rejects_uninitialized_tokenizer(self) -> None:
+        stage = VLLMEmbeddingModelStage(model_identifier=TEST_MODEL, pretokenize=True)
+        stage.model = _FakeEmbeddingModel()  # type: ignore[assignment]
+        batch = DocumentBatch(dataset_name="test_dataset", data=pa.table({"text": ["0"]}))
+
+        with pytest.raises(ValueError, match="Tokenizer is not initialized"):
+            stage.process(batch)
+
+    @pytest.mark.parametrize("pretokenize", [True, False])
+    def test_process_chunks_rows_in_both_pretokenization_modes(self, pretokenize: bool) -> None:
+        stage = VLLMEmbeddingModelStage(
+            model_identifier=TEST_MODEL,
+            pretokenize=pretokenize,
+            metadata_fields=["id"],
+            model_inference_batch_size=2,
+        )
+        model = _FakeEmbeddingModel()
+        tokenizer = _FakeTokenizer()
+        stage.model = model  # type: ignore[assignment]
+        stage.tokenizer = tokenizer  # type: ignore[assignment]
+        batch = DocumentBatch(
+            dataset_name="test_dataset",
+            data=pa.table({"text": ["0", "1", "2", "3", "4"], "id": [10, 11, 12, 13, 14]}),
+        )
+
+        result = stage.process(batch)
+
+        assert model.calls == [[0, 1], [2, 3], [4]]
+        assert tokenizer.calls == ([["0", "1"], ["2", "3"], ["4"]] if pretokenize else [])
+        assert isinstance(result.data, pa.Table)
+        assert result.data.column_names == ["id", "embeddings"]
+        assert result.data["id"].to_pylist() == [10, 11, 12, 13, 14]
+        assert result.data["embeddings"].to_pylist() == [
+            [0.0, 1.0],
+            [1.0, 1.0],
+            [2.0, 1.0],
+            [3.0, 1.0],
+            [4.0, 1.0],
+        ]
+
+    def test_process_preserves_configured_arrow_columns_without_pandas(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        input_table = pa.table(
+            {
+                "id": pa.array([7, 8], type=pa.int64()),
+                "text": pa.array(["00", "11"], type=pa.string()),
+                "nullable": pa.array(["value", None], type=pa.string()),
+                "nested": pa.array([[1, 2], None], type=pa.list_(pa.int32())),
+            }
+        )
+        batch = DocumentBatch(dataset_name="test_dataset", data=input_table)
+
+        def _fail_to_pandas() -> None:
+            pytest.fail("Arrow input must not be converted to pandas")
+
+        monkeypatch.setattr(batch, "to_pandas", _fail_to_pandas)
+        stage = VLLMEmbeddingModelStage(
+            model_identifier=TEST_MODEL,
+            pretokenize=False,
+            metadata_fields=["nested", "nullable", "text", "id"],
+            model_inference_batch_size=1,
+            max_chars=1,
+        )
+        model = _FakeEmbeddingModel()
+        stage.model = model  # type: ignore[assignment]
+
+        result = stage.process(batch)
+
+        assert isinstance(result.data, pa.Table)
+        assert result.data.column_names == ["nested", "nullable", "text", "id", "embeddings"]
+        assert model.calls == [[0], [1]]
+        for field_name in ["nested", "nullable", "text", "id"]:
+            assert result.data.schema.field(field_name).equals(input_table.schema.field(field_name))
+            assert result.data[field_name].equals(input_table[field_name])
+        assert result.data.schema.field("embeddings").type == pa.list_(pa.float32())
+
+    def test_process_prepares_exactly_one_chunk_ahead(self) -> None:
+        from threading import Event
+
+        second_chunk_prepared = Event()
+        third_chunk_prepared = Event()
+
+        class _TrackingStage(VLLMEmbeddingModelStage):
+            def _prepare_input_chunk(
+                self,
+                text_column: pa.ChunkedArray,
+                offset: int,
+                chunk_size: int,
+            ) -> tuple[list[Any], float]:
+                prepared = super()._prepare_input_chunk(text_column, offset, chunk_size)
+                if offset == 2:
+                    second_chunk_prepared.set()
+                elif offset == 4:
+                    third_chunk_prepared.set()
+                return prepared
+
+        class _TrackingModel(_FakeEmbeddingModel):
+            def embed(
+                self,
+                input_data: list[Any],
+                *,
+                tokenization_kwargs: dict[str, int],
+                use_tqdm: bool,
+            ) -> list[SimpleNamespace]:
+                if not self.calls:
+                    assert second_chunk_prepared.wait(timeout=2)
+                    assert not third_chunk_prepared.is_set()
+                return super().embed(
+                    input_data,
+                    tokenization_kwargs=tokenization_kwargs,
+                    use_tqdm=use_tqdm,
+                )
+
+        stage = _TrackingStage(
+            model_identifier=TEST_MODEL,
+            pretokenize=False,
+            model_inference_batch_size=2,
+        )
+        model = _TrackingModel()
+        stage.model = model  # type: ignore[assignment]
+        batch = DocumentBatch(
+            dataset_name="test_dataset",
+            data=pa.table({"text": ["0", "1", "2", "3", "4"]}),
+        )
+
+        stage.process(batch)
+
+        assert model.calls == [[0, 1], [2, 3], [4]]
+        assert third_chunk_prepared.is_set()
+
+    @pytest.mark.parametrize(
+        ("table", "metadata_fields", "message"),
+        [
+            (pa.table({"id": [1]}), None, "missing required text field"),
+            (pa.table({"text": ["first"], "id": [1]}), ["id", "source"], "missing metadata fields"),
+        ],
+    )
+    def test_process_rejects_missing_fields(
+        self,
+        table: pa.Table,
+        metadata_fields: list[str] | None,
+        message: str,
+    ) -> None:
+        stage = VLLMEmbeddingModelStage(
+            model_identifier=TEST_MODEL,
+            pretokenize=False,
+            metadata_fields=metadata_fields,
+        )
+        stage.model = SimpleNamespace()
+
+        with pytest.raises(ValueError, match=message):
+            stage.process(DocumentBatch(dataset_name="test_dataset", data=table))
+
+    def test_process_reports_aggregate_chunk_metrics(self) -> None:
+        class _TimedPreparationStage(VLLMEmbeddingModelStage):
+            def _prepare_input_chunk(
+                self,
+                text_column: pa.ChunkedArray,
+                offset: int,
+                chunk_size: int,
+            ) -> tuple[list[Any], float]:
+                input_data, _ = super()._prepare_input_chunk(text_column, offset, chunk_size)
+                return input_data, 0.25
+
+            def _embed_chunk(
+                self,
+                input_data: list[Any],
+                expected_size: int,
+            ) -> tuple[np.ndarray, dict[str, float]]:
+                embedding_matrix, metrics = super()._embed_chunk(input_data, expected_size)
+                metrics["vllm_embedding_time"] = 0.5
+                return embedding_matrix, metrics
+
+        stage = _TimedPreparationStage(
+            model_identifier=TEST_MODEL,
+            pretokenize=False,
+            metadata_fields=["text"],
+            model_inference_batch_size=2,
+        )
+        stage.model = _FakeEmbeddingModel()  # type: ignore[assignment]
+        batch = DocumentBatch(
+            dataset_name="test_dataset",
+            data=pa.table({"text": ["0", "1", "2", "3", "4"]}),
+        )
+
+        result = stage.process(batch)
+        metrics = stage._consume_custom_metrics()
+
+        assert result.num_items == 5
+        assert metrics["tokenization_time"] == 0.75
+        assert metrics["input_tokens"] == 10
+        assert metrics["vllm_embedding_time"] == 1.5
+
+    def test_process_rejects_wrong_vllm_output_count(self) -> None:
+        class _ShortOutputModel(_FakeEmbeddingModel):
+            def embed(
+                self,
+                input_data: list[Any],
+                *,
+                tokenization_kwargs: dict[str, int],
+                use_tqdm: bool,
+            ) -> list[SimpleNamespace]:
+                return super().embed(
+                    input_data,
+                    tokenization_kwargs=tokenization_kwargs,
+                    use_tqdm=use_tqdm,
+                )[:-1]
+
+        stage = VLLMEmbeddingModelStage(model_identifier=TEST_MODEL, pretokenize=False)
+        stage.model = _ShortOutputModel()  # type: ignore[assignment]
+
+        with pytest.raises(ValueError, match="returned 1 embeddings for a 2-row input chunk"):
+            stage.process(DocumentBatch(dataset_name="test_dataset", data=pa.table({"text": ["0", "1"]})))
+
+    def test_process_rejects_non_matrix_embeddings(self) -> None:
+        class _ScalarEmbeddingModel(_FakeEmbeddingModel):
+            def embed(
+                self,
+                input_data: list[Any],
+                *,
+                tokenization_kwargs: dict[str, int],
+                use_tqdm: bool,
+            ) -> list[SimpleNamespace]:
+                outputs = super().embed(
+                    input_data,
+                    tokenization_kwargs=tokenization_kwargs,
+                    use_tqdm=use_tqdm,
+                )
+                for output in outputs:
+                    output.outputs.embedding = 1.0
+                return outputs
+
+        stage = VLLMEmbeddingModelStage(model_identifier=TEST_MODEL, pretokenize=False)
+        stage.model = _ScalarEmbeddingModel()  # type: ignore[assignment]
+
+        with pytest.raises(ValueError, match="two-dimensional embedding matrix"):
+            stage.process(DocumentBatch(dataset_name="test_dataset", data=pa.table({"text": ["0"]})))
+
+    def test_process_rejects_embedding_dimension_changes(self) -> None:
+        class _ChangingDimensionModel(_FakeEmbeddingModel):
+            def embed(
+                self,
+                input_data: list[Any],
+                *,
+                tokenization_kwargs: dict[str, int],
+                use_tqdm: bool,
+            ) -> list[SimpleNamespace]:
+                outputs = super().embed(
+                    input_data,
+                    tokenization_kwargs=tokenization_kwargs,
+                    use_tqdm=use_tqdm,
+                )
+                if len(self.calls) == 2:
+                    outputs[0].outputs.embedding.append(2.0)
+                return outputs
+
+        stage = VLLMEmbeddingModelStage(
+            model_identifier=TEST_MODEL,
+            pretokenize=False,
+            model_inference_batch_size=1,
+        )
+        stage.model = _ChangingDimensionModel()  # type: ignore[assignment]
+
+        with pytest.raises(ValueError, match="embedding dimension changed from 2 to 3"):
+            stage.process(DocumentBatch(dataset_name="test_dataset", data=pa.table({"text": ["0", "1"]})))
+
+    def test_process_replaces_selected_embedding_field_in_place(self) -> None:
+        stage = VLLMEmbeddingModelStage(
+            model_identifier=TEST_MODEL,
+            pretokenize=False,
+            metadata_fields=["id", "embeddings", "text"],
+        )
+        stage.model = _FakeEmbeddingModel()  # type: ignore[assignment]
+        batch = DocumentBatch(
+            dataset_name="test_dataset",
+            data=pa.table({"text": ["0"], "id": [7], "embeddings": [[99]]}),
+        )
+
+        result = stage.process(batch)
+
+        assert stage.outputs() == (["data"], ["id", "embeddings", "text"])
+        assert result.data.column_names == ["id", "embeddings", "text"]
+        assert result.data["embeddings"].to_pylist() == [[0.0, 1.0]]
+        assert result.data.schema.field("embeddings").type == pa.list_(pa.float32())
 
     @pytest.mark.parametrize("pretokenize", [True, False])
     def test_vllm_produces_valid_embeddings(

--- a/tests/stages/text/embedders/test_vllm.py
+++ b/tests/stages/text/embedders/test_vllm.py
@@ -63,6 +63,7 @@ class TestVLLMEmbeddingModelStage:
         assert stage.model_identifier == TEST_MODEL
         assert stage.text_field == "text"
         assert stage.embedding_field == "embeddings"
+        assert stage.embedding_output_dtype == "float32"
         assert stage.metadata_fields == []
         assert stage.model_inference_batch_size == 8192
         assert stage.pretokenize is True
@@ -79,6 +80,7 @@ class TestVLLMEmbeddingModelStage:
             model_identifier=TEST_MODEL,
             text_field="content",
             embedding_field="emb",
+            embedding_output_dtype="float16",
             metadata_fields=["id", "content", "id"],
             model_inference_batch_size=17,
             pretokenize=True,
@@ -90,6 +92,7 @@ class TestVLLMEmbeddingModelStage:
         assert stage.model_identifier == TEST_MODEL
         assert stage.text_field == "content"
         assert stage.embedding_field == "emb"
+        assert stage.embedding_output_dtype == "float16"
         assert stage.metadata_fields == ["id", "content"]
         assert stage.model_inference_batch_size == 17
         assert stage.pretokenize is True
@@ -171,15 +174,20 @@ class TestVLLMEmbeddingModelStage:
             with pytest.raises(ValueError, match=message):
                 stage.process(DocumentBatch(dataset_name="test_dataset", data=table))
 
-    @pytest.mark.parametrize("pretokenize", [True, False])
+    @pytest.mark.parametrize(
+        "embedding_case",
+        [(True, "float16", pa.float16()), (False, "float32", pa.float32())],
+        ids=["pretokenized-float16", "raw-text-float32"],
+    )
     def test_process_batches_real_model_equivalent_to_unbatched(
         self,
         sample_data: DocumentBatch,
-        pretokenize: bool,
+        embedding_case: tuple[bool, str, pa.DataType],
         reference_model: "SentenceTransformer",
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         """Bounded batches preserve embeddings, Arrow metadata, and aggregate metrics."""
+        pretokenize, embedding_output_dtype, arrow_dtype = embedding_case
 
         class _RecordingStage(VLLMEmbeddingModelStage):
             embedded_chunk_sizes: list[int]
@@ -198,6 +206,7 @@ class TestVLLMEmbeddingModelStage:
         vllm_stage = _RecordingStage(
             model_identifier=TEST_MODEL,
             pretokenize=pretokenize,
+            embedding_output_dtype=embedding_output_dtype,
             metadata_fields=["id", "nested"],
             model_inference_batch_size=None,
             verbose=False,
@@ -218,7 +227,8 @@ class TestVLLMEmbeddingModelStage:
             cosine_sim = torch.nn.functional.cosine_similarity(
                 torch.tensor(unbatched_embeddings), torch.tensor(reference_embeddings), dim=1
             )
-            assert torch.allclose(cosine_sim, torch.ones_like(cosine_sim), atol=1e-5)
+            reference_atol = 5e-5 if embedding_output_dtype == "float16" else 1e-5
+            assert torch.allclose(cosine_sim, torch.ones_like(cosine_sim), atol=reference_atol)
 
             for batch_size, expected_chunk_sizes in [(2, [2, 2, 1]), (3, [3, 2])]:
                 vllm_stage.model_inference_batch_size = batch_size
@@ -232,7 +242,7 @@ class TestVLLMEmbeddingModelStage:
                 for field_name in ["id", "nested"]:
                     assert result.schema.field(field_name).equals(input_table.schema.field(field_name))
                     assert result[field_name].equals(input_table[field_name])
-                assert result.schema.field("embeddings").type == pa.list_(pa.float32())
+                assert result.schema.field("embeddings").type == pa.list_(arrow_dtype)
                 batched_embeddings = np.asarray(result["embeddings"].to_pylist())
                 batch_cosine_sim = torch.nn.functional.cosine_similarity(
                     torch.tensor(batched_embeddings), torch.tensor(unbatched_embeddings), dim=1

--- a/tests/stages/text/embedders/test_vllm.py
+++ b/tests/stages/text/embedders/test_vllm.py
@@ -14,7 +14,6 @@
 
 from contextlib import suppress
 from pathlib import Path
-from types import SimpleNamespace
 from typing import Any
 
 import pytest
@@ -25,7 +24,6 @@ with suppress(ImportError):
     from nemo_curator.stages.text.embedders.vllm import VLLMEmbeddingModelStage
 
 import numpy as np
-import pandas as pd
 import pyarrow as pa
 import torch
 
@@ -35,55 +33,16 @@ from nemo_curator.tasks import DocumentBatch
 TEST_MODEL = "sentence-transformers/all-MiniLM-L6-v2"
 
 
-class _FakeTokenizer:
-    def __init__(self) -> None:
-        self.calls: list[list[str]] = []
-
-    def batch_encode_plus(
-        self,
-        input_data: list[str],
-        *,
-        truncation: bool,
-        max_length: int,
-    ) -> SimpleNamespace:
-        assert truncation is True
-        assert max_length == 512
-        self.calls.append(input_data)
-        return SimpleNamespace(input_ids=[[int(text), int(text) + 100] for text in input_data])
-
-
-class _FakeEmbeddingModel:
-    def __init__(self) -> None:
-        self.calls: list[list[int]] = []
-        self.model_config = SimpleNamespace(max_model_len=512)
-
-    def embed(
-        self,
-        input_data: list[Any],
-        *,
-        tokenization_kwargs: dict[str, int],
-        use_tqdm: bool,
-    ) -> list[SimpleNamespace]:
-        assert tokenization_kwargs == {"truncate_prompt_tokens": -1}
-        assert use_tqdm is False
-        row_ids = [
-            int(prompt["prompt_token_ids"][0]) if isinstance(prompt, dict) else int(prompt) for prompt in input_data
-        ]
-        self.calls.append(row_ids)
-        return [
-            SimpleNamespace(
-                prompt_token_ids=[row_id, row_id + 100],
-                outputs=SimpleNamespace(embedding=[float(row_id), 1.0]),
-            )
-            for row_id in row_ids
-        ]
-
-
 @pytest.fixture
 def sample_data() -> DocumentBatch:
     """Create sample text data for testing."""
-    texts = ["Hello world", "This is a test", "Machine learning is great"]
-    data = pd.DataFrame({"text": texts})
+    data = pa.table(
+        {
+            "id": pa.array([10, 11, 12, 13, 14], type=pa.int64()),
+            "text": ["Hello world", "This is a test", "Machine learning is great", "A fourth row", "Final row"],
+            "nested": pa.array([[1, 2], None, [3], [], [4, 5]], type=pa.list_(pa.int32())),
+        }
+    )
     return DocumentBatch(dataset_name="test_dataset", data=data)
 
 
@@ -104,15 +63,15 @@ class TestVLLMEmbeddingModelStage:
         assert stage.model_identifier == TEST_MODEL
         assert stage.text_field == "text"
         assert stage.embedding_field == "embeddings"
-        assert stage.metadata_fields is None
-        assert stage.model_inference_batch_size == 10_000
+        assert stage.metadata_fields == []
+        assert stage.model_inference_batch_size == 8192
         assert stage.pretokenize is True
         assert stage.verbose is False
         assert stage.model is None
         assert stage.tokenizer is None
 
         assert stage.inputs() == (["data"], ["text"])
-        assert stage.outputs() == (["data"], ["text", "embeddings"])
+        assert stage.outputs() == (["data"], ["embeddings"])
 
     def test_custom_initialization(self) -> None:
         """Test initialization with custom parameters."""
@@ -143,28 +102,6 @@ class TestVLLMEmbeddingModelStage:
 
         assert stage.resources.gpus == 1
         assert stage.resources.cpus == 1
-
-    def test_new_options_preserve_existing_positional_arguments(self) -> None:
-        stage = VLLMEmbeddingModelStage(
-            TEST_MODEL,
-            {"gpu_memory_utilization": 0.5},
-            "content",
-            False,
-            "vector",
-            123,
-            "/tmp/cache",  # noqa: S108
-            "test-token",
-            True,
-        )
-
-        assert stage.vllm_init_kwargs == {"gpu_memory_utilization": 0.5}
-        assert stage.text_field == "content"
-        assert stage.pretokenize is False
-        assert stage.embedding_field == "vector"
-        assert stage.max_chars == 123
-        assert stage.cache_dir == "/tmp/cache"  # noqa: S108
-        assert stage.hf_token == "test-token"  # noqa: S105
-        assert stage.verbose is True
 
     def test_llm_uses_cache_dir_for_download(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
         """Ensure vLLM receives download_dir so weights reuse snapshot cache."""
@@ -218,325 +155,51 @@ class TestVLLMEmbeddingModelStage:
         assert captured["llm"]["model"] == f"/resolved/snapshots/{TEST_MODEL}"
         assert captured["llm"]["kwargs"]["download_dir"] == str(cache_dir)
 
-    @pytest.mark.parametrize("batch_size", [None, True, 1.5, 0, -1])
-    def test_rejects_invalid_model_inference_batch_size(self, batch_size: Any) -> None:  # noqa: ANN401
-        with pytest.raises(ValueError, match="model_inference_batch_size must be a positive integer"):
-            VLLMEmbeddingModelStage(
-                model_identifier=TEST_MODEL,
-                model_inference_batch_size=batch_size,
-            )
-
-    @pytest.mark.parametrize("pretokenize", [True, False])
-    def test_process_rejects_uninitialized_model(self, pretokenize: bool) -> None:
-        stage = VLLMEmbeddingModelStage(model_identifier=TEST_MODEL, pretokenize=pretokenize)
-        batch = DocumentBatch(dataset_name="test_dataset", data=pa.table({"text": ["first"]}))
-
-        with pytest.raises(ValueError, match="vLLM model is not initialized"):
-            stage.process(batch)
-
-    def test_process_rejects_empty_batch(self) -> None:
-        stage = VLLMEmbeddingModelStage(model_identifier=TEST_MODEL, pretokenize=False)
-        stage.model = SimpleNamespace()
-        batch = DocumentBatch(
-            dataset_name="test_dataset",
-            data=pa.table({"text": pa.array([], type=pa.string())}),
-        )
-
-        with pytest.raises(ValueError, match="empty document batch"):
-            stage.process(batch)
-
-    def test_process_rejects_uninitialized_tokenizer(self) -> None:
-        stage = VLLMEmbeddingModelStage(model_identifier=TEST_MODEL, pretokenize=True)
-        stage.model = _FakeEmbeddingModel()  # type: ignore[assignment]
-        batch = DocumentBatch(dataset_name="test_dataset", data=pa.table({"text": ["0"]}))
-
-        with pytest.raises(ValueError, match="Tokenizer is not initialized"):
-            stage.process(batch)
-
-    @pytest.mark.parametrize("pretokenize", [True, False])
-    def test_process_chunks_rows_in_both_pretokenization_modes(self, pretokenize: bool) -> None:
-        stage = VLLMEmbeddingModelStage(
-            model_identifier=TEST_MODEL,
-            pretokenize=pretokenize,
-            metadata_fields=["id"],
-            model_inference_batch_size=2,
-        )
-        model = _FakeEmbeddingModel()
-        tokenizer = _FakeTokenizer()
-        stage.model = model  # type: ignore[assignment]
-        stage.tokenizer = tokenizer  # type: ignore[assignment]
-        batch = DocumentBatch(
-            dataset_name="test_dataset",
-            data=pa.table({"text": ["0", "1", "2", "3", "4"], "id": [10, 11, 12, 13, 14]}),
-        )
-
-        result = stage.process(batch)
-
-        assert model.calls == [[0, 1], [2, 3], [4]]
-        assert tokenizer.calls == ([["0", "1"], ["2", "3"], ["4"]] if pretokenize else [])
-        assert isinstance(result.data, pa.Table)
-        assert result.data.column_names == ["id", "embeddings"]
-        assert result.data["id"].to_pylist() == [10, 11, 12, 13, 14]
-        assert result.data["embeddings"].to_pylist() == [
-            [0.0, 1.0],
-            [1.0, 1.0],
-            [2.0, 1.0],
-            [3.0, 1.0],
-            [4.0, 1.0],
+    def test_process_rejects_invalid_configurations(self) -> None:
+        invalid_configurations = [
+            (pa.table({"id": [1]}), None, "missing required text field"),
+            (pa.table({"text": ["first"], "id": [1]}), ["id", "source"], "missing metadata fields"),
         ]
+        for table, metadata_fields, message in invalid_configurations:
+            stage = VLLMEmbeddingModelStage(
+                model_identifier=TEST_MODEL,
+                pretokenize=False,
+                metadata_fields=metadata_fields,
+            )
+            stage.model = object()  # type: ignore[assignment]
 
-    def test_process_preserves_configured_arrow_columns_without_pandas(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        input_table = pa.table(
-            {
-                "id": pa.array([7, 8], type=pa.int64()),
-                "text": pa.array(["00", "11"], type=pa.string()),
-                "nullable": pa.array(["value", None], type=pa.string()),
-                "nested": pa.array([[1, 2], None], type=pa.list_(pa.int32())),
-            }
-        )
-        batch = DocumentBatch(dataset_name="test_dataset", data=input_table)
+            with pytest.raises(ValueError, match=message):
+                stage.process(DocumentBatch(dataset_name="test_dataset", data=table))
+
+    @pytest.mark.parametrize("pretokenize", [True, False])
+    def test_process_batches_real_model_equivalent_to_unbatched(
+        self,
+        sample_data: DocumentBatch,
+        pretokenize: bool,
+        reference_model: "SentenceTransformer",
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Bounded batches preserve embeddings, Arrow metadata, and aggregate metrics."""
+
+        class _RecordingStage(VLLMEmbeddingModelStage):
+            embedded_chunk_sizes: list[int]
+
+            def _embed_chunk(self, input_data: list[Any], expected_size: int) -> tuple[np.ndarray, dict[str, float]]:
+                self.embedded_chunk_sizes.append(expected_size)
+                return super()._embed_chunk(input_data, expected_size)
+
+        input_table = sample_data.to_pyarrow()
+        texts = input_table["text"].to_pylist()
 
         def _fail_to_pandas() -> None:
             pytest.fail("Arrow input must not be converted to pandas")
 
-        monkeypatch.setattr(batch, "to_pandas", _fail_to_pandas)
-        stage = VLLMEmbeddingModelStage(
-            model_identifier=TEST_MODEL,
-            pretokenize=False,
-            metadata_fields=["nested", "nullable", "text", "id"],
-            model_inference_batch_size=1,
-            max_chars=1,
-        )
-        model = _FakeEmbeddingModel()
-        stage.model = model  # type: ignore[assignment]
-
-        result = stage.process(batch)
-
-        assert isinstance(result.data, pa.Table)
-        assert result.data.column_names == ["nested", "nullable", "text", "id", "embeddings"]
-        assert model.calls == [[0], [1]]
-        for field_name in ["nested", "nullable", "text", "id"]:
-            assert result.data.schema.field(field_name).equals(input_table.schema.field(field_name))
-            assert result.data[field_name].equals(input_table[field_name])
-        assert result.data.schema.field("embeddings").type == pa.list_(pa.float32())
-
-    def test_process_prepares_exactly_one_chunk_ahead(self) -> None:
-        from threading import Event
-
-        second_chunk_prepared = Event()
-        third_chunk_prepared = Event()
-
-        class _TrackingStage(VLLMEmbeddingModelStage):
-            def _prepare_input_chunk(
-                self,
-                text_column: pa.ChunkedArray,
-                offset: int,
-                chunk_size: int,
-            ) -> tuple[list[Any], float]:
-                prepared = super()._prepare_input_chunk(text_column, offset, chunk_size)
-                if offset == 2:
-                    second_chunk_prepared.set()
-                elif offset == 4:
-                    third_chunk_prepared.set()
-                return prepared
-
-        class _TrackingModel(_FakeEmbeddingModel):
-            def embed(
-                self,
-                input_data: list[Any],
-                *,
-                tokenization_kwargs: dict[str, int],
-                use_tqdm: bool,
-            ) -> list[SimpleNamespace]:
-                if not self.calls:
-                    assert second_chunk_prepared.wait(timeout=2)
-                    assert not third_chunk_prepared.is_set()
-                return super().embed(
-                    input_data,
-                    tokenization_kwargs=tokenization_kwargs,
-                    use_tqdm=use_tqdm,
-                )
-
-        stage = _TrackingStage(
-            model_identifier=TEST_MODEL,
-            pretokenize=False,
-            model_inference_batch_size=2,
-        )
-        model = _TrackingModel()
-        stage.model = model  # type: ignore[assignment]
-        batch = DocumentBatch(
-            dataset_name="test_dataset",
-            data=pa.table({"text": ["0", "1", "2", "3", "4"]}),
-        )
-
-        stage.process(batch)
-
-        assert model.calls == [[0, 1], [2, 3], [4]]
-        assert third_chunk_prepared.is_set()
-
-    @pytest.mark.parametrize(
-        ("table", "metadata_fields", "message"),
-        [
-            (pa.table({"id": [1]}), None, "missing required text field"),
-            (pa.table({"text": ["first"], "id": [1]}), ["id", "source"], "missing metadata fields"),
-        ],
-    )
-    def test_process_rejects_missing_fields(
-        self,
-        table: pa.Table,
-        metadata_fields: list[str] | None,
-        message: str,
-    ) -> None:
-        stage = VLLMEmbeddingModelStage(
-            model_identifier=TEST_MODEL,
-            pretokenize=False,
-            metadata_fields=metadata_fields,
-        )
-        stage.model = SimpleNamespace()
-
-        with pytest.raises(ValueError, match=message):
-            stage.process(DocumentBatch(dataset_name="test_dataset", data=table))
-
-    def test_process_reports_aggregate_chunk_metrics(self) -> None:
-        class _TimedPreparationStage(VLLMEmbeddingModelStage):
-            def _prepare_input_chunk(
-                self,
-                text_column: pa.ChunkedArray,
-                offset: int,
-                chunk_size: int,
-            ) -> tuple[list[Any], float]:
-                input_data, _ = super()._prepare_input_chunk(text_column, offset, chunk_size)
-                return input_data, 0.25
-
-            def _embed_chunk(
-                self,
-                input_data: list[Any],
-                expected_size: int,
-            ) -> tuple[np.ndarray, dict[str, float]]:
-                embedding_matrix, metrics = super()._embed_chunk(input_data, expected_size)
-                metrics["vllm_embedding_time"] = 0.5
-                return embedding_matrix, metrics
-
-        stage = _TimedPreparationStage(
-            model_identifier=TEST_MODEL,
-            pretokenize=False,
-            metadata_fields=["text"],
-            model_inference_batch_size=2,
-        )
-        stage.model = _FakeEmbeddingModel()  # type: ignore[assignment]
-        batch = DocumentBatch(
-            dataset_name="test_dataset",
-            data=pa.table({"text": ["0", "1", "2", "3", "4"]}),
-        )
-
-        result = stage.process(batch)
-        metrics = stage._consume_custom_metrics()
-
-        assert result.num_items == 5
-        assert metrics["tokenization_time"] == 0.75
-        assert metrics["input_tokens"] == 10
-        assert metrics["vllm_embedding_time"] == 1.5
-
-    def test_process_rejects_wrong_vllm_output_count(self) -> None:
-        class _ShortOutputModel(_FakeEmbeddingModel):
-            def embed(
-                self,
-                input_data: list[Any],
-                *,
-                tokenization_kwargs: dict[str, int],
-                use_tqdm: bool,
-            ) -> list[SimpleNamespace]:
-                return super().embed(
-                    input_data,
-                    tokenization_kwargs=tokenization_kwargs,
-                    use_tqdm=use_tqdm,
-                )[:-1]
-
-        stage = VLLMEmbeddingModelStage(model_identifier=TEST_MODEL, pretokenize=False)
-        stage.model = _ShortOutputModel()  # type: ignore[assignment]
-
-        with pytest.raises(ValueError, match="returned 1 embeddings for a 2-row input chunk"):
-            stage.process(DocumentBatch(dataset_name="test_dataset", data=pa.table({"text": ["0", "1"]})))
-
-    def test_process_rejects_non_matrix_embeddings(self) -> None:
-        class _ScalarEmbeddingModel(_FakeEmbeddingModel):
-            def embed(
-                self,
-                input_data: list[Any],
-                *,
-                tokenization_kwargs: dict[str, int],
-                use_tqdm: bool,
-            ) -> list[SimpleNamespace]:
-                outputs = super().embed(
-                    input_data,
-                    tokenization_kwargs=tokenization_kwargs,
-                    use_tqdm=use_tqdm,
-                )
-                for output in outputs:
-                    output.outputs.embedding = 1.0
-                return outputs
-
-        stage = VLLMEmbeddingModelStage(model_identifier=TEST_MODEL, pretokenize=False)
-        stage.model = _ScalarEmbeddingModel()  # type: ignore[assignment]
-
-        with pytest.raises(ValueError, match="two-dimensional embedding matrix"):
-            stage.process(DocumentBatch(dataset_name="test_dataset", data=pa.table({"text": ["0"]})))
-
-    def test_process_rejects_embedding_dimension_changes(self) -> None:
-        class _ChangingDimensionModel(_FakeEmbeddingModel):
-            def embed(
-                self,
-                input_data: list[Any],
-                *,
-                tokenization_kwargs: dict[str, int],
-                use_tqdm: bool,
-            ) -> list[SimpleNamespace]:
-                outputs = super().embed(
-                    input_data,
-                    tokenization_kwargs=tokenization_kwargs,
-                    use_tqdm=use_tqdm,
-                )
-                if len(self.calls) == 2:
-                    outputs[0].outputs.embedding.append(2.0)
-                return outputs
-
-        stage = VLLMEmbeddingModelStage(
-            model_identifier=TEST_MODEL,
-            pretokenize=False,
-            model_inference_batch_size=1,
-        )
-        stage.model = _ChangingDimensionModel()  # type: ignore[assignment]
-
-        with pytest.raises(ValueError, match="embedding dimension changed from 2 to 3"):
-            stage.process(DocumentBatch(dataset_name="test_dataset", data=pa.table({"text": ["0", "1"]})))
-
-    def test_process_replaces_selected_embedding_field_in_place(self) -> None:
-        stage = VLLMEmbeddingModelStage(
-            model_identifier=TEST_MODEL,
-            pretokenize=False,
-            metadata_fields=["id", "embeddings", "text"],
-        )
-        stage.model = _FakeEmbeddingModel()  # type: ignore[assignment]
-        batch = DocumentBatch(
-            dataset_name="test_dataset",
-            data=pa.table({"text": ["0"], "id": [7], "embeddings": [[99]]}),
-        )
-
-        result = stage.process(batch)
-
-        assert stage.outputs() == (["data"], ["id", "embeddings", "text"])
-        assert result.data.column_names == ["id", "embeddings", "text"]
-        assert result.data["embeddings"].to_pylist() == [[0.0, 1.0]]
-        assert result.data.schema.field("embeddings").type == pa.list_(pa.float32())
-
-    @pytest.mark.parametrize("pretokenize", [True, False])
-    def test_vllm_produces_valid_embeddings(
-        self, sample_data: DocumentBatch, pretokenize: bool, reference_model: "SentenceTransformer"
-    ) -> None:
-        """Test that VLLM produces embeddings matching SentenceTransformer reference."""
-        vllm_stage = VLLMEmbeddingModelStage(
+        monkeypatch.setattr(sample_data, "to_pandas", _fail_to_pandas)
+        vllm_stage = _RecordingStage(
             model_identifier=TEST_MODEL,
             pretokenize=pretokenize,
+            metadata_fields=["id", "nested"],
+            model_inference_batch_size=None,
             verbose=False,
         )
         try:
@@ -544,18 +207,39 @@ class TestVLLMEmbeddingModelStage:
         except Exception:  # noqa: BLE001
             pytest.skip("Skipping test due to model download failure")
         vllm_stage.setup()
-        result = vllm_stage.process(sample_data)
+        try:
+            vllm_stage.embedded_chunk_sizes = []
+            unbatched_result = vllm_stage.process(sample_data).to_pyarrow()
+            unbatched_metrics = vllm_stage._consume_custom_metrics()
+            assert vllm_stage.embedded_chunk_sizes == [5]
 
-        assert isinstance(result, DocumentBatch)
-        result_df = result.to_pandas()
-        assert "embeddings" in result_df.columns
-        assert len(result_df) == 3
+            unbatched_embeddings = np.asarray(unbatched_result["embeddings"].to_pylist())
+            reference_embeddings = reference_model.encode(texts)
+            cosine_sim = torch.nn.functional.cosine_similarity(
+                torch.tensor(unbatched_embeddings), torch.tensor(reference_embeddings), dim=1
+            )
+            assert torch.allclose(cosine_sim, torch.ones_like(cosine_sim), atol=1e-5)
 
-        reference_embeddings = reference_model.encode(sample_data.to_pandas()["text"].tolist())
-        vllm_embeddings = np.array(result_df["embeddings"].tolist())
+            for batch_size, expected_chunk_sizes in [(2, [2, 2, 1]), (3, [3, 2])]:
+                vllm_stage.model_inference_batch_size = batch_size
+                vllm_stage.embedded_chunk_sizes = []
 
-        vllm_embeddings_torch = torch.tensor(vllm_embeddings)
-        reference_embeddings_torch = torch.tensor(reference_embeddings)
+                result = vllm_stage.process(sample_data).to_pyarrow()
+                metrics = vllm_stage._consume_custom_metrics()
 
-        cosine_sim = torch.nn.functional.cosine_similarity(vllm_embeddings_torch, reference_embeddings_torch, dim=1)
-        assert torch.allclose(cosine_sim, torch.ones_like(cosine_sim), atol=1e-5)
+                assert vllm_stage.embedded_chunk_sizes == expected_chunk_sizes
+                assert result.column_names == ["id", "nested", "embeddings"]
+                for field_name in ["id", "nested"]:
+                    assert result.schema.field(field_name).equals(input_table.schema.field(field_name))
+                    assert result[field_name].equals(input_table[field_name])
+                assert result.schema.field("embeddings").type == pa.list_(pa.float32())
+                batched_embeddings = np.asarray(result["embeddings"].to_pylist())
+                batch_cosine_sim = torch.nn.functional.cosine_similarity(
+                    torch.tensor(batched_embeddings), torch.tensor(unbatched_embeddings), dim=1
+                )
+                assert torch.allclose(batch_cosine_sim, torch.ones_like(batch_cosine_sim), atol=1e-5)
+                assert metrics["input_tokens"] == unbatched_metrics["input_tokens"]
+                assert metrics["vllm_embedding_time"] > 0
+                assert metrics["tokenization_time"] >= 0
+        finally:
+            vllm_stage.teardown()

--- a/tests/utils/test_vllm_utils.py
+++ b/tests/utils/test_vllm_utils.py
@@ -227,6 +227,28 @@ class TestCreateVllmLlm:
         assert captured_kwargs.get("gpu_memory_utilization") == 0.95
         assert captured_kwargs.get("max_num_batched_tokens") == 16384
 
+    def test_retry_helper_forwards_exact_engine_kwargs(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        captured_kwargs: dict = {}
+
+        class FakeLLM:
+            def __init__(self, **kwargs: object) -> None:
+                captured_kwargs.update(kwargs)
+
+        self._inject_fake_vllm(monkeypatch, FakeLLM)
+        monkeypatch.setattr(_vllm_utils, "pick_free_port", lambda: 12345)
+
+        _vllm_utils.create_vllm_llm_with_retry(
+            model="fake/model",
+            runner="pooling",
+            disable_log_stats=True,
+        )
+
+        assert captured_kwargs == {
+            "model": "fake/model",
+            "runner": "pooling",
+            "disable_log_stats": True,
+        }
+
     def test_non_eaddrinuse_raises_immediately(self, monkeypatch: pytest.MonkeyPatch):
         """A non-port-collision RuntimeError should propagate without retry."""
         call_count = 0


### PR DESCRIPTION
## Description

**Main Change** - Add `model_inference_batch_size` support for vLLM too. Otherwise it generates a gigantic tokenized column for all texts which can result in CPU OOM. Now we only tokenize what we feed into the LLM. The output returned is a pyarrow table (earlier it was a pd.DataFrame with a embedding column which was list[float] i.e. fp64. Now we do fp32.

Also related to OOM: we don't now persist text column always

**Other changes**
1. Use `create_vllm_llm_with_retry` inside setup
2. Add `metadata_fields` for embedding (removed text as the default column that gets preserved)

Linear: [NMCUR-240](https://linear.app/nvidia/issue/NMCUR-240)

## Validation

- 27 focused embedder, utility, and workflow-configuration tests passed
- 12 semantic-dedup workflow tests passed across Xenna and Ray Data
- Pre-commit passed

## Benchmark comparison

Compared [nightly baseline](http://rratzel-ws1:5050/run-viewer?dir=login-eos-nightly%3A%2Flustre%2Ffsw%2Fcoreai_dlalgo_ci%2Fcurator_ci%2Fresults%2Fmain&run=nightly-2026_08_20__06_39_17_UTC) (`ae713b5e`) with the [PR run](http://rratzel-ws1:5050/run-viewer?dir=login-eos-adhoc%3A%2Flustre%2Ffsw%2Fcoreai_dlalgo_ci%2Fcurator_ci%2Fresults%2Fmain-mirror&run=pr-2317-2026_08_21__00_38_20_UTC-878cf463) (`878cf463`). Both entries succeeded and processed the same 5,807,132 documents. Time values are seconds; delta is `(PR - nightly) / nightly`, so negative time deltas are improvements.

| Executor | Runtime metric | Nightly | PR | Delta |
|---|---|---:|---:|---:|
| Ray Data | `time_taken_s` | 901.925 | 847.189 | -6.07% |
| Ray Data | `throughput_docs_per_sec` | 6,438.60 | 6,854.59 | +6.46% |
| Ray Data | vLLM `process_time_mean` | 2.962 | 2.850 | -3.79% |
| Ray Data | custom `tokenization_time_mean` | 0.388 | 0.543 | +39.78% |
| Ray Data | custom `vllm_embedding_time_mean` | 2.417 | 2.461 | +1.81% |
| Xenna | `time_taken_s` | 768.562 | 743.618 | -3.25% |
| Xenna | `throughput_docs_per_sec` | 7,555.84 | 7,809.30 | +3.35% |
| Xenna | vLLM `process_time_mean` | 3.031 | 2.910 | -4.00% |
| Xenna | custom `tokenization_time_mean` | 0.413 | 0.560 | +35.44% |
| Xenna | custom `vllm_embedding_time_mean` | 2.454 | 2.510 | +2.31% |

Overall end-to-end runtime improved by 6.1% on Ray Data and 3.2% on Xenna, while embedding-stage `process_time_mean` improved by about 4% for both executors. The custom tokenization mean increased, but its overlap with vLLM inference keeps the aggregate stage time lower. This is a single-run comparison on different EOS hosts (`eos0288` before and `eos0183` after), so modest differences should be treated as directional.