### PR TITLE
perf: use PyArrow fast path for JSONL reads

### DIFF
--- a/fern/versions/main/pages/curate-text/load-data/read-existing.mdx
+++ b/fern/versions/main/pages/curate-text/load-data/read-existing.mdx
@@ -130,6 +130,9 @@ Both `JsonlReader` and `ParquetReader` support these configuration options:
 | `"pandas"` | `pandas.DataFrame` | You need pandas-specific options or inference, such as `convert_dates` or mixed-type object columns |
 | Another pandas engine, such as `"ujson"` or `"pyarrow"` | `pandas.DataFrame` | You explicitly need an engine supported by `pandas.read_json` |
 
+Use `engine="pandas"` or `engine="ujson"` with `lines=False`. Both `engine="pyarrow_direct"`
+and `engine="pyarrow"` require `lines=True`.
+
 The direct engine does not silently fall back to pandas. If PyArrow cannot infer a consistent
 schema—for example, when one JSON field contains both numbers and strings—select the pandas
 engine explicitly:

--- a/fern/versions/main/pages/curate-text/load-data/read-existing.mdx
+++ b/fern/versions/main/pages/curate-text/load-data/read-existing.mdx
@@ -119,6 +119,51 @@ Both `JsonlReader` and `ParquetReader` support these configuration options:
 | `fields` | list[str] \| None | Column names to read (column selection) | None (all columns) |
 | `read_kwargs` | dict[str, Any] \| None | Extra arguments for the underlying reader | None |
 
+### JSONL Engine Selection
+
+`JsonlReader` parses JSONL directly into a PyArrow table by default. Choose the engine through
+`read_kwargs` when your dataset requires different inference behavior.
+
+| `read_kwargs["engine"]` | Output backing type | Use when |
+| --- | --- | --- |
+| Omitted or `"pyarrow_direct"` | `pyarrow.Table` | Recommended for throughput and Arrow-native processing |
+| `"pandas"` | `pandas.DataFrame` | You need pandas-specific options or inference, such as `convert_dates` or mixed-type object columns |
+| Another pandas engine, such as `"ujson"` or `"pyarrow"` | `pandas.DataFrame` | You explicitly need an engine supported by `pandas.read_json` |
+
+The direct engine does not silently fall back to pandas. If PyArrow cannot infer a consistent
+schema—for example, when one JSON field contains both numbers and strings—select the pandas
+engine explicitly:
+
+```python
+reader = JsonlReader(
+    file_paths="/path/to/data",
+    read_kwargs={
+        "engine": "pandas",
+        "convert_dates": ["created_at"],
+    },
+)
+```
+
+The direct engine accepts these additional options:
+
+| Option | Description | Default |
+| --- | --- | --- |
+| `pyarrow_block_size` | Initial number of bytes PyArrow processes per parser block | 8 MiB |
+| `pyarrow_max_block_size` | Maximum parser block used when retrying an unusually large JSON object | 256 MiB |
+| `storage_options` | Options passed to `fsspec` when opening remote files | `{}` |
+| `compression` | Compression passed to `fsspec`; `"infer"` uses the file extension | `"infer"` |
+| `lines` | JSONL requires one JSON object per line and therefore only supports `True` | `True` |
+
+`pyarrow_block_size` is separate from the top-level `blocksize` parameter. The top-level parameter
+controls how files are grouped into distributed tasks; the PyArrow option controls parsing inside
+each file. When one JSON object is too large for the initial parser window, Curator doubles the
+parser block and retries up to `pyarrow_max_block_size`. The maximum is a safety ceiling for rows
+such as base64-encoded images or PDFs, not the amount read for every row. If the row still does not
+fit, the PyArrow error is returned to the caller.
+
+Remote JSONL paths continue to use `fsspec`, with the resulting file-like stream passed directly to
+PyArrow. This supports the same remote paths and `storage_options` used during file partitioning.
+
 ### Parquet-Specific Features
 
 `ParquetReader` provides these optimizations:

--- a/fern/versions/main/pages/curate-text/load-data/read-existing.mdx
+++ b/fern/versions/main/pages/curate-text/load-data/read-existing.mdx
@@ -130,9 +130,6 @@ Both `JsonlReader` and `ParquetReader` support these configuration options:
 | `"pandas"` | `pandas.DataFrame` | You need pandas-specific options or inference, such as `convert_dates` or mixed-type object columns |
 | Another pandas engine, such as `"ujson"` or `"pyarrow"` | `pandas.DataFrame` | You explicitly need an engine supported by `pandas.read_json` |
 
-Use `engine="pandas"` or `engine="ujson"` with `lines=False`. Both `engine="pyarrow_direct"`
-and `engine="pyarrow"` require `lines=True`.
-
 The direct engine does not silently fall back to pandas. If PyArrow cannot infer a consistent
 schema—for example, when one JSON field contains both numbers and strings—select the pandas
 engine explicitly:

--- a/fern/versions/main/pages/curate-text/load-data/read-existing.mdx
+++ b/fern/versions/main/pages/curate-text/load-data/read-existing.mdx
@@ -150,19 +150,9 @@ The direct engine accepts these additional options:
 | --- | --- | --- |
 | `pyarrow_block_size` | Initial number of bytes PyArrow processes per parser block | 8 MiB |
 | `pyarrow_max_block_size` | Maximum parser block used when retrying an unusually large JSON object | 256 MiB |
-| `storage_options` | Options passed to `fsspec` when opening remote files | `{}` |
-| `compression` | Compression passed to `fsspec`; `"infer"` uses the file extension | `"infer"` |
-| `lines` | JSONL requires one JSON object per line and therefore only supports `True` | `True` |
 
-`pyarrow_block_size` is separate from the top-level `blocksize` parameter. The top-level parameter
-controls how files are grouped into distributed tasks; the PyArrow option controls parsing inside
-each file. When one JSON object is too large for the initial parser window, Curator doubles the
-parser block and retries up to `pyarrow_max_block_size`. The maximum is a safety ceiling for rows
-such as base64-encoded images or PDFs, not the amount read for every row. If the row still does not
-fit, the PyArrow error is returned to the caller.
-
-Remote JSONL paths continue to use `fsspec`, with the resulting file-like stream passed directly to
-PyArrow. This supports the same remote paths and `storage_options` used during file partitioning.
+The direct reader processes 8 MiB chunks and retries with larger chunks, up to 256 MiB, for rows
+containing large payloads such as base64-encoded images or PDFs.
 
 ### Parquet-Specific Features
 

--- a/fern/versions/main/pages/curate-text/process-data/content-processing/add-id.mdx
+++ b/fern/versions/main/pages/curate-text/process-data/content-processing/add-id.mdx
@@ -119,7 +119,7 @@ results = pipeline.run()
 ray_client.stop()
 
 # Examine the first 5 rows of the first DocumentBatch
-print(results[0].data.head())
+print(results[0].to_pandas().head())
 ```
 
 This approach:

--- a/nemo_curator/stages/text/classifiers/utils.py
+++ b/nemo_curator/stages/text/classifiers/utils.py
@@ -36,10 +36,10 @@ class SortByLengthStage(ProcessingStage[DocumentBatch, DocumentBatch]):
         return ["data"], [ATTENTION_MASK_FIELD, SEQ_ORDER_FIELD]
 
     def process(self, batch: DocumentBatch) -> DocumentBatch:
-        if SEQ_ORDER_FIELD in batch.data.columns:
+        if SEQ_ORDER_FIELD in batch.get_columns():
             return batch
 
-        output = batch.data.copy()
+        output = batch.to_pandas()
 
         # Add column to preserve original order
         output[SEQ_ORDER_FIELD] = np.arange(len(output))

--- a/nemo_curator/stages/text/io/reader/base.py
+++ b/nemo_curator/stages/text/io/reader/base.py
@@ -90,19 +90,19 @@ class BaseReader(ProcessingStage[ReaderTask, DocumentBatch]):
         return self._document_batch(task, output)
 
     def _document_batch(self, task: ReaderTask, output: ReaderOutput) -> DocumentBatch:
-        result = output.data
+        batch = DocumentBatch(
+            dataset_name=task.dataset_name,
+            data=output.data,
+            _metadata=output.metadata if output.metadata is not None else task._metadata,
+        )
         if self._generate_ids or self._assign_ids:
             batch_key = self._id_generator_key(task)
             if self._generate_ids:
-                result = self._generate_ids_func(batch_key, result)
+                self._generate_ids_func(batch_key, batch)
             else:
-                result = self._assign_ids_func(batch_key, result)
+                self._assign_ids_func(batch_key, batch)
 
-        return DocumentBatch(
-            dataset_name=task.dataset_name,
-            data=result,
-            _metadata=output.metadata if output.metadata is not None else task._metadata,
-        )
+        return batch
 
     def _validate_result(self, task: ReaderTask, result: ReaderData) -> None:
         if self.allow_empty:
@@ -134,36 +134,32 @@ class BaseReader(ProcessingStage[ReaderTask, DocumentBatch]):
         return task.get_deterministic_id()
 
     @staticmethod
-    def _append_ids(data: ReaderData, ids: np.ndarray) -> ReaderData:
+    def _append_ids(batch: DocumentBatch, start_id: int, count: int) -> None:
         from nemo_curator.stages.deduplication.id_generator import CURATOR_DEDUP_ID_STR
 
-        if isinstance(data, pd.DataFrame):
-            data[CURATOR_DEDUP_ID_STR] = ids
-            return data
-        return data.append_column(CURATOR_DEDUP_ID_STR, pa.array(ids, type=pa.int64()))
-
-    def _assign_ids_func(self, filepath: str | list[str], data: ReaderData) -> ReaderData:
-        from nemo_curator.stages.deduplication.id_generator import CURATOR_DEDUP_ID_STR
-
-        columns = data.columns if isinstance(data, pd.DataFrame) else data.column_names
-        if CURATOR_DEDUP_ID_STR not in columns:
-            min_id, max_id = ray.get(self.id_generator.get_batch_range.remote(filepath, None))
-            data = self._append_ids(data, np.arange(min_id, max_id + 1))
+        ids = np.arange(start_id, start_id + count)
+        if isinstance(batch.data, pd.DataFrame):
+            batch.data[CURATOR_DEDUP_ID_STR] = ids
         else:
-            logger.warning(f"Column {CURATOR_DEDUP_ID_STR} already exists in {filepath}, not re-assigning IDs")
-        return data
+            batch.data = batch.data.append_column(CURATOR_DEDUP_ID_STR, pa.array(ids, type=pa.int64()))
 
-    def _generate_ids_func(self, filepath: str | list[str], data: ReaderData) -> ReaderData:
+    def _assign_ids_func(self, batch_key: str | list[str], batch: DocumentBatch) -> None:
         from nemo_curator.stages.deduplication.id_generator import CURATOR_DEDUP_ID_STR
 
-        columns = data.columns if isinstance(data, pd.DataFrame) else data.column_names
-        if CURATOR_DEDUP_ID_STR not in columns:
-            num_rows = len(data)
-            min_id = ray.get(self.id_generator.register_batch.remote(filepath, num_rows))
-            data = self._append_ids(data, np.arange(min_id, min_id + num_rows))
+        if CURATOR_DEDUP_ID_STR not in batch.get_columns():
+            min_id, max_id = ray.get(self.id_generator.get_batch_range.remote(batch_key, None))
+            self._append_ids(batch, min_id, max_id - min_id + 1)
         else:
-            logger.warning(f"Column {CURATOR_DEDUP_ID_STR} already exists in {filepath}, not generating new IDs")
-        return data
+            logger.warning(f"Column {CURATOR_DEDUP_ID_STR} already exists in {batch_key}, not re-assigning IDs")
+
+    def _generate_ids_func(self, batch_key: str | list[str], batch: DocumentBatch) -> None:
+        from nemo_curator.stages.deduplication.id_generator import CURATOR_DEDUP_ID_STR
+
+        if CURATOR_DEDUP_ID_STR not in batch.get_columns():
+            min_id = ray.get(self.id_generator.register_batch.remote(batch_key, batch.num_items))
+            self._append_ids(batch, min_id, batch.num_items)
+        else:
+            logger.warning(f"Column {CURATOR_DEDUP_ID_STR} already exists in {batch_key}, not generating new IDs")
 
     def ray_stage_spec(self) -> dict[str, Any]:
         return {RayStageSpecKeys.IS_ACTOR_STAGE: self._generate_ids or self._assign_ids}

--- a/nemo_curator/stages/text/io/reader/base.py
+++ b/nemo_curator/stages/text/io/reader/base.py
@@ -91,12 +91,12 @@ class BaseReader(ProcessingStage[ReaderTask, DocumentBatch]):
 
     def _document_batch(self, task: ReaderTask, output: ReaderOutput) -> DocumentBatch:
         result = output.data
-        # Apply IDs only for Pandas DataFrames
-        if isinstance(result, pd.DataFrame):
+        if self._generate_ids or self._assign_ids:
+            batch_key = self._id_generator_key(task)
             if self._generate_ids:
-                result = self._generate_ids_func(task.data, result)
-            elif self._assign_ids:
-                result = self._assign_ids_func(task.data, result)
+                result = self._generate_ids_func(batch_key, result)
+            else:
+                result = self._assign_ids_func(batch_key, result)
 
         return DocumentBatch(
             dataset_name=task.dataset_name,
@@ -125,26 +125,43 @@ class BaseReader(ProcessingStage[ReaderTask, DocumentBatch]):
         raise NotImplementedError
 
     # ID helpers ----------------------------------------------------------------
-    def _assign_ids_func(self, filepath: str | list[str], df: pd.DataFrame) -> pd.DataFrame:
+    @staticmethod
+    def _id_generator_key(task: ReaderTask) -> str | list[str]:
+        if isinstance(task, FileGroupTask):
+            return task.data
+        return task.get_deterministic_id()
+
+    @staticmethod
+    def _append_ids(data: ReaderData, ids: np.ndarray) -> ReaderData:
         from nemo_curator.stages.deduplication.id_generator import CURATOR_DEDUP_ID_STR
 
-        if CURATOR_DEDUP_ID_STR not in df.columns:
+        if isinstance(data, pd.DataFrame):
+            data[CURATOR_DEDUP_ID_STR] = ids
+            return data
+        return data.append_column(CURATOR_DEDUP_ID_STR, pa.array(ids, type=pa.int64()))
+
+    def _assign_ids_func(self, filepath: str | list[str], data: ReaderData) -> ReaderData:
+        from nemo_curator.stages.deduplication.id_generator import CURATOR_DEDUP_ID_STR
+
+        columns = data.columns if isinstance(data, pd.DataFrame) else data.column_names
+        if CURATOR_DEDUP_ID_STR not in columns:
             min_id, max_id = ray.get(self.id_generator.get_batch_range.remote(filepath, None))
-            df[CURATOR_DEDUP_ID_STR] = np.arange(min_id, max_id + 1)
+            data = self._append_ids(data, np.arange(min_id, max_id + 1))
         else:
             logger.warning(f"Column {CURATOR_DEDUP_ID_STR} already exists in {filepath}, not re-assigning IDs")
-        return df
+        return data
 
-    def _generate_ids_func(self, filepath: str | list[str], df: pd.DataFrame) -> pd.DataFrame:
+    def _generate_ids_func(self, filepath: str | list[str], data: ReaderData) -> ReaderData:
         from nemo_curator.stages.deduplication.id_generator import CURATOR_DEDUP_ID_STR
 
-        if CURATOR_DEDUP_ID_STR not in df.columns:
-            num_rows = len(df)
+        columns = data.columns if isinstance(data, pd.DataFrame) else data.column_names
+        if CURATOR_DEDUP_ID_STR not in columns:
+            num_rows = len(data)
             min_id = ray.get(self.id_generator.register_batch.remote(filepath, num_rows))
-            df[CURATOR_DEDUP_ID_STR] = np.arange(min_id, min_id + num_rows)
+            data = self._append_ids(data, np.arange(min_id, min_id + num_rows))
         else:
             logger.warning(f"Column {CURATOR_DEDUP_ID_STR} already exists in {filepath}, not generating new IDs")
-        return df
+        return data
 
     def ray_stage_spec(self) -> dict[str, Any]:
         return {RayStageSpecKeys.IS_ACTOR_STAGE: self._generate_ids or self._assign_ids}

--- a/nemo_curator/stages/text/io/reader/base.py
+++ b/nemo_curator/stages/text/io/reader/base.py
@@ -127,6 +127,8 @@ class BaseReader(ProcessingStage[ReaderTask, DocumentBatch]):
     # ID helpers ----------------------------------------------------------------
     @staticmethod
     def _id_generator_key(task: ReaderTask) -> str | list[str]:
+        # TODO(NMCUR-315): Use the deterministic task ID for FileGroupTask as well.
+        # Keep returning file paths for backward compatibility until existing ID registries are migrated.
         if isinstance(task, FileGroupTask):
             return task.data
         return task.get_deterministic_id()

--- a/nemo_curator/stages/text/io/reader/jsonl.py
+++ b/nemo_curator/stages/text/io/reader/jsonl.py
@@ -31,6 +31,10 @@ from .base import BaseFileReader
 
 PANDAS_ENGINE = "pandas"
 PYARROW_DIRECT_ENGINE = "pyarrow_direct"
+# These parser block sizes are independent of JsonlReader.blocksize, which controls
+# how files are grouped into tasks. Start above PyArrow's 1 MiB default to avoid
+# retries for moderately large records, but cap retries for unusually large rows
+# such as records containing base64-encoded images or PDFs.
 DEFAULT_PYARROW_BLOCK_SIZE = 8 * 1024 * 1024
 DEFAULT_PYARROW_MAX_BLOCK_SIZE = 256 * 1024 * 1024
 
@@ -57,6 +61,14 @@ def _read_jsonl_file_with_pyarrow(
     storage_options: dict[str, Any],
     compression: str | None,
 ) -> pa.Table:
+    """Read one JSONL file, growing the parser block for an oversized record.
+
+    PyArrow reports ``straddling object`` when a JSON object is too large for
+    its current parsing window. Each retry doubles the block size up to
+    ``max_block_size``; the error is re-raised at the ceiling, so this loop is
+    bounded. Remote paths and custom storage options are opened through
+    ``fsspec`` and passed to PyArrow as a file-like stream.
+    """
     while True:
         try:
             read_options = paj.ReadOptions(block_size=block_size, use_threads=False)
@@ -80,6 +92,7 @@ def _read_jsonl_with_pyarrow(
     read_kwargs: dict[str, Any],
     fields: list[str] | None,
 ) -> pa.Table:
+    """Read JSONL paths directly into Arrow without a pandas conversion."""
     read_kwargs = dict(read_kwargs)
     read_kwargs.pop("engine", None)
     if read_kwargs.pop("lines", True) is False:
@@ -153,7 +166,14 @@ class JsonlReaderStage(BaseFileReader):
 
     Args:
         fields (list[str], optional): If specified, only read these fields (columns). Defaults to None.
-        read_kwargs (dict[str, Any], optional): Keyword arguments for the reader. Defaults to {}.
+        read_kwargs (dict[str, Any], optional): Reader options. The default
+            ``engine="pyarrow_direct"`` returns a ``pa.Table``. Select
+            ``engine="pandas"`` for a ``pd.DataFrame`` and pandas-specific
+            parsing or type inference. Other engine values are forwarded to
+            ``pd.read_json`` for backward compatibility. The direct engine
+            accepts ``compression``, ``storage_options``,
+            ``pyarrow_block_size``, and ``pyarrow_max_block_size``;
+            ``lines`` must remain ``True``. Defaults to {}.
         _generate_ids (bool): Whether to generate monotonically increasing IDs across all files.
             This uses IdGenerator actor, which needs to be instantiated before using this stage.
             This can be slow, so it is recommended to use AddId stage instead, unless monotonically increasing IDs
@@ -175,8 +195,10 @@ class JsonlReaderStage(BaseFileReader):
         """Read JSONL files into an Arrow table or pandas DataFrame.
 
         The default ``pyarrow_direct`` engine retains Arrow data without a
-        pandas conversion. Use ``engine="pandas"`` when pandas-specific
-        parsing and inference are required.
+        pandas conversion and does not fall back when Arrow rejects an input.
+        Use ``engine="pandas"`` when pandas-specific parsing and inference are
+        required. Other engine values are delegated to ``pd.read_json`` and
+        also return a pandas DataFrame.
         """
 
         read_kwargs = {} if read_kwargs is None else dict(read_kwargs)
@@ -193,6 +215,25 @@ class JsonlReader(CompositeStage[EmptyTask, DocumentBatch]):
     This high-level stage decomposes into:
     1. FilePartitioningStage - partitions files into groups
     2. JsonlReaderStage - reads file groups into DocumentBatches
+
+    Args:
+        file_paths: File paths, directories, or glob patterns to read.
+        files_per_partition: Number of files grouped into each reader task.
+            When set, this takes precedence over ``blocksize``.
+        blocksize: Target storage size for each file-group task. This does not
+            control PyArrow's parser blocks; configure those through
+            ``read_kwargs`` instead.
+        fields: Optional columns to retain.
+        read_kwargs: Options for JSON parsing and remote storage. Direct
+            PyArrow parsing is the default. Set ``engine="pandas"`` for pandas
+            inference or another pandas-supported engine value to delegate to
+            ``pd.read_json``. The direct engine accepts ``compression``,
+            ``storage_options``, ``pyarrow_block_size``, and
+            ``pyarrow_max_block_size``.
+        task_type: Output task modality. Only ``"document"`` is supported.
+        file_extensions: File extensions considered during partitioning.
+        _generate_ids: Generate stable, monotonically increasing document IDs.
+        _assign_ids: Assign IDs previously registered for the same reader task.
     """
 
     file_paths: str | list[str]

--- a/nemo_curator/stages/text/io/reader/jsonl.py
+++ b/nemo_curator/stages/text/io/reader/jsonl.py
@@ -137,10 +137,7 @@ def _read_jsonl_with_pandas(
     read_kwargs = dict(read_kwargs)
     if read_kwargs.get("engine") == PANDAS_ENGINE:
         read_kwargs.pop("engine")
-    if read_kwargs.get("lines", True) is False:
-        msg = "lines=False is not supported for JSONL reader"
-        raise ValueError(msg)
-    read_kwargs["lines"] = True
+    read_kwargs.setdefault("lines", True)
 
     dfs = []
     for file_path in paths:

--- a/nemo_curator/stages/text/io/reader/jsonl.py
+++ b/nemo_curator/stages/text/io/reader/jsonl.py
@@ -37,6 +37,12 @@ DEFAULT_PYARROW_BLOCK_SIZE = 8 * 1024 * 1024
 DEFAULT_PYARROW_MAX_BLOCK_SIZE = 256 * 1024 * 1024
 
 
+def _validate_jsonl_read_kwargs(read_kwargs: dict[str, Any] | None) -> None:
+    if read_kwargs is not None and read_kwargs.get("lines", True) is False:
+        msg = "JsonlReader only supports lines=True"
+        raise RuntimeError(msg)
+
+
 def _pyarrow_select_columns(table: pa.Table, fields: list[str] | None, file_path: str) -> pa.Table | None:
     if fields is None:
         return table
@@ -93,9 +99,7 @@ def _read_jsonl_with_pyarrow(
     """Read JSONL paths directly with PyArrow."""
     read_kwargs = dict(read_kwargs)
     read_kwargs.pop("engine", None)
-    if read_kwargs.pop("lines", True) is False:
-        msg = f"engine={PYARROW_DIRECT_ENGINE!r} only supports lines=True"
-        raise RuntimeError(msg)
+    read_kwargs.pop("lines", None)
 
     block_size = read_kwargs.pop("pyarrow_block_size", DEFAULT_PYARROW_BLOCK_SIZE)
     max_block_size = read_kwargs.pop("pyarrow_max_block_size", DEFAULT_PYARROW_MAX_BLOCK_SIZE)
@@ -137,7 +141,7 @@ def _read_jsonl_with_pandas(
     read_kwargs = dict(read_kwargs)
     if read_kwargs.get("engine") == PANDAS_ENGINE:
         read_kwargs.pop("engine")
-    read_kwargs.setdefault("lines", True)
+    read_kwargs["lines"] = True
 
     dfs = []
     for file_path in paths:
@@ -175,6 +179,10 @@ class JsonlReaderStage(BaseFileReader):
     """
 
     name: str = "jsonl_reader"
+
+    def __post_init__(self) -> None:
+        super().__post_init__()
+        _validate_jsonl_read_kwargs(self.read_kwargs)
 
     def read_data(
         self,
@@ -227,6 +235,7 @@ class JsonlReader(CompositeStage[EmptyTask, DocumentBatch]):
     def __post_init__(self):
         """Initialize parent class after dataclass initialization."""
         super().__init__()
+        _validate_jsonl_read_kwargs(self.read_kwargs)
         if self.read_kwargs is not None:
             self.storage_options = self.read_kwargs.get("storage_options", {})
 

--- a/nemo_curator/stages/text/io/reader/jsonl.py
+++ b/nemo_curator/stages/text/io/reader/jsonl.py
@@ -15,15 +15,155 @@
 from dataclasses import dataclass, field
 from typing import Any, Literal
 
+import fsspec
+import numpy as np
 import pandas as pd
+import pyarrow as pa
+import pyarrow.json as paj
 from loguru import logger
 
 from nemo_curator.stages.base import CompositeStage
 from nemo_curator.stages.file_partitioning import FilePartitioningStage
 from nemo_curator.tasks import DocumentBatch, EmptyTask
+from nemo_curator.utils.client_utils import is_remote_url
 from nemo_curator.utils.file_utils import FILETYPE_TO_DEFAULT_EXTENSIONS, pandas_select_columns
 
 from .base import BaseFileReader
+
+AUTO_ENGINE = "auto"
+PANDAS_ENGINE = "pandas"
+PYARROW_DIRECT_ENGINE = "pyarrow_direct"
+DEFAULT_PYARROW_BLOCK_SIZE = 8 * 1024 * 1024
+DEFAULT_PYARROW_MAX_BLOCK_SIZE = 256 * 1024 * 1024
+PYARROW_DIRECT_READ_KWARGS = frozenset(
+    {
+        "compression",
+        "engine",
+        "lines",
+        "pyarrow_block_size",
+        "pyarrow_max_block_size",
+        "storage_options",
+    }
+)
+
+
+def _pyarrow_to_pandas_dtype(arrow_type: pa.DataType) -> pd.StringDtype | None:
+    if pa.types.is_string(arrow_type) or pa.types.is_large_string(arrow_type):
+        try:
+            return pd.StringDtype(storage="pyarrow", na_value=np.nan)
+        except TypeError:  # pandas < 3.0
+            return pd.StringDtype(storage="pyarrow")
+    return None
+
+
+def _pyarrow_select_columns(table: pa.Table, fields: list[str] | None, file_path: str) -> pa.Table | None:
+    if fields is None:
+        return table
+
+    existing_fields = [column for column in fields if column in table.column_names]
+    missing_fields = [column for column in fields if column not in table.column_names]
+    if missing_fields:
+        logger.warning(f"Columns {missing_fields} not found in {file_path}")
+    if existing_fields:
+        return table.select(existing_fields)
+
+    logger.error(f"None of the requested columns found in {file_path}")
+    return None
+
+
+def _read_jsonl_file_with_pyarrow(
+    file_path: str,
+    block_size: int,
+    max_block_size: int,
+    storage_options: dict[str, Any],
+    compression: str | None,
+) -> pa.Table:
+    while True:
+        try:
+            read_options = paj.ReadOptions(block_size=block_size, use_threads=False)
+            if not is_remote_url(file_path) and not storage_options and compression == "infer":
+                return paj.read_json(file_path, read_options=read_options)
+            with fsspec.open(
+                file_path,
+                mode="rb",
+                compression=compression,
+                **storage_options,
+            ) as stream:
+                return paj.read_json(stream, read_options=read_options)
+        except pa.ArrowInvalid as error:
+            if "straddling object" not in str(error) or block_size >= max_block_size:
+                raise
+            block_size = min(block_size * 2, max_block_size)
+
+
+def _read_jsonl_with_pyarrow(
+    paths: list[str],
+    read_kwargs: dict[str, Any],
+    fields: list[str] | None,
+) -> pd.DataFrame:
+    read_kwargs = dict(read_kwargs)
+    read_kwargs.pop("engine", None)
+    if read_kwargs.pop("lines", True) is False:
+        msg = "lines=False is not supported for JSONL reader"
+        raise ValueError(msg)
+
+    block_size = read_kwargs.pop("pyarrow_block_size", DEFAULT_PYARROW_BLOCK_SIZE)
+    max_block_size = read_kwargs.pop("pyarrow_max_block_size", DEFAULT_PYARROW_MAX_BLOCK_SIZE)
+    storage_options = read_kwargs.pop("storage_options", {}) or {}
+    compression = read_kwargs.pop("compression", "infer")
+    if block_size <= 0 or max_block_size < block_size:
+        msg = "pyarrow block sizes must be positive and max block size must be at least the initial size"
+        raise ValueError(msg)
+    if read_kwargs:
+        unsupported = ", ".join(sorted(read_kwargs))
+        msg = f"Unsupported read_kwargs for engine={PYARROW_DIRECT_ENGINE!r}: {unsupported}"
+        raise TypeError(msg)
+
+    tables = []
+    for file_path in paths:
+        table = _read_jsonl_file_with_pyarrow(
+            file_path,
+            block_size,
+            max_block_size,
+            storage_options,
+            compression,
+        )
+        table = _pyarrow_select_columns(table, fields, file_path)
+        if table is not None:
+            tables.append(table)
+    if not tables:
+        msg = f"No data read from files in task {paths} with direct PyArrow JSONL reader"
+        logger.error(msg)
+        raise ValueError(msg)
+
+    table = pa.concat_tables(tables, promote_options="permissive")
+    return table.to_pandas(types_mapper=_pyarrow_to_pandas_dtype, use_threads=False)
+
+
+def _read_jsonl_with_pandas(
+    paths: list[str],
+    read_kwargs: dict[str, Any],
+    fields: list[str] | None,
+) -> pd.DataFrame:
+    read_kwargs = dict(read_kwargs)
+    if read_kwargs.get("engine") in {AUTO_ENGINE, PANDAS_ENGINE}:
+        read_kwargs.pop("engine")
+    if read_kwargs.get("lines", True) is False:
+        msg = "lines=False is not supported for JSONL reader"
+        raise ValueError(msg)
+    read_kwargs["lines"] = True
+
+    dfs = []
+    for file_path in paths:
+        df = pd.read_json(file_path, **read_kwargs)
+        if fields is not None:
+            df = pandas_select_columns(df, fields, file_path)
+        dfs.append(df)
+    if not dfs:
+        msg = f"No data read from files in task {paths} with read_kwargs {read_kwargs} in JSONL reader"
+        logger.error(msg)
+        raise ValueError(msg)
+    return pd.concat(dfs, ignore_index=True)
 
 
 @dataclass
@@ -54,30 +194,35 @@ class JsonlReaderStage(BaseFileReader):
         read_kwargs: dict[str, Any] | None = None,
         fields: list[str] | None = None,
     ) -> pd.DataFrame:
-        """Read JSONL files using Pandas."""
+        """Read JSONL files into a pandas DataFrame.
 
-        # Normalize read_kwargs to a dict to avoid TypeError when None
-        # Work on a copy to avoid mutating caller's dict
+        The default ``auto`` engine uses PyArrow directly, then falls back to
+        pandas when Arrow cannot parse or combine the input. Use
+        ``engine="pyarrow_direct"`` to disable fallback, or ``engine="pandas"``
+        when pandas-specific parsing and inference are required.
+        """
+
         read_kwargs = {} if read_kwargs is None else dict(read_kwargs)
-        # Default to lines=True if not specified
-        if "lines" in read_kwargs and read_kwargs["lines"] is False:
-            msg = "lines=False is not supported for JSONL reader"
-            raise ValueError(msg)
-        else:
-            read_kwargs["lines"] = True
+        engine = read_kwargs.get("engine", AUTO_ENGINE)
+        if engine not in {AUTO_ENGINE, PYARROW_DIRECT_ENGINE}:
+            return _read_jsonl_with_pandas(paths, read_kwargs, fields)
 
-        dfs = []
-        for file_path in paths:
-            df = pd.read_json(file_path, **read_kwargs)
-            if fields is not None:
-                df = pandas_select_columns(df, fields, file_path)
-            dfs.append(df)
-        # Concatenate all dataframes
-        if not dfs:
-            msg = f"No data read from files in task {paths} with read_kwargs {read_kwargs} in JSONL reader"
-            logger.error(msg)
-            raise ValueError(msg)
-        return pd.concat(dfs, ignore_index=True)
+        if engine == AUTO_ENGINE and not set(read_kwargs).issubset(PYARROW_DIRECT_READ_KWARGS):
+            return _read_jsonl_with_pandas(paths, read_kwargs, fields)
+
+        if engine == PYARROW_DIRECT_ENGINE:
+            return _read_jsonl_with_pyarrow(paths, read_kwargs, fields)
+
+        try:
+            return _read_jsonl_with_pyarrow(paths, read_kwargs, fields)
+        except pa.ArrowException as error:
+            logger.warning(f"Direct PyArrow JSONL read failed; falling back to pandas for task {paths}: {error}")
+            pandas_kwargs = {
+                key: value
+                for key, value in read_kwargs.items()
+                if key not in {"pyarrow_block_size", "pyarrow_max_block_size"}
+            }
+            return _read_jsonl_with_pandas(paths, pandas_kwargs, fields)
 
 
 @dataclass

--- a/nemo_curator/stages/text/io/reader/jsonl.py
+++ b/nemo_curator/stages/text/io/reader/jsonl.py
@@ -16,7 +16,6 @@ from dataclasses import dataclass, field
 from typing import Any, Literal
 
 import fsspec
-import numpy as np
 import pandas as pd
 import pyarrow as pa
 import pyarrow.json as paj
@@ -30,30 +29,10 @@ from nemo_curator.utils.file_utils import FILETYPE_TO_DEFAULT_EXTENSIONS, pandas
 
 from .base import BaseFileReader
 
-AUTO_ENGINE = "auto"
 PANDAS_ENGINE = "pandas"
 PYARROW_DIRECT_ENGINE = "pyarrow_direct"
 DEFAULT_PYARROW_BLOCK_SIZE = 8 * 1024 * 1024
 DEFAULT_PYARROW_MAX_BLOCK_SIZE = 256 * 1024 * 1024
-PYARROW_DIRECT_READ_KWARGS = frozenset(
-    {
-        "compression",
-        "engine",
-        "lines",
-        "pyarrow_block_size",
-        "pyarrow_max_block_size",
-        "storage_options",
-    }
-)
-
-
-def _pyarrow_to_pandas_dtype(arrow_type: pa.DataType) -> pd.StringDtype | None:
-    if pa.types.is_string(arrow_type) or pa.types.is_large_string(arrow_type):
-        try:
-            return pd.StringDtype(storage="pyarrow", na_value=np.nan)
-        except TypeError:  # pandas < 3.0
-            return pd.StringDtype(storage="pyarrow")
-    return None
 
 
 def _pyarrow_select_columns(table: pa.Table, fields: list[str] | None, file_path: str) -> pa.Table | None:
@@ -100,7 +79,7 @@ def _read_jsonl_with_pyarrow(
     paths: list[str],
     read_kwargs: dict[str, Any],
     fields: list[str] | None,
-) -> pd.DataFrame:
+) -> pa.Table:
     read_kwargs = dict(read_kwargs)
     read_kwargs.pop("engine", None)
     if read_kwargs.pop("lines", True) is False:
@@ -136,8 +115,7 @@ def _read_jsonl_with_pyarrow(
         logger.error(msg)
         raise ValueError(msg)
 
-    table = pa.concat_tables(tables, promote_options="permissive")
-    return table.to_pandas(types_mapper=_pyarrow_to_pandas_dtype, use_threads=False)
+    return pa.concat_tables(tables, promote_options="permissive")
 
 
 def _read_jsonl_with_pandas(
@@ -146,7 +124,7 @@ def _read_jsonl_with_pandas(
     fields: list[str] | None,
 ) -> pd.DataFrame:
     read_kwargs = dict(read_kwargs)
-    if read_kwargs.get("engine") in {AUTO_ENGINE, PANDAS_ENGINE}:
+    if read_kwargs.get("engine") == PANDAS_ENGINE:
         read_kwargs.pop("engine")
     if read_kwargs.get("lines", True) is False:
         msg = "lines=False is not supported for JSONL reader"
@@ -193,36 +171,19 @@ class JsonlReaderStage(BaseFileReader):
         paths: list[str],
         read_kwargs: dict[str, Any] | None = None,
         fields: list[str] | None = None,
-    ) -> pd.DataFrame:
-        """Read JSONL files into a pandas DataFrame.
+    ) -> pd.DataFrame | pa.Table:
+        """Read JSONL files into an Arrow table or pandas DataFrame.
 
-        The default ``auto`` engine uses PyArrow directly, then falls back to
-        pandas when Arrow cannot parse or combine the input. Use
-        ``engine="pyarrow_direct"`` to disable fallback, or ``engine="pandas"``
-        when pandas-specific parsing and inference are required.
+        The default ``pyarrow_direct`` engine retains Arrow data without a
+        pandas conversion. Use ``engine="pandas"`` when pandas-specific
+        parsing and inference are required.
         """
 
         read_kwargs = {} if read_kwargs is None else dict(read_kwargs)
-        engine = read_kwargs.get("engine", AUTO_ENGINE)
-        if engine not in {AUTO_ENGINE, PYARROW_DIRECT_ENGINE}:
-            return _read_jsonl_with_pandas(paths, read_kwargs, fields)
-
-        if engine == AUTO_ENGINE and not set(read_kwargs).issubset(PYARROW_DIRECT_READ_KWARGS):
-            return _read_jsonl_with_pandas(paths, read_kwargs, fields)
-
+        engine = read_kwargs.get("engine", PYARROW_DIRECT_ENGINE)
         if engine == PYARROW_DIRECT_ENGINE:
             return _read_jsonl_with_pyarrow(paths, read_kwargs, fields)
-
-        try:
-            return _read_jsonl_with_pyarrow(paths, read_kwargs, fields)
-        except pa.ArrowException as error:
-            logger.warning(f"Direct PyArrow JSONL read failed; falling back to pandas for task {paths}: {error}")
-            pandas_kwargs = {
-                key: value
-                for key, value in read_kwargs.items()
-                if key not in {"pyarrow_block_size", "pyarrow_max_block_size"}
-            }
-            return _read_jsonl_with_pandas(paths, pandas_kwargs, fields)
+        return _read_jsonl_with_pandas(paths, read_kwargs, fields)
 
 
 @dataclass

--- a/nemo_curator/stages/text/io/reader/jsonl.py
+++ b/nemo_curator/stages/text/io/reader/jsonl.py
@@ -31,10 +31,8 @@ from .base import BaseFileReader
 
 PANDAS_ENGINE = "pandas"
 PYARROW_DIRECT_ENGINE = "pyarrow_direct"
-# These parser block sizes are independent of JsonlReader.blocksize, which controls
-# how files are grouped into tasks. Start above PyArrow's 1 MiB default to avoid
-# retries for moderately large records, but cap retries for unusually large rows
-# such as records containing base64-encoded images or PDFs.
+# Read 8 MiB chunks to accommodate most rows, but retry up to 256 MiB for
+# rows containing large binary payloads such as base64-encoded images or PDFs.
 DEFAULT_PYARROW_BLOCK_SIZE = 8 * 1024 * 1024
 DEFAULT_PYARROW_MAX_BLOCK_SIZE = 256 * 1024 * 1024
 
@@ -92,12 +90,12 @@ def _read_jsonl_with_pyarrow(
     read_kwargs: dict[str, Any],
     fields: list[str] | None,
 ) -> pa.Table:
-    """Read JSONL paths directly into Arrow without a pandas conversion."""
+    """Read JSONL paths directly with PyArrow."""
     read_kwargs = dict(read_kwargs)
     read_kwargs.pop("engine", None)
     if read_kwargs.pop("lines", True) is False:
-        msg = "lines=False is not supported for JSONL reader"
-        raise ValueError(msg)
+        msg = f"engine={PYARROW_DIRECT_ENGINE!r} only supports lines=True"
+        raise RuntimeError(msg)
 
     block_size = read_kwargs.pop("pyarrow_block_size", DEFAULT_PYARROW_BLOCK_SIZE)
     max_block_size = read_kwargs.pop("pyarrow_max_block_size", DEFAULT_PYARROW_MAX_BLOCK_SIZE)
@@ -166,14 +164,9 @@ class JsonlReaderStage(BaseFileReader):
 
     Args:
         fields (list[str], optional): If specified, only read these fields (columns). Defaults to None.
-        read_kwargs (dict[str, Any], optional): Reader options. The default
-            ``engine="pyarrow_direct"`` returns a ``pa.Table``. Select
-            ``engine="pandas"`` for a ``pd.DataFrame`` and pandas-specific
-            parsing or type inference. Other engine values are forwarded to
-            ``pd.read_json`` for backward compatibility. The direct engine
-            accepts ``compression``, ``storage_options``,
-            ``pyarrow_block_size``, and ``pyarrow_max_block_size``;
-            ``lines`` must remain ``True``. Defaults to {}.
+        read_kwargs (dict[str, Any], optional): Reader options. ``engine="pyarrow_direct"``
+            uses the direct PyArrow reader; all other engines, including ``"pyarrow"``,
+            are passed to ``pd.read_json``. Defaults to {}.
         _generate_ids (bool): Whether to generate monotonically increasing IDs across all files.
             This uses IdGenerator actor, which needs to be instantiated before using this stage.
             This can be slow, so it is recommended to use AddId stage instead, unless monotonically increasing IDs
@@ -192,14 +185,7 @@ class JsonlReaderStage(BaseFileReader):
         read_kwargs: dict[str, Any] | None = None,
         fields: list[str] | None = None,
     ) -> pd.DataFrame | pa.Table:
-        """Read JSONL files into an Arrow table or pandas DataFrame.
-
-        The default ``pyarrow_direct`` engine retains Arrow data without a
-        pandas conversion and does not fall back when Arrow rejects an input.
-        Use ``engine="pandas"`` when pandas-specific parsing and inference are
-        required. Other engine values are delegated to ``pd.read_json`` and
-        also return a pandas DataFrame.
-        """
+        """Read JSONL files using the selected engine."""
 
         read_kwargs = {} if read_kwargs is None else dict(read_kwargs)
         engine = read_kwargs.get("engine", PYARROW_DIRECT_ENGINE)
@@ -220,16 +206,10 @@ class JsonlReader(CompositeStage[EmptyTask, DocumentBatch]):
         file_paths: File paths, directories, or glob patterns to read.
         files_per_partition: Number of files grouped into each reader task.
             When set, this takes precedence over ``blocksize``.
-        blocksize: Target storage size for each file-group task. This does not
-            control PyArrow's parser blocks; configure those through
-            ``read_kwargs`` instead.
+        blocksize: Target storage size for each file-group task.
         fields: Optional columns to retain.
-        read_kwargs: Options for JSON parsing and remote storage. Direct
-            PyArrow parsing is the default. Set ``engine="pandas"`` for pandas
-            inference or another pandas-supported engine value to delegate to
-            ``pd.read_json``. The direct engine accepts ``compression``,
-            ``storage_options``, ``pyarrow_block_size``, and
-            ``pyarrow_max_block_size``.
+        read_kwargs: Options passed to ``pd.read_json``, or to the direct
+            PyArrow reader when ``engine="pyarrow_direct"``.
         task_type: Output task modality. Only ``"document"`` is supported.
         file_extensions: File extensions considered during partitioning.
         _generate_ids: Generate stable, monotonically increasing document IDs.

--- a/nemo_curator/stages/text/io/reader/lance.py
+++ b/nemo_curator/stages/text/io/reader/lance.py
@@ -142,6 +142,10 @@ class LanceReaderStage(BaseReader):
         output_fields = list(columns or [])
         if self.include_lance_metadata:
             output_fields.extend([LANCE_ROWID_COLUMN, LANCE_ROWADDR_COLUMN, LANCE_FRAGID_COLUMN])
+        if self._generate_ids or self._assign_ids:
+            from nemo_curator.stages.deduplication.id_generator import CURATOR_DEDUP_ID_STR
+
+            output_fields.append(CURATOR_DEDUP_ID_STR)
         return ["data"], output_fields
 
     def _scanner_kwargs(self, read_kwargs: dict[str, Any], fields: list[str] | None) -> dict[str, Any]:

--- a/nemo_curator/tasks/document.py
+++ b/nemo_curator/tasks/document.py
@@ -24,10 +24,7 @@ from .tasks import Task
 
 def _pyarrow_to_pandas_dtype(arrow_type: pa.DataType) -> pd.StringDtype | None:
     if pa.types.is_string(arrow_type) or pa.types.is_large_string(arrow_type):
-        try:
-            return pd.StringDtype(storage="pyarrow", na_value=np.nan)
-        except TypeError:  # pandas < 3.0
-            return pd.StringDtype(storage="pyarrow")
+        return pd.StringDtype(storage="pyarrow", na_value=np.nan)
     return None
 
 

--- a/nemo_curator/tasks/document.py
+++ b/nemo_curator/tasks/document.py
@@ -14,11 +14,21 @@
 
 from dataclasses import dataclass, field
 
+import numpy as np
 import pandas as pd
 import pyarrow as pa
 from loguru import logger
 
 from .tasks import Task
+
+
+def _pyarrow_to_pandas_dtype(arrow_type: pa.DataType) -> pd.StringDtype | None:
+    if pa.types.is_string(arrow_type) or pa.types.is_large_string(arrow_type):
+        try:
+            return pd.StringDtype(storage="pyarrow", na_value=np.nan)
+        except TypeError:  # pandas < 3.0
+            return pd.StringDtype(storage="pyarrow")
+    return None
 
 
 @dataclass
@@ -46,7 +56,7 @@ class DocumentBatch(Task[pa.Table | pd.DataFrame]):
         if isinstance(self.data, pd.DataFrame):
             return self.data
         elif isinstance(self.data, pa.Table):
-            return self.data.to_pandas()
+            return self.data.to_pandas(types_mapper=_pyarrow_to_pandas_dtype, use_threads=False)
         else:
             msg = f"Cannot convert {type(self.data)} to Pandas DataFrame"
             raise TypeError(msg)

--- a/tests/stages/text/classifiers/test_utils.py
+++ b/tests/stages/text/classifiers/test_utils.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import pandas as pd
+import pyarrow as pa
 
 from nemo_curator.stages.text.classifiers.utils import SortByLengthStage
 from nemo_curator.stages.text.models.utils import SEQ_ORDER_FIELD
@@ -42,3 +43,29 @@ class TestSortByLengthStage:
         result = stage.process(batch)
         # Check that the data is not modified
         assert result.data.equals(batch.data)
+
+    def test_process_pyarrow(self):
+        batch = DocumentBatch(
+            dataset_name="test",
+            data=pa.table({"attention_mask": [[1, 1, 1, 1, 0], [1, 1, 1, 1, 1], [1, 1, 1, 0, 0]]}),
+        )
+
+        result = SortByLengthStage().process(batch)
+
+        assert isinstance(result.data, pd.DataFrame)
+        assert result.data[SEQ_ORDER_FIELD].tolist() == [2, 0, 1]
+
+    def test_process_pyarrow_no_op(self):
+        batch = DocumentBatch(
+            dataset_name="test",
+            data=pa.table(
+                {
+                    "attention_mask": [[1, 1, 1, 1, 0], [1, 1, 1, 1, 1], [1, 1, 1, 0, 0]],
+                    SEQ_ORDER_FIELD: [1, 2, 0],
+                }
+            ),
+        )
+
+        result = SortByLengthStage().process(batch)
+
+        assert result is batch

--- a/tests/stages/text/io/reader/test_integration.py
+++ b/tests/stages/text/io/reader/test_integration.py
@@ -30,6 +30,7 @@ from nemo_curator.stages.deduplication.id_generator import (
 )
 from nemo_curator.stages.text.io.reader.jsonl import JsonlReader
 from nemo_curator.tasks import DocumentBatch
+from tests.stages.text.io.utils import normalize_string_dtypes
 
 # File format configurations
 FILE_FORMAT_CONFIGS = {
@@ -205,7 +206,10 @@ class TestReaderIntegrationWithoutIdGenerator:
         actual_sorted = combined_df.sort_values("text").reset_index(drop=True)
 
         # Compare DataFrames
-        pd.testing.assert_frame_equal(expected_sorted, actual_sorted)
+        pd.testing.assert_frame_equal(
+            normalize_string_dtypes(expected_sorted),
+            normalize_string_dtypes(actual_sorted),
+        )
 
     def test_total_record_count(self, test_config: "TestReaderIntegrationWithoutIdGenerator"):
         """Test that total number of records matches expected."""
@@ -332,7 +336,10 @@ class TestReaderIntegrationWithIdGenerator:
         actual_sorted = content_df.sort_values("text").reset_index(drop=True)
 
         # Compare DataFrames
-        pd.testing.assert_frame_equal(expected_sorted, actual_sorted)
+        pd.testing.assert_frame_equal(
+            normalize_string_dtypes(expected_sorted),
+            normalize_string_dtypes(actual_sorted),
+        )
 
     def test_total_record_count_with_ids(self, test_config: "TestReaderIntegrationWithIdGenerator"):
         """Test that total number of records matches expected."""

--- a/tests/stages/text/io/reader/test_jsonl.py
+++ b/tests/stages/text/io/reader/test_jsonl.py
@@ -94,6 +94,17 @@ class TestJsonlReaderWithoutIdGenerator:
         with pytest.raises(RuntimeError, match=r"pyarrow_direct.*lines=True"):
             JsonlReaderStage(read_kwargs={"engine": "pyarrow_direct", "lines": False}).process(task)
 
+    def test_pandas_reader_accepts_lines_false(self, tmp_path: Path) -> None:
+        """The pandas reader should support a JSON array when lines is false."""
+        file_path = tmp_path / "records.json"
+        file_path.write_text('[{"text":"first"},{"text":"second"}]', encoding="utf-8")
+        task = FileGroupTask(dataset_name="ds", data=[str(file_path)], _metadata={})
+
+        result = JsonlReaderStage(read_kwargs={"engine": "pandas", "lines": False}).process(task)
+
+        assert isinstance(result.data, pd.DataFrame)
+        assert result.data["text"].tolist() == ["first", "second"]
+
     def test_pandas_pyarrow_engine_returns_dataframe(self, sample_jsonl_files: list[str]) -> None:
         """The pandas PyArrow engine should remain available through read_kwargs."""
         task = FileGroupTask(dataset_name="ds", data=sample_jsonl_files, _metadata={})

--- a/tests/stages/text/io/reader/test_jsonl.py
+++ b/tests/stages/text/io/reader/test_jsonl.py
@@ -127,7 +127,7 @@ class TestJsonlReaderWithoutIdGenerator:
 
         # Prefer the default/pyarrow_direct path for throughput. Select pandas explicitly
         # when pandas-specific inference, such as timezone-aware dates, is required.
-        assert pandas_result.data["created_at"].dtype == pd.DatetimeTZDtype(unit="ns", tz="UTC")
+        assert isinstance(pandas_result.data["created_at"].dtype, pd.DatetimeTZDtype)
         assert pandas_result.data["created_at"].tolist() == [expected]
         assert isinstance(arrow_result.data, pa.Table)
         assert arrow_result.data.schema.field("created_at").type == pa.string()

--- a/tests/stages/text/io/reader/test_jsonl.py
+++ b/tests/stages/text/io/reader/test_jsonl.py
@@ -87,23 +87,20 @@ class TestJsonlReaderWithoutIdGenerator:
             "Doc 2-2",
         ]
 
-    def test_pyarrow_direct_rejects_lines_false(self, sample_jsonl_files: list[str]) -> None:
-        """The direct reader should clearly reject JSON formats unsupported by PyArrow."""
-        task = FileGroupTask(dataset_name="ds", data=sample_jsonl_files, _metadata={})
+    @pytest.mark.parametrize("engine", [None, "pyarrow_direct", "pandas", "ujson", "pyarrow"])
+    def test_stage_rejects_lines_false_at_initialization(self, engine: str | None) -> None:
+        """JsonlReaderStage should reject non-JSONL input for every engine."""
+        read_kwargs = {"lines": False}
+        if engine is not None:
+            read_kwargs["engine"] = engine
 
-        with pytest.raises(RuntimeError, match=r"pyarrow_direct.*lines=True"):
-            JsonlReaderStage(read_kwargs={"engine": "pyarrow_direct", "lines": False}).process(task)
+        with pytest.raises(RuntimeError, match="JsonlReader only supports lines=True"):
+            JsonlReaderStage(read_kwargs=read_kwargs)
 
-    def test_pandas_reader_accepts_lines_false(self, tmp_path: Path) -> None:
-        """The pandas reader should support a JSON array when lines is false."""
-        file_path = tmp_path / "records.json"
-        file_path.write_text('[{"text":"first"},{"text":"second"}]', encoding="utf-8")
-        task = FileGroupTask(dataset_name="ds", data=[str(file_path)], _metadata={})
-
-        result = JsonlReaderStage(read_kwargs={"engine": "pandas", "lines": False}).process(task)
-
-        assert isinstance(result.data, pd.DataFrame)
-        assert result.data["text"].tolist() == ["first", "second"]
+    def test_composite_reader_rejects_lines_false_at_initialization(self, tmp_path: Path) -> None:
+        """JsonlReader should reject non-JSONL input before decomposition."""
+        with pytest.raises(RuntimeError, match="JsonlReader only supports lines=True"):
+            JsonlReader(file_paths=str(tmp_path), read_kwargs={"engine": "pandas", "lines": False})
 
     def test_pandas_pyarrow_engine_returns_dataframe(self, sample_jsonl_files: list[str]) -> None:
         """The pandas PyArrow engine should remain available through read_kwargs."""

--- a/tests/stages/text/io/reader/test_jsonl.py
+++ b/tests/stages/text/io/reader/test_jsonl.py
@@ -12,9 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import json
 from pathlib import Path
 
+import fsspec
 import pandas as pd
+import pyarrow as pa
 import pytest
 
 from nemo_curator.stages.deduplication.id_generator import (
@@ -66,6 +69,94 @@ class TestJsonlReaderWithoutIdGenerator:
             assert list(df.columns) == ["text"]
             assert len(df) == 2
 
+    def test_default_reader_uses_pyarrow_fast_path(self, sample_jsonl_files: list[str]) -> None:
+        """The default reader should retain its DataFrame contract with Arrow-backed strings."""
+        task = FileGroupTask(dataset_name="ds", data=sample_jsonl_files, _metadata={})
+
+        result = JsonlReaderStage(fields=["text"]).process(task)
+
+        assert isinstance(result.data, pd.DataFrame)
+        assert result.data["text"].dtype.storage == "pyarrow"
+        assert result.data["text"].tolist() == [
+            "Doc 0-1",
+            "Doc 0-2",
+            "Doc 1-1",
+            "Doc 1-2",
+            "Doc 2-1",
+            "Doc 2-2",
+        ]
+
+    def test_auto_reader_falls_back_to_pandas_for_mixed_column_types(self, tmp_path: Path) -> None:
+        """Auto mode should preserve compatibility when PyArrow rejects mixed JSON types."""
+        file_path = tmp_path / "mixed.jsonl"
+        file_path.write_text('{"value":1}\n{"value":"one"}\n', encoding="utf-8")
+        task = FileGroupTask(dataset_name="ds", data=[str(file_path)], _metadata={})
+
+        result = JsonlReaderStage(read_kwargs={"engine": "auto"}).process(task)
+
+        assert result.data["value"].tolist() == [1, "one"]
+
+    def test_pandas_and_pyarrow_direct_document_inference_difference(self, tmp_path: Path) -> None:
+        """Document when callers need pandas inference instead of the faster direct parser."""
+        file_path = tmp_path / "timestamp.jsonl"
+        expected = pd.Timestamp("2026-08-20T12:34:56Z")
+        pd.DataFrame({"created_at": [expected], "text": ["hello"]}).to_json(
+            file_path,
+            orient="records",
+            lines=True,
+            date_format="iso",
+        )
+        task = FileGroupTask(dataset_name="ds", data=[str(file_path)], _metadata={})
+
+        pandas_result = JsonlReaderStage(read_kwargs={"engine": "pandas"}).process(task).data
+        arrow_result = JsonlReaderStage(read_kwargs={"engine": "pyarrow_direct"}).process(task).data
+        auto_with_pandas_option = JsonlReaderStage(read_kwargs={"convert_dates": ["created_at"]}).process(task).data
+
+        # Prefer the default/pyarrow_direct path for throughput. Select pandas when
+        # pandas-specific inference is required; auto also preserves pandas-only options.
+        assert pandas_result["created_at"].tolist() == [expected]
+        assert auto_with_pandas_option["created_at"].tolist() == [expected]
+        assert isinstance(arrow_result["created_at"].iloc[0], str)
+        assert pd.Timestamp(arrow_result["created_at"].iloc[0]) == expected
+
+    def test_pyarrow_direct_does_not_fall_back(self, tmp_path: Path) -> None:
+        """The explicit direct engine should expose unsupported Arrow input instead of silently changing engines."""
+        file_path = tmp_path / "mixed.jsonl"
+        file_path.write_text('{"value":1}\n{"value":"one"}\n', encoding="utf-8")
+        task = FileGroupTask(dataset_name="ds", data=[str(file_path)], _metadata={})
+
+        with pytest.raises(pa.ArrowInvalid, match="changed from number to string"):
+            JsonlReaderStage(read_kwargs={"engine": "pyarrow_direct"}).process(task)
+
+    def test_pyarrow_direct_grows_block_for_large_record(self, tmp_path: Path) -> None:
+        """A record larger than the initial parse block should be retried with a larger block."""
+        text = "x" * (1024 * 1024 + 64 * 1024)
+        file_path = tmp_path / "large.jsonl"
+        file_path.write_text(json.dumps({"text": text}) + "\n", encoding="utf-8")
+        task = FileGroupTask(dataset_name="ds", data=[str(file_path)], _metadata={})
+        stage = JsonlReaderStage(
+            read_kwargs={
+                "engine": "pyarrow_direct",
+                "pyarrow_block_size": 1024 * 1024,
+                "pyarrow_max_block_size": 2 * 1024 * 1024,
+            }
+        )
+
+        result = stage.process(task)
+
+        assert result.data["text"].tolist() == [text]
+
+    def test_pyarrow_direct_reads_fsspec_url(self) -> None:
+        """The direct engine should retain JsonlReader's remote-filesystem behavior."""
+        file_path = "memory://jsonl-reader/direct.jsonl"
+        with fsspec.open(file_path, mode="wt", encoding="utf-8") as stream:
+            stream.write('{"text":"first"}\n{"text":"second"}\n')
+        task = FileGroupTask(dataset_name="ds", data=[file_path], _metadata={})
+
+        result = JsonlReaderStage(read_kwargs={"engine": "pyarrow_direct"}).process(task)
+
+        assert result.data["text"].tolist() == ["first", "second"]
+
     def test_storage_options_via_read_kwargs(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         """Reader should use storage options from reader.read_kwargs."""
         # Create a file
@@ -74,7 +165,7 @@ class TestJsonlReaderWithoutIdGenerator:
 
         # Reader uses read_kwargs storage options
         task = FileGroupTask(dataset_name="ds", data=[str(file_path)], _metadata={})
-        stage = JsonlReaderStage(read_kwargs={"storage_options": {"auto_mkdir": True}})
+        stage = JsonlReaderStage(read_kwargs={"engine": "pandas", "storage_options": {"auto_mkdir": True}})
 
         seen: dict[str, object] = {}
 
@@ -115,7 +206,7 @@ class TestJsonlReaderWithoutIdGenerator:
 
         monkeypatch.setattr(pd, "read_json", fake_read_json)
         task = FileGroupTask(dataset_name="ds", data=[str(f)], _metadata={})
-        stage = JsonlReaderStage(read_kwargs={"storage_options": {"auto_mkdir": True}})
+        stage = JsonlReaderStage(read_kwargs={"engine": "pandas", "storage_options": {"auto_mkdir": True}})
         out = stage.process(task)
         assert seen["storage_options"] == {"auto_mkdir": True}
         df = out.to_pandas()

--- a/tests/stages/text/io/reader/test_jsonl.py
+++ b/tests/stages/text/io/reader/test_jsonl.py
@@ -163,6 +163,22 @@ class TestJsonlReaderWithoutIdGenerator:
         assert isinstance(result.data, pa.Table)
         assert result.data["text"].to_pylist() == [text]
 
+    def test_pyarrow_direct_stops_growing_block_at_maximum(self, tmp_path: Path) -> None:
+        """A record larger than the maximum block should raise instead of retrying indefinitely."""
+        file_path = tmp_path / "too_large.jsonl"
+        file_path.write_text(json.dumps({"text": "x" * (5 * 1024)}) + "\n", encoding="utf-8")
+        task = FileGroupTask(dataset_name="ds", data=[str(file_path)], _metadata={})
+        stage = JsonlReaderStage(
+            read_kwargs={
+                "engine": "pyarrow_direct",
+                "pyarrow_block_size": 1024,
+                "pyarrow_max_block_size": 2 * 1024,
+            }
+        )
+
+        with pytest.raises(pa.ArrowInvalid, match="straddling object"):
+            stage.process(task)
+
     def test_pyarrow_direct_reads_fsspec_url(self) -> None:
         """The direct engine should retain JsonlReader's remote-filesystem behavior."""
         file_path = "memory://jsonl-reader/direct.jsonl"

--- a/tests/stages/text/io/reader/test_jsonl.py
+++ b/tests/stages/text/io/reader/test_jsonl.py
@@ -56,6 +56,7 @@ class TestJsonlReaderWithoutIdGenerator:
         for task in file_group_tasks:
             stage = JsonlReaderStage()
             result = stage.process(task)
+            assert isinstance(result.data, pa.Table)
             df = result.to_pandas()
             assert CURATOR_DEDUP_ID_STR not in df.columns
             assert len(df) == 2  # Each file has 2 rows
@@ -69,15 +70,15 @@ class TestJsonlReaderWithoutIdGenerator:
             assert list(df.columns) == ["text"]
             assert len(df) == 2
 
-    def test_default_reader_uses_pyarrow_fast_path(self, sample_jsonl_files: list[str]) -> None:
-        """The default reader should retain its DataFrame contract with Arrow-backed strings."""
+    def test_default_reader_returns_pyarrow_table(self, sample_jsonl_files: list[str]) -> None:
+        """The default reader should keep parsed data in Arrow until pandas is requested."""
         task = FileGroupTask(dataset_name="ds", data=sample_jsonl_files, _metadata={})
 
         result = JsonlReaderStage(fields=["text"]).process(task)
 
-        assert isinstance(result.data, pd.DataFrame)
-        assert result.data["text"].dtype.storage == "pyarrow"
-        assert result.data["text"].tolist() == [
+        assert isinstance(result.data, pa.Table)
+        assert result.data.schema.field("text").type == pa.string()
+        assert result.data["text"].to_pylist() == [
             "Doc 0-1",
             "Doc 0-2",
             "Doc 1-1",
@@ -86,14 +87,25 @@ class TestJsonlReaderWithoutIdGenerator:
             "Doc 2-2",
         ]
 
-    def test_auto_reader_falls_back_to_pandas_for_mixed_column_types(self, tmp_path: Path) -> None:
-        """Auto mode should preserve compatibility when PyArrow rejects mixed JSON types."""
+    def test_default_reader_does_not_change_engine_for_mixed_column_types(self, tmp_path: Path) -> None:
+        """Distributed reader tasks should fail consistently instead of changing representation."""
         file_path = tmp_path / "mixed.jsonl"
         file_path.write_text('{"value":1}\n{"value":"one"}\n', encoding="utf-8")
         task = FileGroupTask(dataset_name="ds", data=[str(file_path)], _metadata={})
 
-        result = JsonlReaderStage(read_kwargs={"engine": "auto"}).process(task)
+        with pytest.raises(pa.ArrowInvalid, match="changed from"):
+            JsonlReaderStage().process(task)
 
+    def test_pandas_reader_keeps_mixed_column_as_object(self, tmp_path: Path) -> None:
+        """Callers can select pandas when mixed JSON types require object storage."""
+        file_path = tmp_path / "mixed.jsonl"
+        file_path.write_text('{"value":1}\n{"value":"one"}\n', encoding="utf-8")
+        task = FileGroupTask(dataset_name="ds", data=[str(file_path)], _metadata={})
+
+        result = JsonlReaderStage(read_kwargs={"engine": "pandas"}).process(task)
+
+        assert isinstance(result.data, pd.DataFrame)
+        assert result.data["value"].dtype == object
         assert result.data["value"].tolist() == [1, "one"]
 
     def test_pandas_and_pyarrow_direct_document_inference_difference(self, tmp_path: Path) -> None:
@@ -108,16 +120,20 @@ class TestJsonlReaderWithoutIdGenerator:
         )
         task = FileGroupTask(dataset_name="ds", data=[str(file_path)], _metadata={})
 
-        pandas_result = JsonlReaderStage(read_kwargs={"engine": "pandas"}).process(task).data
-        arrow_result = JsonlReaderStage(read_kwargs={"engine": "pyarrow_direct"}).process(task).data
-        auto_with_pandas_option = JsonlReaderStage(read_kwargs={"convert_dates": ["created_at"]}).process(task).data
+        pandas_result = JsonlReaderStage(read_kwargs={"engine": "pandas", "convert_dates": ["created_at"]}).process(
+            task
+        )
+        arrow_result = JsonlReaderStage(read_kwargs={"engine": "pyarrow_direct"}).process(task)
 
-        # Prefer the default/pyarrow_direct path for throughput. Select pandas when
-        # pandas-specific inference is required; auto also preserves pandas-only options.
-        assert pandas_result["created_at"].tolist() == [expected]
-        assert auto_with_pandas_option["created_at"].tolist() == [expected]
-        assert isinstance(arrow_result["created_at"].iloc[0], str)
-        assert pd.Timestamp(arrow_result["created_at"].iloc[0]) == expected
+        # Prefer the default/pyarrow_direct path for throughput. Select pandas explicitly
+        # when pandas-specific inference, such as timezone-aware dates, is required.
+        assert pandas_result.data["created_at"].dtype == pd.DatetimeTZDtype(unit="ns", tz="UTC")
+        assert pandas_result.data["created_at"].tolist() == [expected]
+        assert isinstance(arrow_result.data, pa.Table)
+        assert arrow_result.data.schema.field("created_at").type == pa.string()
+        arrow_as_pandas = arrow_result.to_pandas()
+        assert arrow_as_pandas["created_at"].dtype.storage == "pyarrow"
+        assert pd.Timestamp(arrow_as_pandas["created_at"].iloc[0]) == expected
 
     def test_pyarrow_direct_does_not_fall_back(self, tmp_path: Path) -> None:
         """The explicit direct engine should expose unsupported Arrow input instead of silently changing engines."""
@@ -125,7 +141,7 @@ class TestJsonlReaderWithoutIdGenerator:
         file_path.write_text('{"value":1}\n{"value":"one"}\n', encoding="utf-8")
         task = FileGroupTask(dataset_name="ds", data=[str(file_path)], _metadata={})
 
-        with pytest.raises(pa.ArrowInvalid, match="changed from number to string"):
+        with pytest.raises(pa.ArrowInvalid, match="changed from"):
             JsonlReaderStage(read_kwargs={"engine": "pyarrow_direct"}).process(task)
 
     def test_pyarrow_direct_grows_block_for_large_record(self, tmp_path: Path) -> None:
@@ -144,7 +160,8 @@ class TestJsonlReaderWithoutIdGenerator:
 
         result = stage.process(task)
 
-        assert result.data["text"].tolist() == [text]
+        assert isinstance(result.data, pa.Table)
+        assert result.data["text"].to_pylist() == [text]
 
     def test_pyarrow_direct_reads_fsspec_url(self) -> None:
         """The direct engine should retain JsonlReader's remote-filesystem behavior."""
@@ -155,7 +172,8 @@ class TestJsonlReaderWithoutIdGenerator:
 
         result = JsonlReaderStage(read_kwargs={"engine": "pyarrow_direct"}).process(task)
 
-        assert result.data["text"].tolist() == ["first", "second"]
+        assert isinstance(result.data, pa.Table)
+        assert result.data["text"].to_pylist() == ["first", "second"]
 
     def test_storage_options_via_read_kwargs(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         """Reader should use storage options from reader.read_kwargs."""
@@ -217,14 +235,26 @@ class TestJsonlReaderWithIdGenerator:
     """Test JSONL reader with ID generation."""
 
     @pytest.mark.usefixtures("ray_client_with_id_generator")
-    def test_sequential_id_generation_and_assignment(self, file_group_tasks: list[FileGroupTask]) -> None:
+    @pytest.mark.parametrize(
+        ("engine", "backing_type"),
+        [("pyarrow_direct", pa.Table), ("pandas", pd.DataFrame)],
+    )
+    def test_sequential_id_generation_and_assignment(
+        self,
+        file_group_tasks: list[FileGroupTask],
+        engine: str,
+        backing_type: type[pa.Table] | type[pd.DataFrame],
+    ) -> None:
         """Test sequential ID generation across multiple batches."""
-        generation_stage = JsonlReaderStage(_generate_ids=True)
+        generation_stage = JsonlReaderStage(read_kwargs={"engine": engine}, _generate_ids=True)
         generation_stage.setup()
 
         all_ids = []
         for task in file_group_tasks:
             result = generation_stage.process(task)
+            assert isinstance(result.data, backing_type)
+            if isinstance(result.data, pa.Table):
+                assert result.data.schema.field(CURATOR_DEDUP_ID_STR).type == pa.int64()
             ids = result.to_pandas()[CURATOR_DEDUP_ID_STR].tolist()
             all_ids.extend(ids)
 
@@ -235,6 +265,7 @@ class TestJsonlReaderWithIdGenerator:
         repeated_ids = []
         for task in file_group_tasks:
             result = generation_stage.process(task)
+            assert isinstance(result.data, backing_type)
             ids = result.to_pandas()[CURATOR_DEDUP_ID_STR].tolist()
             repeated_ids.extend(ids)
 
@@ -243,18 +274,35 @@ class TestJsonlReaderWithIdGenerator:
 
         """ If we now create a new stage with _assign_ids=True, the IDs should be the same as the previous batch."""
         all_ids = []
-        assign_stage = JsonlReaderStage(_assign_ids=True)
+        assign_stage = JsonlReaderStage(read_kwargs={"engine": engine}, _assign_ids=True)
         assign_stage.setup()
         for i, task in enumerate(file_group_tasks):
             result = assign_stage.process(task)
-            df = result.to_pandas()
+            assert isinstance(result.data, backing_type)
             expected_ids = [i * 2, i * 2 + 1]  # Task 0: [0,1], Task 1: [2,3], Task 2: [4,5]
-            assert (
-                df[CURATOR_DEDUP_ID_STR].tolist() == expected_ids
-            )  # These ids should be the same as the previous batch
-            all_ids.extend(df[CURATOR_DEDUP_ID_STR].tolist())
+            ids = result.to_pandas()[CURATOR_DEDUP_ID_STR].tolist()
+            assert ids == expected_ids  # These ids should be the same as the previous batch
+            all_ids.extend(ids)
 
         assert all_ids == list(range(6))
+
+    @pytest.mark.usefixtures("ray_client_with_id_generator")
+    @pytest.mark.parametrize("id_mode", ["generate", "assign"])
+    def test_id_operations_preserve_existing_arrow_column(self, tmp_path: Path, id_mode: str) -> None:
+        """Reader-side ID operations should leave an existing Arrow ID column unchanged."""
+        file_path = tmp_path / "with_ids.jsonl"
+        pd.DataFrame({"text": ["first", "second"], CURATOR_DEDUP_ID_STR: [101, 202]}).to_json(
+            file_path,
+            orient="records",
+            lines=True,
+        )
+        stage = JsonlReaderStage(_generate_ids=id_mode == "generate", _assign_ids=id_mode == "assign")
+        stage.setup()
+
+        result = stage.process(FileGroupTask(dataset_name="ds", data=[str(file_path)], _metadata={}))
+
+        assert isinstance(result.data, pa.Table)
+        assert result.data[CURATOR_DEDUP_ID_STR].to_pylist() == [101, 202]
 
     def test_generate_ids_no_actor_error(self) -> None:
         """Test error when actor doesn't exist and ID generation is requested."""

--- a/tests/stages/text/io/reader/test_jsonl.py
+++ b/tests/stages/text/io/reader/test_jsonl.py
@@ -87,6 +87,29 @@ class TestJsonlReaderWithoutIdGenerator:
             "Doc 2-2",
         ]
 
+    def test_pyarrow_direct_rejects_lines_false(self, sample_jsonl_files: list[str]) -> None:
+        """The direct reader should clearly reject JSON formats unsupported by PyArrow."""
+        task = FileGroupTask(dataset_name="ds", data=sample_jsonl_files, _metadata={})
+
+        with pytest.raises(RuntimeError, match=r"pyarrow_direct.*lines=True"):
+            JsonlReaderStage(read_kwargs={"engine": "pyarrow_direct", "lines": False}).process(task)
+
+    def test_pandas_pyarrow_engine_returns_dataframe(self, sample_jsonl_files: list[str]) -> None:
+        """The pandas PyArrow engine should remain available through read_kwargs."""
+        task = FileGroupTask(dataset_name="ds", data=sample_jsonl_files, _metadata={})
+
+        result = JsonlReaderStage(read_kwargs={"engine": "pyarrow"}).process(task)
+
+        assert isinstance(result.data, pd.DataFrame)
+        assert result.data["text"].tolist() == [
+            "Doc 0-1",
+            "Doc 0-2",
+            "Doc 1-1",
+            "Doc 1-2",
+            "Doc 2-1",
+            "Doc 2-2",
+        ]
+
     def test_default_reader_does_not_change_engine_for_mixed_column_types(self, tmp_path: Path) -> None:
         """Distributed reader tasks should fail consistently instead of changing representation."""
         file_path = tmp_path / "mixed.jsonl"

--- a/tests/stages/text/io/reader/test_lance.py
+++ b/tests/stages/text/io/reader/test_lance.py
@@ -19,6 +19,7 @@ import pyarrow as pa
 import pytest
 from lance.schema import json_to_schema
 
+from nemo_curator.stages.deduplication.id_generator import CURATOR_DEDUP_ID_STR
 from nemo_curator.stages.text.io.reader.base import BaseReader
 from nemo_curator.stages.text.io.reader.lance import (
     LANCE_FRAGID_COLUMN,
@@ -134,6 +135,28 @@ def test_lance_reader_exposes_stable_row_ids(tmp_path: Path):
     assert batch._metadata["lance"]["has_stable_row_ids"] is True
     assert table[LANCE_ROWID_COLUMN].null_count == 0
     assert len(set(table[LANCE_ROWID_COLUMN].to_pylist())) == table.num_rows
+
+
+@pytest.mark.usefixtures("ray_client_with_id_generator")
+def test_lance_reader_generates_and_assigns_arrow_ids(tmp_path: Path) -> None:
+    """BaseReader should use a stable string key for non-file Arrow read tasks."""
+    dataset_path = tmp_path / "ids.lance"
+    _write_lance_dataset(dataset_path)
+    task = LancePartitioningStage(path=str(dataset_path)).process(EmptyTask())[0]
+
+    generation_stage = LanceReaderStage(fields=["text"], include_lance_metadata=False, _generate_ids=True)
+    assert CURATOR_DEDUP_ID_STR in generation_stage.outputs()[1]
+    generation_stage.setup()
+    generated = generation_stage.process(task)
+
+    assignment_stage = LanceReaderStage(fields=["text"], include_lance_metadata=False, _assign_ids=True)
+    assignment_stage.setup()
+    assigned = assignment_stage.process(task)
+
+    assert isinstance(generated.data, pa.Table)
+    assert isinstance(assigned.data, pa.Table)
+    assert generated.data[CURATOR_DEDUP_ID_STR].to_pylist() == [0, 1, 2, 3]
+    assert assigned.data[CURATOR_DEDUP_ID_STR].to_pylist() == [0, 1, 2, 3]
 
 
 def test_lance_reader_validates_requested_fragments(tmp_path: Path):

--- a/tests/stages/text/io/utils.py
+++ b/tests/stages/text/io/utils.py
@@ -1,0 +1,23 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pandas as pd
+
+
+def normalize_string_dtypes(dataframe: pd.DataFrame) -> pd.DataFrame:
+    """Materialize pandas string extension columns for content comparisons."""
+    string_columns = {
+        column: object for column, dtype in dataframe.dtypes.items() if isinstance(dtype, pd.StringDtype)
+    }
+    return dataframe.astype(string_columns)

--- a/tests/stages/text/io/writer/test_jsonl.py
+++ b/tests/stages/text/io/writer/test_jsonl.py
@@ -23,6 +23,7 @@ import pytest
 from nemo_curator.stages.text.io.writer import JsonlWriter
 from nemo_curator.stages.text.io.writer import base as writer_base
 from nemo_curator.tasks import DocumentBatch
+from tests.stages.text.io.utils import normalize_string_dtypes
 
 
 class TestJsonlWriter:
@@ -90,7 +91,10 @@ class TestJsonlWriter:
         # Verify file extension and content
         assert file_path.endswith(".jsonl"), "JSONL files should have .jsonl extension"
         df = pd.read_json(file_path, lines=True)
-        pd.testing.assert_frame_equal(df, document_batch.to_pandas())
+        pd.testing.assert_frame_equal(
+            normalize_string_dtypes(df),
+            normalize_string_dtypes(document_batch.to_pandas()),
+        )
 
     def test_jsonl_writer_with_columns_subset(self, pandas_document_batch: DocumentBatch, tmpdir: str):
         """Only selected columns should be written when columns are provided."""

--- a/tests/stages/text/io/writer/test_parquet.py
+++ b/tests/stages/text/io/writer/test_parquet.py
@@ -23,6 +23,7 @@ import pytest
 from nemo_curator.stages.text.io.writer import ParquetWriter
 from nemo_curator.stages.text.io.writer import base as writer_base
 from nemo_curator.tasks import DocumentBatch
+from tests.stages.text.io.utils import normalize_string_dtypes
 
 
 class TestParquetWriter:
@@ -90,7 +91,10 @@ class TestParquetWriter:
         # Verify file extension and content
         assert file_path.endswith(".parquet"), "Parquet files should have .parquet extension"
         df = pd.read_parquet(file_path)
-        pd.testing.assert_frame_equal(df, document_batch.to_pandas())
+        pd.testing.assert_frame_equal(
+            normalize_string_dtypes(df),
+            normalize_string_dtypes(document_batch.to_pandas()),
+        )
 
     @pytest.mark.parametrize("document_batch", ["pandas"], indirect=True)
     def test_parquet_writer_overwrite_mode(self, document_batch: DocumentBatch, tmpdir: str):

--- a/tests/tasks/test_document.py
+++ b/tests/tasks/test_document.py
@@ -1,0 +1,38 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pandas as pd
+import pyarrow as pa
+import pytest
+
+from nemo_curator.tasks import DocumentBatch
+
+
+@pytest.mark.parametrize("string_type", [pa.string(), pa.large_string()])
+def test_to_pandas_preserves_arrow_string_storage(string_type: pa.DataType) -> None:
+    """Converting an Arrow batch should not materialize strings as Python objects."""
+    table = pa.table(
+        {
+            "text": pa.array(["first", None, "third"], type=string_type),
+            "score": pa.array([1, 2, 3], type=pa.int64()),
+        }
+    )
+
+    dataframe = DocumentBatch(dataset_name="test", data=table).to_pandas()
+
+    assert isinstance(dataframe, pd.DataFrame)
+    assert dataframe["text"].dtype.storage == "pyarrow"
+    assert dataframe["text"].tolist()[::2] == ["first", "third"]
+    assert pd.isna(dataframe["text"].iloc[1])
+    assert dataframe["score"].dtype == "int64"


### PR DESCRIPTION
## What changed

This PR makes direct PyArrow parsing the default for JSONL files and keeps the result as a `pa.Table` until a stage actually needs pandas.

Reader-side `_curator_dedup_id` generation and assignment now work with both Arrow tables and pandas DataFrames. As a result, `LanceReader` now supports `_generate_ids` and `_assign_ids` without converting its Arrow output to pandas first.

When pandas is needed, `DocumentBatch.to_pandas()` handles the conversion and preserves Arrow-backed string columns.

## Choosing an engine

JSONL reads use direct PyArrow parsing by default. Callers can select `engine="pandas"` when they need pandas-specific parsing or type inference.

The two engines do not always infer identical types. For example, pandas may interpret an ISO `created_at` value as a timezone-aware datetime while PyArrow retains it as a string. Mixed-type columns are another situation where the pandas engine may be the better fit.

The PyArrow path continues to support remote files through `fsspec`. It normally reads with an 8 MiB block. If PyArrow reports that a single JSONL record straddles the block boundary, the reader retries with progressively larger blocks so that it can read the complete row. The 256 MiB maximum is a safety ceiling for unusually large individual records, such as rows containing a base64-encoded image or PDF; it is not the default amount read for every row.

## Lance and reader IDs

Because ID handling lives in `BaseReader`, Arrow-backed Lance reads now support `_generate_ids` and `_assign_ids` too.

Lance tasks use a stable identity based on the dataset path, version, and fragment IDs. File readers retain their existing path-based registry keys for backward compatibility; NMCUR-315 tracks moving them to deterministic task IDs as well.

## Compatibility

This work is based directly on `main`, including RAPIDS 26.08 and pandas 3 from #2303. PyArrow remains at 19.0.1 under the current dependency constraints.

## Testing

The tests cover:

- Direct PyArrow and explicit pandas JSONL reads
- ID generation and assignment for Arrow and pandas
- Large JSONL records and remote `fsspec` inputs
- Expected pandas/PyArrow dtype differences
- `DocumentBatch` Arrow-string conversion
- Lance ID generation and assignment
- Related reader, writer, and dedup-removal workflows

## Benchmarks

The table compares the latest completed `main` nightly (`nightly-2026_08_20__06_39_17_UTC`) with this PR (`pr-2325-2026_08_21__00_25_05_UTC-519ad6a9`). Reader time is the mean `jsonl_reader_process_time` per task. Lower is better.

| Benchmark | Mean JSONL reader time, nightly → PR | E2E runtime change |
|---|---:|---:|
| `domain_classification_raydata` | 1.244s → 0.324s (74.0% faster) | 0.8% slower |
| `domain_classification_xenna` | 1.357s → 0.416s (69.4% faster) | 7.5% faster |
| `embedding_generation_raydata` | 0.183s → 0.048s (73.7% faster) | 0.7% faster |
| `embedding_generation_xenna` | 0.212s → 0.054s (74.4% faster) | 0.2% faster |
| `dedup_removal_raydata` | 49.02s → 9.05s (81.5% faster) | 46.9% faster |
| `dedup_removal_xenna` | 33.62s → 9.83s (70.8% faster) | 68.0% faster |
| `score_filter_raydata` | 0.333s → 0.079s (76.3% faster) | 3.8% faster |
| `score_filter_xenna` | 0.303s → 0.069s (77.3% faster) | 2.0% slower |
| `fasttext_filter_raydata` | 0.308s → 0.073s (76.4% faster) | 0.8% faster |
| `fasttext_filter_xenna` | 0.372s → 0.084s (77.3% faster) | 5.8% faster |
| `modifier_raydata` | 0.358s → 0.085s (76.1% faster) | 3.2% faster |
| `modifier_xenna` | 0.341s → 0.082s (75.9% faster) | 4.7% faster |
| `ndd_dynamo_dp8` | 0.175s → 0.046s (73.8% faster) | 7.0% slower |
| `ndd_ray_serve_dp8` | 0.168s → 0.046s (72.8% faster) | <0.1% faster |

Across all 14 entries, the median JSONL reader task is 75.2% faster and median E2E runtime improves by 2.0%. Looking only at the 12 entries where JSONL reading is not the dominant cost, median E2E runtime improves by 0.8%.