### PR TITLE
[benchmarking] Make benchmark reporting resilient

### DIFF
--- a/benchmarking/run.py
+++ b/benchmarking/run.py
@@ -21,7 +21,7 @@ import shutil
 import sys
 import time
 import traceback
-from collections.abc import Mapping, Sequence
+from collections.abc import Mapping
 from contextlib import nullcontext
 from pathlib import Path
 from typing import Any
@@ -55,6 +55,7 @@ from runner.ray_cluster import (
     teardown_ray_cluster_and_env,
 )
 from runner.session import Session
+from runner.sinks.sink import call_sink_hook, initialize_sinks
 from runner.utils import (
     assert_valid_config_dict,
     find_result,
@@ -235,44 +236,6 @@ def run_data_setups(
         if not overall_success:
             break
     return overall_success
-
-
-def _call_sink_hook(sink: object, hook_name: str, *, context: str = "", **kwargs: object) -> bool:
-    """Call a sink hook without letting reporting failures affect benchmarks."""
-    sink_name = sink.__class__.__name__
-    try:
-        getattr(sink, hook_name)(**kwargs)
-    except Exception as e:
-        context_msg = f" while {context}" if context else ""
-        logger.exception(
-            "Sink {}.{} failed{}; benchmark execution will continue: {}",
-            sink_name,
-            hook_name,
-            context_msg,
-            e,
-        )
-        return False
-    return True
-
-
-def _initialize_sinks(
-    sinks: Sequence[object], *, session_name: str, session: Session, env_dict: dict[str, Any]
-) -> list[object]:
-    """Initialize sinks, returning only those safe to use for later hooks."""
-    active_sinks = []
-    for sink in sinks:
-        if _call_sink_hook(
-            sink,
-            "initialize",
-            context="initializing benchmark reporting sinks",
-            session_name=session_name,
-            session=session,
-            env_dict=env_dict,
-        ):
-            active_sinks.append(sink)
-        else:
-            logger.warning("Disabling sink {} for the remainder of this session", sink.__class__.__name__)
-    return active_sinks
 
 
 def run_entry(  # noqa: PLR0913
@@ -583,7 +546,7 @@ def main() -> int:  # noqa: C901, PLR0911, PLR0912, PLR0915
         logger.error("Data setup failed; benchmark entries will not be run.")
         return 1
 
-    active_sinks = _initialize_sinks(session.sinks, session_name=session_name, session=session, env_dict=env_dict)
+    active_sinks = initialize_sinks(session.sinks, session_name=session_name, session=session, env_dict=env_dict)
 
     # Print a summary of the entries that will be run in the for loop below
     # Disabled entries will not be printed
@@ -609,7 +572,7 @@ def main() -> int:  # noqa: C901, PLR0911, PLR0912, PLR0915
         logger.info(f"🚀 Running {entry.name} (run ID: {run_id})")
 
         for sink in active_sinks:
-            _call_sink_hook(
+            call_sink_hook(
                 sink,
                 "register_benchmark_entry_starting",
                 context=f"registering {entry.name} as starting",
@@ -643,7 +606,7 @@ def main() -> int:  # noqa: C901, PLR0911, PLR0912, PLR0915
         finally:
             session_overall_success &= run_success
             for sink in active_sinks:
-                _call_sink_hook(
+                call_sink_hook(
                     sink,
                     "register_benchmark_entry_finished",
                     context=f"registering {entry.name} as finished",
@@ -653,7 +616,7 @@ def main() -> int:  # noqa: C901, PLR0911, PLR0912, PLR0915
             logger.remove(entry_log_id)
 
     for sink in active_sinks:
-        _call_sink_hook(sink, "finalize", context="finalizing benchmark reporting sinks")
+        call_sink_hook(sink, "finalize", context="finalizing benchmark reporting sinks")
     logger.info(f"Session {session_name} completed with overall success: {session_overall_success}")
     return 0 if session_overall_success else 1
 

--- a/benchmarking/run.py
+++ b/benchmarking/run.py
@@ -21,7 +21,7 @@ import shutil
 import sys
 import time
 import traceback
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
 from contextlib import nullcontext
 from pathlib import Path
 from typing import Any
@@ -235,6 +235,44 @@ def run_data_setups(
         if not overall_success:
             break
     return overall_success
+
+
+def _call_sink_hook(sink: object, hook_name: str, *, context: str = "", **kwargs: object) -> bool:
+    """Call a sink hook without letting reporting failures affect benchmarks."""
+    sink_name = sink.__class__.__name__
+    try:
+        getattr(sink, hook_name)(**kwargs)
+    except Exception as e:
+        context_msg = f" while {context}" if context else ""
+        logger.exception(
+            "Sink {}.{} failed{}; benchmark execution will continue: {}",
+            sink_name,
+            hook_name,
+            context_msg,
+            e,
+        )
+        return False
+    return True
+
+
+def _initialize_sinks(
+    sinks: Sequence[object], *, session_name: str, session: Session, env_dict: dict[str, Any]
+) -> list[object]:
+    """Initialize sinks, returning only those safe to use for later hooks."""
+    active_sinks = []
+    for sink in sinks:
+        if _call_sink_hook(
+            sink,
+            "initialize",
+            context="initializing benchmark reporting sinks",
+            session_name=session_name,
+            session=session,
+            env_dict=env_dict,
+        ):
+            active_sinks.append(sink)
+        else:
+            logger.warning("Disabling sink {} for the remainder of this session", sink.__class__.__name__)
+    return active_sinks
 
 
 def run_entry(  # noqa: PLR0913
@@ -545,8 +583,7 @@ def main() -> int:  # noqa: C901, PLR0911, PLR0912, PLR0915
         logger.error("Data setup failed; benchmark entries will not be run.")
         return 1
 
-    for sink in session.sinks:
-        sink.initialize(session_name=session_name, session=session, env_dict=env_dict)
+    active_sinks = _initialize_sinks(session.sinks, session_name=session_name, session=session, env_dict=env_dict)
 
     # Print a summary of the entries that will be run in the for loop below
     # Disabled entries will not be printed
@@ -571,8 +608,14 @@ def main() -> int:  # noqa: C901, PLR0911, PLR0912, PLR0915
         entry_log_id = logger.add(entry_stdouterr_path, mode="a", colorize=False)
         logger.info(f"🚀 Running {entry.name} (run ID: {run_id})")
 
-        for sink in session.sinks:
-            sink.register_benchmark_entry_starting(result_dict=result_data, benchmark_entry=entry)
+        for sink in active_sinks:
+            _call_sink_hook(
+                sink,
+                "register_benchmark_entry_starting",
+                context=f"registering {entry.name} as starting",
+                result_dict=result_data,
+                benchmark_entry=entry,
+            )
 
         try:
             run_success = run_entry(
@@ -598,13 +641,19 @@ def main() -> int:  # noqa: C901, PLR0911, PLR0912, PLR0915
             )
 
         finally:
-            logger.remove(entry_log_id)
             session_overall_success &= run_success
-            for sink in session.sinks:
-                sink.register_benchmark_entry_finished(result_dict=result_data, benchmark_entry=entry)
+            for sink in active_sinks:
+                _call_sink_hook(
+                    sink,
+                    "register_benchmark_entry_finished",
+                    context=f"registering {entry.name} as finished",
+                    result_dict=result_data,
+                    benchmark_entry=entry,
+                )
+            logger.remove(entry_log_id)
 
-    for sink in session.sinks:
-        sink.finalize()
+    for sink in active_sinks:
+        _call_sink_hook(sink, "finalize", context="finalizing benchmark reporting sinks")
     logger.info(f"Session {session_name} completed with overall success: {session_overall_success}")
     return 0 if session_overall_success else 1
 

--- a/benchmarking/runner/sinks/sink.py
+++ b/benchmarking/runner/sinks/sink.py
@@ -11,11 +11,49 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from abc import ABC, abstractmethod
-from typing import Any
+from __future__ import annotations
 
-from runner.entry import Entry
-from runner.session import Session
+import logging
+from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+    from runner.entry import Entry
+    from runner.session import Session
+
+logger = logging.getLogger(__name__)
+
+
+def _log_sink_exception(sink_name: str, hook_name: str, context_msg: str, error: Exception) -> None:
+    try:
+        from loguru import logger as loguru_logger
+    except ModuleNotFoundError:
+        logger.exception(
+            "Sink %s.%s failed%s; benchmark execution will continue: %s",
+            sink_name,
+            hook_name,
+            context_msg,
+            error,
+        )
+    else:
+        loguru_logger.exception(
+            "Sink {}.{} failed{}; benchmark execution will continue: {}",
+            sink_name,
+            hook_name,
+            context_msg,
+            error,
+        )
+
+
+def _log_sink_disabled(sink_name: str) -> None:
+    try:
+        from loguru import logger as loguru_logger
+    except ModuleNotFoundError:
+        logger.warning("Disabling sink %s for the remainder of this session", sink_name)
+    else:
+        loguru_logger.warning("Disabling sink {} for the remainder of this session", sink_name)
 
 
 class Sink(ABC):
@@ -65,3 +103,35 @@ class Sink(ABC):
     @abstractmethod
     def finalize(self) -> None:
         """Finalize the sink after all results have been processed."""
+
+
+def call_sink_hook(sink: object, hook_name: str, *, context: str = "", **kwargs: object) -> bool:
+    """Call a sink hook without letting reporting failures affect benchmarks."""
+    sink_name = sink.__class__.__name__
+    try:
+        getattr(sink, hook_name)(**kwargs)
+    except Exception as e:
+        context_msg = f" while {context}" if context else ""
+        _log_sink_exception(sink_name, hook_name, context_msg, e)
+        return False
+    return True
+
+
+def initialize_sinks(
+    sinks: Sequence[object], *, session_name: str, session: Session, env_dict: dict[str, Any]
+) -> list[object]:
+    """Initialize sinks, returning only those safe to use for later hooks."""
+    active_sinks = []
+    for sink in sinks:
+        if call_sink_hook(
+            sink,
+            "initialize",
+            context="initializing benchmark reporting sinks",
+            session_name=session_name,
+            session=session,
+            env_dict=env_dict,
+        ):
+            active_sinks.append(sink)
+        else:
+            _log_sink_disabled(sink.__class__.__name__)
+    return active_sinks

--- a/benchmarking/runner/sinks/slack_sink.py
+++ b/benchmarking/runner/sinks/slack_sink.py
@@ -259,6 +259,20 @@ class SlackParentMessage(SlackMessageBase):
             ]
         )
 
+    def _get_run_status_text(self, markdown: bool) -> str:
+        """Format the overall session status for Slack blocks or fallback text."""
+        counts = self._get_entry_status_counts()
+        if counts["running"] or counts["waiting"]:
+            status = "▶️ running"
+        elif counts["failed"]:
+            status = "❌ complete with failures"
+        else:
+            status = "✅ complete"
+
+        if markdown:
+            return f"*Run status:* {status}"
+        return f"Run status: {status}"
+
     def to_slack_blocks(self) -> list[dict[str, Any]]:
         """Convert the parent message data to Slack blocks format.
 
@@ -282,6 +296,15 @@ class SlackParentMessage(SlackMessageBase):
                 "text": {
                     "type": "mrkdwn",
                     "text": self._get_entry_status_summary_text(markdown=True),
+                },
+            }
+        )
+        blocks.append(
+            {
+                "type": "section",
+                "text": {
+                    "type": "mrkdwn",
+                    "text": self._get_run_status_text(markdown=True),
                 },
             }
         )
@@ -310,6 +333,7 @@ class SlackParentMessage(SlackMessageBase):
             f"Curator Benchmark Summary - {self.session_name}",
             "",
             self._get_entry_status_summary_text(markdown=False),
+            self._get_run_status_text(markdown=False),
         ]
         if self.viewer_url:
             lines.append(f"Results viewer: {self.session_name} ({self.viewer_url})")

--- a/benchmarking/runner/sinks/slack_sink.py
+++ b/benchmarking/runner/sinks/slack_sink.py
@@ -46,20 +46,6 @@ class SlackMessageBase:
             "elements": [{"type": "rich_text_section", "elements": [{"type": "text", "text": " "}]}],
         },
     ]
-    _THREE_COL_BLANK_ROW: ClassVar[list[dict[str, Any]]] = [
-        {
-            "type": "rich_text",
-            "elements": [{"type": "rich_text_section", "elements": [{"type": "text", "text": " "}]}],
-        },
-        {
-            "type": "rich_text",
-            "elements": [{"type": "rich_text_section", "elements": [{"type": "text", "text": " "}]}],
-        },
-        {
-            "type": "rich_text",
-            "elements": [{"type": "rich_text_section", "elements": [{"type": "text", "text": " "}]}],
-        },
-    ]
 
     def __init__(self):
         """Initialize the base message."""
@@ -161,53 +147,6 @@ class SlackMessageBase:
         ]
 
     @staticmethod
-    def _get_three_column_row(left_text: str, middle_text: str, right_text: str) -> list[dict[str, Any]]:
-        """Create a three-column row for Slack rich text tables."""
-        left_text = left_text or " "
-        middle_text = middle_text or " "
-        right_text = right_text or " "
-        return [
-            {
-                "type": "rich_text",
-                "elements": [{"type": "rich_text_section", "elements": [{"type": "text", "text": left_text}]}],
-            },
-            {
-                "type": "rich_text",
-                "elements": [{"type": "rich_text_section", "elements": [{"type": "text", "text": middle_text}]}],
-            },
-            {
-                "type": "rich_text",
-                "elements": [{"type": "rich_text_section", "elements": [{"type": "text", "text": right_text}]}],
-            },
-        ]
-
-    @staticmethod
-    def _get_three_column_row_bold(left_text: str, middle_text: str, right_text: str) -> list[dict[str, Any]]:
-        """Create a three-column row with bold left column for Slack rich text tables."""
-        left_text = left_text or " "
-        middle_text = middle_text or " "
-        right_text = right_text or " "
-        return [
-            {
-                "type": "rich_text",
-                "elements": [
-                    {
-                        "type": "rich_text_section",
-                        "elements": [{"type": "text", "text": left_text, "style": {"bold": True}}],
-                    }
-                ],
-            },
-            {
-                "type": "rich_text",
-                "elements": [{"type": "rich_text_section", "elements": [{"type": "text", "text": middle_text}]}],
-            },
-            {
-                "type": "rich_text",
-                "elements": [{"type": "rich_text_section", "elements": [{"type": "text", "text": right_text}]}],
-            },
-        ]
-
-    @staticmethod
     def _get_formatted_metric_value_tuple(metric: str, result: Any) -> tuple[str, str]:  # noqa: ANN401
         """Format a metric value for display in Slack.
 
@@ -248,8 +187,9 @@ class SlackMessageBase:
 class SlackParentMessage(SlackMessageBase):
     """Represents a parent message in a Slack channel containing benchmark run summary.
 
-    Maintains a list of benchmark entries and their status, along with metadata about the
-    benchmark run such as session name and environment information.
+    Maintains a list of benchmark entries and their status so the parent
+    message can show bounded live summary counts. Detailed per-entry data is
+    reported in threaded replies and the run viewer.
     """
 
     def __init__(self, session_name: str, env_dict: dict[str, Any], viewer_url: str | None = None):
@@ -266,34 +206,19 @@ class SlackParentMessage(SlackMessageBase):
         self.env_dict = env_dict
         self.viewer_url = viewer_url
         self.entries: dict[str, str] = {}  # Dictionary mapping entry_name to status_string
-        self.entry_time_taken_s: dict[str, str] = {}  # Dictionary mapping entry_name to formatted time_taken_s
         self._has_updates: bool = False  # Track if entries have changed since last post
 
-    def update_entry(self, entry_name: str, status: str, time_taken_s: str = "") -> None:
-        """Add or update a benchmark entry status and optional time_taken_s display value.
+    def update_entry(self, entry_name: str, status: str) -> None:
+        """Add or update a benchmark entry status.
 
         Args:
             entry_name: Name of the benchmark entry.
             status: Status string (e.g., "✅ success", "❌ FAILED", "▶️ running", "⏳ waiting to start").
-            time_taken_s: Formatted time_taken_s value for the parent table, or blank when not applicable.
         """
-        # Check if this is actually a change
-        if (
-            entry_name not in self.entries
-            or self.entries[entry_name] != status
-            or self.entry_time_taken_s.get(entry_name, "") != time_taken_s
-        ):
+        # Check if this is actually a change.
+        if entry_name not in self.entries or self.entries[entry_name] != status:
             self.entries[entry_name] = status
-            self.entry_time_taken_s[entry_name] = time_taken_s
             self._has_updates = True
-
-    @classmethod
-    def format_time_taken_s(cls, result_dict: dict[str, Any]) -> str:
-        """Format time_taken_s for the parent summary table when the metric is present."""
-        time_taken_s = find_result(result_dict, "time_taken_s")
-        if time_taken_s is None:
-            return ""
-        return cls._get_formatted_metric_value_tuple("time_taken_s", time_taken_s)[1]
 
     def _get_entry_status_counts(self) -> dict[str, int]:
         """Summarize entry statuses for the parent Slack message."""
@@ -373,34 +298,6 @@ class SlackParentMessage(SlackMessageBase):
                 }
             )
 
-        # Table of benchmark entries, their status, optional time_taken_s, and the environment.
-        blocks.append({"type": "divider"})
-        rows = []
-        indent = "-    "  # start with a dash since leading whitespace is stripped
-        for entry_name, status in self.entries.items():
-            rows.append(
-                self._get_three_column_row_bold(
-                    entry_name,
-                    status,
-                    self.entry_time_taken_s.get(entry_name, ""),
-                )
-            )
-        rows.append(self._THREE_COL_BLANK_ROW)
-        rows.append(self._get_three_column_row_bold("ENVIRONMENT", " ", ""))
-        for var, val in self.env_dict.items():
-            if var in {"pip_freeze_txt", "conda_explicit_txt", "viewer_url"}:
-                continue
-            (fvar, fval) = self._get_formatted_metric_value_tuple(var, val)
-            rows.append(self._get_three_column_row(f"{indent}{fvar}", fval, ""))
-        rows.append(self._THREE_COL_BLANK_ROW)
-
-        blocks.append(
-            {
-                "type": "table",
-                "rows": rows,
-            }
-        )
-
         return blocks
 
     def to_fallback_text(self) -> str:
@@ -414,12 +311,8 @@ class SlackParentMessage(SlackMessageBase):
             "",
             self._get_entry_status_summary_text(markdown=False),
         ]
-        if self.entries:
-            lines.append("\nBenchmark Entries:")
-            for entry_name, status in self.entries.items():
-                time_taken_s = self.entry_time_taken_s.get(entry_name, "")
-                suffix = f" ({time_taken_s})" if time_taken_s else ""
-                lines.append(f"  • {entry_name}: {status}{suffix}")
+        if self.viewer_url:
+            lines.append(f"Results viewer: {self.session_name} ({self.viewer_url})")
         return "\n".join(lines)
 
     def get_channel_id(self) -> str | None:
@@ -675,7 +568,6 @@ class SlackSink(Sink):
                     "ts": self._parent_message.get_timestamp(),
                     "channel": self._parent_message.get_channel_id(),
                     "entries": dict(self._parent_message.entries),
-                    "entry_time_taken_s": dict(self._parent_message.entry_time_taken_s),
                 }
                 # NOTE: This is the only time the state file is created.
                 # If the benchmark session is re-run using the same session name
@@ -693,10 +585,8 @@ class SlackSink(Sink):
                     viewer_url=self.viewer_url,
                 )
                 self._parent_message.set_response({"ts": state["ts"], "channel": state["channel"], "ok": True})
-                entry_time_taken_s = state.get("entry_time_taken_s", {})
                 for entry_name, entry_status in state["entries"].items():
                     self._parent_message.entries[entry_name] = entry_status
-                    self._parent_message.entry_time_taken_s[entry_name] = entry_time_taken_s.get(entry_name, "")
         finally:
             if fd is not None:
                 os.close(fd)
@@ -730,8 +620,6 @@ class SlackSink(Sink):
         else:
             pings = sink_data.get("ping_on_failure", [])
         status_text = "✅ success" if result_dict["success"] else "❌ FAILED"
-        time_taken_s_text = SlackParentMessage.format_time_taken_s(result_dict)
-
         warnings = result_dict.get("warnings", [])
 
         # Create a new message for the entry to post in the thread.
@@ -743,7 +631,7 @@ class SlackSink(Sink):
         )
         self._child_messages.append(msg)
         # Update the session summary message with the new entry status.
-        self._update_parent_entry(benchmark_entry.name, status_text, time_taken_s=time_taken_s_text)
+        self._update_parent_entry(benchmark_entry.name, status_text)
 
         if self.live_updates:
             self._post_updates()
@@ -801,7 +689,7 @@ class SlackSink(Sink):
             warnings=warnings,
         )
 
-    def _update_parent_entry(self, entry_name: str, status: str, time_taken_s: str = "") -> None:
+    def _update_parent_entry(self, entry_name: str, status: str) -> None:
         """Update a single entry's status in the shared state file and post the update to Slack.
 
         Acquires an exclusive file lock for the duration of the read-modify-write cycle and
@@ -810,7 +698,6 @@ class SlackSink(Sink):
         Args:
             entry_name: Name of the benchmark entry to update.
             status: New status string for the entry.
-            time_taken_s: Formatted time_taken_s value for the entry, or blank when not applicable.
         """
         if self._state_path is None:
             logger.error("SlackSink: Cannot update parent entry — state path not set. Was initialize() called?")
@@ -823,11 +710,9 @@ class SlackSink(Sink):
         try:
             fcntl.flock(f.fileno(), fcntl.LOCK_EX)
             state = json.load(f)
-            state.setdefault("entry_time_taken_s", {})
             state["entries"][entry_name] = status
-            state["entry_time_taken_s"][entry_name] = time_taken_s
             for name, st in state["entries"].items():
-                self._parent_message.update_entry(name, st, state["entry_time_taken_s"].get(name, ""))
+                self._parent_message.update_entry(name, st)
             try:
                 self._update_message(self._parent_message)
             finally:

--- a/benchmarking/runner/sinks/slack_sink.py
+++ b/benchmarking/runner/sinks/slack_sink.py
@@ -295,7 +295,7 @@ class SlackParentMessage(SlackMessageBase):
                 "type": "section",
                 "text": {
                     "type": "mrkdwn",
-                    "text": self._get_entry_status_summary_text(markdown=True),
+                    "text": self._get_run_status_text(markdown=True),
                 },
             }
         )
@@ -304,7 +304,7 @@ class SlackParentMessage(SlackMessageBase):
                 "type": "section",
                 "text": {
                     "type": "mrkdwn",
-                    "text": self._get_run_status_text(markdown=True),
+                    "text": self._get_entry_status_summary_text(markdown=True),
                 },
             }
         )
@@ -332,8 +332,8 @@ class SlackParentMessage(SlackMessageBase):
         lines = [
             f"Curator Benchmark Summary - {self.session_name}",
             "",
-            self._get_entry_status_summary_text(markdown=False),
             self._get_run_status_text(markdown=False),
+            self._get_entry_status_summary_text(markdown=False),
         ]
         if self.viewer_url:
             lines.append(f"Results viewer: {self.session_name} ({self.viewer_url})")

--- a/tests/benchmarking/runner/sinks/test_slack_sink.py
+++ b/tests/benchmarking/runner/sinks/test_slack_sink.py
@@ -44,6 +44,7 @@ def test_slack_parent_message_reports_entry_status_counts() -> None:
     assert section_texts[0] == (
         "*Total entries:* 4  •  *passed ✅:* 1  •  *failed ❌:* 1  •  *running ▶️:* 1  •  *waiting ⏳:* 1"
     )
+    assert section_texts[1] == "*Run status:* ▶️ running"
     assert all("Overall Status" not in text for text in section_texts)
     assert all(block.get("type") != "table" for block in blocks)
 
@@ -57,7 +58,8 @@ def test_slack_parent_message_labels_viewer_link_with_session_name() -> None:
 
     section_texts = _section_texts(message.to_slack_blocks())
 
-    assert section_texts[1] == "*Results viewer:* <http://viewer.example.com/run?name=test-session|test-session>"
+    assert section_texts[1] == "*Run status:* ✅ complete"
+    assert section_texts[2] == "*Results viewer:* <http://viewer.example.com/run?name=test-session|test-session>"
 
 
 def test_slack_parent_message_fallback_reports_entry_status_counts() -> None:
@@ -72,5 +74,6 @@ def test_slack_parent_message_fallback_reports_entry_status_counts() -> None:
     assert "failed ❌: 1" in fallback_text
     assert "running ▶️: 0" in fallback_text
     assert "waiting ⏳: 0" in fallback_text
+    assert "Run status: ❌ complete with failures" in fallback_text
     assert "Benchmark Entries:" not in fallback_text
     assert "passed_entry" not in fallback_text

--- a/tests/benchmarking/runner/sinks/test_slack_sink.py
+++ b/tests/benchmarking/runner/sinks/test_slack_sink.py
@@ -41,10 +41,10 @@ def test_slack_parent_message_reports_entry_status_counts() -> None:
     blocks = message.to_slack_blocks()
     section_texts = _section_texts(blocks)
 
-    assert section_texts[0] == (
+    assert section_texts[0] == "*Run status:* ▶️ running"
+    assert section_texts[1] == (
         "*Total entries:* 4  •  *passed ✅:* 1  •  *failed ❌:* 1  •  *running ▶️:* 1  •  *waiting ⏳:* 1"
     )
-    assert section_texts[1] == "*Run status:* ▶️ running"
     assert all("Overall Status" not in text for text in section_texts)
     assert all(block.get("type") != "table" for block in blocks)
 
@@ -58,7 +58,7 @@ def test_slack_parent_message_labels_viewer_link_with_session_name() -> None:
 
     section_texts = _section_texts(message.to_slack_blocks())
 
-    assert section_texts[1] == "*Run status:* ✅ complete"
+    assert section_texts[0] == "*Run status:* ✅ complete"
     assert section_texts[2] == "*Results viewer:* <http://viewer.example.com/run?name=test-session|test-session>"
 
 
@@ -69,6 +69,7 @@ def test_slack_parent_message_fallback_reports_entry_status_counts() -> None:
 
     fallback_text = message.to_fallback_text()
 
+    assert fallback_text.splitlines()[2] == "Run status: ❌ complete with failures"
     assert "Total entries: 2" in fallback_text
     assert "passed ✅: 1" in fallback_text
     assert "failed ❌: 1" in fallback_text

--- a/tests/benchmarking/runner/sinks/test_slack_sink.py
+++ b/tests/benchmarking/runner/sinks/test_slack_sink.py
@@ -31,35 +31,21 @@ def _section_texts(blocks: list[dict[str, Any]]) -> list[str]:
     ]
 
 
-def _table_rows(blocks: list[dict[str, Any]]) -> list[list[dict[str, Any]]]:
-    return next(block["rows"] for block in blocks if block.get("type") == "table")
-
-
-def _row_texts(row: list[dict[str, Any]]) -> list[str]:
-    return [cell["elements"][0]["elements"][0]["text"] for cell in row]
-
-
 def test_slack_parent_message_reports_entry_status_counts() -> None:
     message = SlackParentMessage(session_name="test-session", env_dict={})
-    time_taken_s = SlackParentMessage.format_time_taken_s({"metrics": {"time_taken_s": 12.345}})
     message.update_entry("waiting_entry", "⏳ waiting to start")
     message.update_entry("running_entry", "▶️ running")
-    message.update_entry("passed_entry", "✅ success", time_taken_s=time_taken_s)
+    message.update_entry("passed_entry", "✅ success")
     message.update_entry("failed_entry", "❌ FAILED")
 
     blocks = message.to_slack_blocks()
     section_texts = _section_texts(blocks)
-    table_rows = _table_rows(blocks)
 
     assert section_texts[0] == (
         "*Total entries:* 4  •  *passed ✅:* 1  •  *failed ❌:* 1  •  *running ▶️:* 1  •  *waiting ⏳:* 1"
     )
     assert all("Overall Status" not in text for text in section_texts)
-    assert all(len(row) == 3 for row in table_rows)
-    assert _row_texts(table_rows[0]) == ["waiting_entry", "⏳ waiting to start", " "]
-    assert _row_texts(table_rows[1]) == ["running_entry", "▶️ running", " "]
-    assert _row_texts(table_rows[2]) == ["passed_entry", "✅ success", "12.35s"]
-    assert _row_texts(table_rows[3]) == ["failed_entry", "❌ FAILED", " "]
+    assert all(block.get("type") != "table" for block in blocks)
 
 
 def test_slack_parent_message_labels_viewer_link_with_session_name() -> None:
@@ -76,7 +62,7 @@ def test_slack_parent_message_labels_viewer_link_with_session_name() -> None:
 
 def test_slack_parent_message_fallback_reports_entry_status_counts() -> None:
     message = SlackParentMessage(session_name="test-session", env_dict={})
-    message.update_entry("passed_entry", "✅ success", time_taken_s="12.35s")
+    message.update_entry("passed_entry", "✅ success")
     message.update_entry("failed_entry", "❌ FAILED")
 
     fallback_text = message.to_fallback_text()
@@ -86,4 +72,5 @@ def test_slack_parent_message_fallback_reports_entry_status_counts() -> None:
     assert "failed ❌: 1" in fallback_text
     assert "running ▶️: 0" in fallback_text
     assert "waiting ⏳: 0" in fallback_text
-    assert "passed_entry: ✅ success (12.35s)" in fallback_text
+    assert "Benchmark Entries:" not in fallback_text
+    assert "passed_entry" not in fallback_text

--- a/tests/benchmarking/test_run_sink_hooks.py
+++ b/tests/benchmarking/test_run_sink_hooks.py
@@ -1,0 +1,86 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "benchmarking"))
+
+import run as benchmark_run
+
+
+class _Sink:
+    def __init__(self, fail_hooks: set[str] | None = None) -> None:
+        self.fail_hooks = fail_hooks or set()
+        self.calls: list[tuple[str, dict[str, object]]] = []
+
+    def _record(self, hook_name: str, kwargs: dict[str, object]) -> None:
+        self.calls.append((hook_name, kwargs))
+        if hook_name in self.fail_hooks:
+            msg = f"{hook_name} failed"
+            raise RuntimeError(msg)
+
+    def initialize(self, **kwargs: object) -> None:
+        self._record("initialize", kwargs)
+
+    def register_benchmark_entry_starting(self, **kwargs: object) -> None:
+        self._record("register_benchmark_entry_starting", kwargs)
+
+    def register_benchmark_entry_finished(self, **kwargs: object) -> None:
+        self._record("register_benchmark_entry_finished", kwargs)
+
+    def finalize(self, **kwargs: object) -> None:
+        self._record("finalize", kwargs)
+
+
+def test_call_sink_hook_returns_false_when_sink_raises() -> None:
+    sink = _Sink(fail_hooks={"register_benchmark_entry_starting"})
+
+    success = benchmark_run._call_sink_hook(
+        sink,
+        "register_benchmark_entry_starting",
+        context="marking an entry as running",
+        result_dict={"name": "entry_a"},
+        benchmark_entry=object(),
+    )
+
+    assert success is False
+    assert sink.calls[0][0] == "register_benchmark_entry_starting"
+
+
+def test_call_sink_hook_returns_true_when_sink_succeeds() -> None:
+    sink = _Sink()
+
+    success = benchmark_run._call_sink_hook(sink, "finalize", context="finalizing sinks")
+
+    assert success is True
+    assert sink.calls == [("finalize", {})]
+
+
+def test_initialize_sinks_filters_failed_initialization() -> None:
+    failing_sink = _Sink(fail_hooks={"initialize"})
+    working_sink = _Sink()
+
+    active_sinks = benchmark_run._initialize_sinks(
+        [failing_sink, working_sink],
+        session_name="test-session",
+        session=object(),
+        env_dict={},
+    )
+
+    assert active_sinks == [working_sink]
+    assert failing_sink.calls[0][0] == "initialize"
+    assert working_sink.calls[0][0] == "initialize"

--- a/tests/benchmarking/test_run_sink_hooks.py
+++ b/tests/benchmarking/test_run_sink_hooks.py
@@ -19,7 +19,7 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "benchmarking"))
 
-import run as benchmark_run
+from runner.sinks.sink import call_sink_hook, initialize_sinks
 
 
 class _Sink:
@@ -49,7 +49,7 @@ class _Sink:
 def test_call_sink_hook_returns_false_when_sink_raises() -> None:
     sink = _Sink(fail_hooks={"register_benchmark_entry_starting"})
 
-    success = benchmark_run._call_sink_hook(
+    success = call_sink_hook(
         sink,
         "register_benchmark_entry_starting",
         context="marking an entry as running",
@@ -64,7 +64,7 @@ def test_call_sink_hook_returns_false_when_sink_raises() -> None:
 def test_call_sink_hook_returns_true_when_sink_succeeds() -> None:
     sink = _Sink()
 
-    success = benchmark_run._call_sink_hook(sink, "finalize", context="finalizing sinks")
+    success = call_sink_hook(sink, "finalize", context="finalizing sinks")
 
     assert success is True
     assert sink.calls == [("finalize", {})]
@@ -74,7 +74,7 @@ def test_initialize_sinks_filters_failed_initialization() -> None:
     failing_sink = _Sink(fail_hooks={"initialize"})
     working_sink = _Sink()
 
-    active_sinks = benchmark_run._initialize_sinks(
+    active_sinks = initialize_sinks(
         [failing_sink, working_sink],
         session_name="test-session",
         session=object(),


### PR DESCRIPTION
## Summary
- isolate benchmark runner sink hook failures from benchmark entry execution
- move sink hook helpers out of `benchmarking/run.py` into an import-light sink module for focused unit coverage
- disable sinks that fail initialization while continuing the session
- bound the Slack parent message to a header, live status counts, explicit run status, and optional results-viewer link
- keep detailed per-entry Slack thread replies unchanged while removing the parent table and parent-only time_taken_s state

## Motivation
Recent nightly runs failed before some benchmark entries executed because Slack sink updates raised Slack API exceptions such as `msg_too_long`. Sink/reporting failures should be logged, but should not be treated as benchmark entry failures. The Slack parent message also needs a bounded payload because benchmark suites can grow beyond Slack table/message limits; detailed run status should live in the run viewer and threaded replies instead.

## Testing
- `git diff --check`
- `python -m py_compile benchmarking/run.py benchmarking/runner/sinks/sink.py tests/benchmarking/test_run_sink_hooks.py`
- `python -m pytest tests/benchmarking/test_run_sink_hooks.py --confcutdir=tests/benchmarking`
- `python -m py_compile benchmarking/runner/sinks/slack_sink.py tests/benchmarking/runner/sinks/test_slack_sink.py`
- smoke-tested `SlackParentMessage` with stubbed external dependencies to verify the parent message has no table block, includes the viewer link, and reports running/complete/complete-with-failures states
- git commit hooks: ruff, ruff format, and signoff passed

Focused Slack-sink pytest still was not run in this shell because the plain Python environment lacks `loguru`. Running pytest without `--confcutdir` is also blocked locally because `tests/conftest.py` imports `ray`.