### PR TITLE
[benchmarking] Limit Slack threaded replies to issues

### DIFF
--- a/benchmarking/nightly-benchmark.yaml
+++ b/benchmarking/nightly-benchmark.yaml
@@ -158,6 +158,7 @@ sinks:
   - name: slack
     enabled: true
     live_updates: true
+    thread_replies_for_failures_or_warnings_only: true
     channel_id: ${SLACK_CHANNEL_ID}
     default_metrics: ["exec_time_s"]
     ping_users_on_failure: true

--- a/benchmarking/runner/sinks/slack_sink.py
+++ b/benchmarking/runner/sinks/slack_sink.py
@@ -522,6 +522,12 @@ class SlackSink(Sink):
         # to remove the per-entry lists. Default True preserves existing behavior.
         self.ping_users_on_failure: bool = sink_config.get("ping_users_on_failure", True)
 
+        # When true, post threaded per-entry replies only for failures or entries
+        # with warnings. The parent summary is still updated for every entry.
+        self.thread_replies_for_failures_or_warnings_only: bool = sink_config.get(
+            "thread_replies_for_failures_or_warnings_only", False
+        )
+
         # Optional legacy sink-level run-viewer URL. Prefer Session.viewer_url for
         # new callers so the value is available to any sink, not just Slack.
         self.viewer_url: str | None = sink_config.get("viewer_url")
@@ -646,14 +652,15 @@ class SlackSink(Sink):
         status_text = "✅ success" if result_dict["success"] else "❌ FAILED"
         warnings = result_dict.get("warnings", [])
 
-        # Create a new message for the entry to post in the thread.
-        msg = self._create_benchmark_entry_message(
-            benchmark_entry,
-            (self.default_metrics + additional_metrics, result_dict),
-            pings,
-            warnings,
-        )
-        self._child_messages.append(msg)
+        if self._should_post_benchmark_entry_message(result_dict, warnings):
+            # Create a new message for the entry to post in the thread.
+            msg = self._create_benchmark_entry_message(
+                benchmark_entry,
+                (self.default_metrics + additional_metrics, result_dict),
+                pings,
+                warnings,
+            )
+            self._child_messages.append(msg)
         # Update the session summary message with the new entry status.
         self._update_parent_entry(benchmark_entry.name, status_text)
 
@@ -712,6 +719,12 @@ class SlackSink(Sink):
             pings=pings,
             warnings=warnings,
         )
+
+    def _should_post_benchmark_entry_message(self, result_dict: dict[str, Any], warnings: list[str]) -> bool:
+        """Return whether to post a threaded per-entry Slack reply."""
+        if not self.thread_replies_for_failures_or_warnings_only:
+            return True
+        return not result_dict["success"] or bool(warnings)
 
     def _update_parent_entry(self, entry_name: str, status: str) -> None:
         """Update a single entry's status in the shared state file and post the update to Slack.

--- a/tests/benchmarking/runner/sinks/test_slack_sink.py
+++ b/tests/benchmarking/runner/sinks/test_slack_sink.py
@@ -16,11 +16,14 @@ from __future__ import annotations
 
 import sys
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    import pytest
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[4] / "benchmarking"))
 
-from runner.sinks.slack_sink import SlackParentMessage
+from runner.sinks.slack_sink import SlackParentMessage, SlackSink
 
 
 def _section_texts(blocks: list[dict[str, Any]]) -> list[str]:
@@ -78,3 +81,28 @@ def test_slack_parent_message_fallback_reports_entry_status_counts() -> None:
     assert "Run status: ❌ complete with failures" in fallback_text
     assert "Benchmark Entries:" not in fallback_text
     assert "passed_entry" not in fallback_text
+
+
+def _slack_sink(monkeypatch: pytest.MonkeyPatch, **config_overrides: object) -> SlackSink:
+    monkeypatch.setenv("SLACK_BOT_TOKEN", "test-token")
+    return SlackSink(
+        {
+            "channel_id": "C123",
+            "default_metrics": ["exec_time_s"],
+            **config_overrides,
+        }
+    )
+
+
+def test_slack_sink_posts_entry_replies_by_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    sink = _slack_sink(monkeypatch)
+
+    assert sink._should_post_benchmark_entry_message({"success": True}, []) is True
+
+
+def test_slack_sink_can_limit_entry_replies_to_failures_or_warnings(monkeypatch: pytest.MonkeyPatch) -> None:
+    sink = _slack_sink(monkeypatch, thread_replies_for_failures_or_warnings_only=True)
+
+    assert sink._should_post_benchmark_entry_message({"success": True}, []) is False
+    assert sink._should_post_benchmark_entry_message({"success": True}, ["warning"])
+    assert sink._should_post_benchmark_entry_message({"success": False}, [])


### PR DESCRIPTION
## Summary
- add a Slack sink option to post threaded per-entry replies only for failures or entries with warnings
- preserve current default behavior by defaulting `thread_replies_for_failures_or_warnings_only` to `false`
- enable the option for nightly benchmark Slack reporting
- add focused tests for default and filtered threaded-reply behavior

## Testing
- `python -m py_compile benchmarking/runner/sinks/slack_sink.py tests/benchmarking/runner/sinks/test_slack_sink.py`
- `git diff --check`
- stubbed smoke test for the new threaded-reply decision logic
- commit hooks: YAML, ruff, ruff format, and signoff passed

Focused Slack sink pytest was not run in this local shell because the plain Python environment lacks `loguru`.