### PR TITLE
Add OrcaRouter as a named inference provider for OCR scoring QA

### DIFF
--- a/fern/versions/main/pages/curate-text/synthetic/nemotron-ocr/index.mdx
+++ b/fern/versions/main/pages/curate-text/synthetic/nemotron-ocr/index.mdx
@@ -122,6 +122,8 @@ The verifier returns `ocr_mode`, indexed box scores, and `missing_text`. Missing
 
 `NVInferenceClient` uses the NVIDIA integration endpoint, reads `NVINFERENCE_API_KEY`, streams final-answer content, allows 10 concurrent requests per worker, uses a 120-second timeout, and retries rate-limit and connection failures three times with exponential backoff and jitter.
 
+To use the [OrcaRouter](https://www.orcarouter.ai) gateway instead, pass `OrcaRouterInferenceClient` (reads `ORCAROUTER_API_KEY`, endpoint `https://api.orcarouter.ai/v1`) as the `client` argument to `OCRScoringQAStage`, or add `--scoring-qa-use-orcarouter` to the tutorial CLI. OrcaRouter exposes OpenAI-compatible `chat/completions` on a single endpoint that routes to many model providers.
+
 ## QA interaction shapes
 
 The source defines five QA type constants. Four tag and balance the multi-turn families; the fifth, `dense_dump`, names the separate single-turn all-words path. Single-occurrence and repeated-text routing within the four tagged families produces six user-visible shapes:

--- a/fern/versions/main/pages/curate-text/synthetic/nemotron-ocr/tutorial.mdx
+++ b/fern/versions/main/pages/curate-text/synthetic/nemotron-ocr/tutorial.mdx
@@ -100,6 +100,19 @@ python -m tutorials.synthetic.omni.ocr_pipeline \
 
 Add `--scoring-qa-fail-on-missing-text` to invalidate images with uncovered text. Otherwise missing regions are recorded, dense dump is disabled for that image, and QA uses boxes that passed scoring. Add `--valid-only` to exclude invalid images; without it, failed records remain with an `error` string.
 
+### Route the verifier through OrcaRouter
+
+Instead of the NVIDIA Inference API, you can route verifier calls through the [OrcaRouter](https://www.orcarouter.ai) gateway — an OpenAI-compatible endpoint that exposes many model providers on one base URL. It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.
+
+Create an OrcaRouter API key at [orcarouter.ai](https://www.orcarouter.ai), then export it:
+
+```bash
+read -s ORCAROUTER_API_KEY
+export ORCAROUTER_API_KEY
+```
+
+Add `--scoring-qa-use-orcarouter` to the CLI invocation in the previous step. The verifier model ID still defaults to the NVIDIA reasoning model; OrcaRouter routes it to an equivalent reasoning model behind the scenes.
+
 ## CLI reference
 
 | Argument | Default | Description |
@@ -121,6 +134,7 @@ Add `--scoring-qa-fail-on-missing-text` to invalidate images with uncovered text
 | `--scoring-qa-max-text-errors` | `0` | Inclusive maximum text errors. |
 | `--scoring-qa-fail-on-missing-text` | False | Invalidate images with missing regions. |
 | `--scoring-qa-dense-dump-prob` | `0.05` | Dense-turn probability for complete OCR. |
+| `--scoring-qa-use-orcarouter` | False | Route the verifier through the OrcaRouter gateway (requires `ORCAROUTER_API_KEY`). |
 
 OCR `merge_level`, verifier generation/batch settings, priority mode, and API client concurrency are Python-only settings.
 
@@ -194,6 +208,20 @@ pipeline.add_stage(JsonlSampleWriterStage(
     valid_only=False,
     image_parent="/workspace/ocr-data/images",
 ))
+```
+
+To route the verifier through [OrcaRouter](https://www.orcarouter.ai) instead of NVIDIA, pass an `OrcaRouterInferenceClient` as the stage `client`:
+
+```python
+from nemo_curator.models.omni.base import OrcaRouterInferenceClient
+
+OCRScoringQAStage(
+    client=OrcaRouterInferenceClient(),  # reads ORCAROUTER_API_KEY
+    temperature=1.0,
+    max_tokens=16384,
+    min_bbox_match=5,
+    max_text_errors=0,
+)
 ```
 
 `JsonlSampleWriterStage` defaults `valid_only=True` when constructed directly, while the tutorial CLI defaults `--valid-only` to false and passes that value explicitly. Set `valid_only=False` to retain invalid records for inspection or a later rerun.

--- a/nemo_curator/models/omni/base.py
+++ b/nemo_curator/models/omni/base.py
@@ -1,10 +1,10 @@
-"""NVIDIA Inference API client for reasoning VLMs.
+"""OpenAI-compatible streaming clients for reasoning VLMs.
 
-Reasoning models on NVIDIA Inference (e.g. Nemotron-Nano-Omni-Reasoning) split
+Reasoning models on remote endpoints (e.g. Nemotron-Nano-Omni-Reasoning) split
 their output into ``delta.reasoning_content`` (chain-of-thought) and
 ``delta.content`` (the final answer), and their non-stream response shape is not
-deserialized cleanly by the OpenAI SDK. This client therefore streams and
-reassembles only ``delta.content``.
+deserialized cleanly by the OpenAI SDK. These clients therefore stream and
+reassemble only ``delta.content``.
 """
 
 import os
@@ -16,26 +16,26 @@ from nemo_curator.models.client.llm_client import ConversationFormatter, Generat
 _PRIORITY_HEADER = {"X-Vertex-AI-LLM-Shared-Request-Type": "priority"}
 
 
-class NVInferenceClient(AsyncOpenAIClient):
+class _OpenAIStreamingClient(AsyncOpenAIClient):
     """Async OpenAI-compatible client that streams reasoning-model output.
 
     Resolves the API key from ``api_key_env_var`` at ``setup()`` time (so the
     key is read on the worker, not serialized from the driver), then reassembles
-    ``delta.content`` from a streaming completion.
+    ``delta.content`` from a streaming completion. Subclasses set the endpoint
+    and key environment variable; ``_extra_headers`` optionally adds provider
+    request headers.
     """
 
     def __init__(
         self,
         *,
-        base_url: str = "https://integrate.api.nvidia.com/v1",
-        api_key_env_var: str = "NVINFERENCE_API_KEY",
-        priority_mode: bool = False,
+        base_url: str,
+        api_key_env_var: str,
         max_concurrent_requests: int = 10,
         timeout: int = 120,
     ) -> None:
         super().__init__(max_concurrent_requests=max_concurrent_requests, base_url=base_url, timeout=timeout)
         self.api_key_env_var = api_key_env_var
-        self.priority_mode = priority_mode
 
     def setup(self) -> None:
         if getattr(self, "client", None) is not None:
@@ -72,8 +72,9 @@ class NVInferenceClient(AsyncOpenAIClient):
             "stream": True,
             "timeout": self.timeout,
         }
-        if self.priority_mode:
-            create_kwargs["extra_headers"] = _PRIORITY_HEADER
+        extra_headers = getattr(self, "_extra_headers", None)
+        if extra_headers:
+            create_kwargs["extra_headers"] = extra_headers
         # extra_kwargs wins on overlap, matching AsyncOpenAIClient.
         if generation_config.extra_kwargs:
             create_kwargs.update(generation_config.extra_kwargs)
@@ -87,3 +88,56 @@ class NVInferenceClient(AsyncOpenAIClient):
             if delta is not None:
                 parts.append(delta)
         return ["".join(parts)]
+
+
+class NVInferenceClient(_OpenAIStreamingClient):
+    """NVIDIA Inference API client for reasoning VLMs.
+
+    Uses the NVIDIA integration endpoint (``https://integrate.api.nvidia.com/v1``)
+    and reads ``NVINFERENCE_API_KEY``. ``priority_mode`` adds the NVIDIA priority
+    queue header for lower latency at higher cost.
+    """
+
+    def __init__(
+        self,
+        *,
+        base_url: str = "https://integrate.api.nvidia.com/v1",
+        api_key_env_var: str = "NVINFERENCE_API_KEY",
+        priority_mode: bool = False,
+        max_concurrent_requests: int = 10,
+        timeout: int = 120,
+    ) -> None:
+        super().__init__(
+            base_url=base_url,
+            api_key_env_var=api_key_env_var,
+            max_concurrent_requests=max_concurrent_requests,
+            timeout=timeout,
+        )
+        self.priority_mode = priority_mode
+        self._extra_headers = _PRIORITY_HEADER if priority_mode else None
+
+
+class OrcaRouterInferenceClient(_OpenAIStreamingClient):
+    """OrcaRouter gateway client for reasoning VLMs.
+
+    Uses the [OrcaRouter](https://www.orcarouter.ai) gateway endpoint
+    (``https://api.orcarouter.ai/v1``) and reads ``ORCAROUTER_API_KEY``.
+    OrcaRouter exposes OpenAI-compatible ``chat/completions`` on a single
+    endpoint that routes to many model providers, so the same streaming
+    reassembly used for NVIDIA reasoning models applies.
+    """
+
+    def __init__(
+        self,
+        *,
+        base_url: str = "https://api.orcarouter.ai/v1",
+        api_key_env_var: str = "ORCAROUTER_API_KEY",
+        max_concurrent_requests: int = 10,
+        timeout: int = 120,
+    ) -> None:
+        super().__init__(
+            base_url=base_url,
+            api_key_env_var=api_key_env_var,
+            max_concurrent_requests=max_concurrent_requests,
+            timeout=timeout,
+        )

--- a/nemo_curator/stages/synthetic/omni/ocr_scoring_qa.py
+++ b/nemo_curator/stages/synthetic/omni/ocr_scoring_qa.py
@@ -29,6 +29,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
+    from nemo_curator.models.client.llm_client import AsyncLLMClient
     from nemo_curator.tasks.image import ImageSampleTask
 
 from nemo_curator.models.omni.base import NVInferenceClient
@@ -152,6 +153,7 @@ class OCRScoringQAStage(ModelProcessingStage[OCRData]):
         dense_dump_prob: float = 0.05,
         batch_size: int | None = None,
         priority_mode: bool = False,
+        client: AsyncLLMClient | None = None,
     ) -> None:
         """Initialise the combined scoring + QA stage.
 
@@ -178,14 +180,20 @@ class OCRScoringQAStage(ModelProcessingStage[OCRData]):
                 underlying coverage warrants.
             batch_size: Override the default batch size of 16.
             priority_mode: Use priority API queue (lower latency, higher cost).
+            client: Override the verifier client. Defaults to
+                :class:`NVInferenceClient`; pass an
+                :class:`OrcaRouterInferenceClient` to route verifier calls
+                through the [OrcaRouter](https://www.orcarouter.ai) gateway.
         """
         self._scoring_model_id = model_id
         self.min_bbox_match = min_bbox_match
         self.max_text_errors = max_text_errors
         self.fail_on_missing_text = fail_on_missing_text
         self.dense_dump_prob = dense_dump_prob
+        if client is None:
+            client = NVInferenceClient(priority_mode=priority_mode)
         super().__init__(
-            client=NVInferenceClient(priority_mode=priority_mode),
+            client=client,
             model_name=model_id,
             max_tokens=max_tokens,
             temperature=temperature,

--- a/tests/models/omni/test_base.py
+++ b/tests/models/omni/test_base.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Unit tests for nemo_curator.models.omni.base.NVInferenceClient."""
+"""Unit tests for nemo_curator.models.omni.base inference clients."""
 
 import asyncio
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -20,7 +20,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from nemo_curator.models.client.llm_client import GenerationConfig
-from nemo_curator.models.omni.base import NVInferenceClient
+from nemo_curator.models.omni.base import NVInferenceClient, OrcaRouterInferenceClient
 
 
 def _content_chunk(content: str | None) -> MagicMock:
@@ -124,3 +124,36 @@ class TestNVInferenceClientStreaming:
         client = _client_with_stream([_content_chunk("ok")], priority_mode=flag)
         _run_query(client, messages=[{"role": "user", "content": "p"}])
         assert client.client.chat.completions.create.call_args.kwargs.get("extra_headers") == expected_header
+
+
+class TestOrcaRouterInferenceClient:
+    def test_defaults_point_to_orcarouter_gateway(self) -> None:
+        client = OrcaRouterInferenceClient()
+        assert client.openai_kwargs["base_url"] == "https://api.orcarouter.ai/v1"
+        assert client.api_key_env_var == "ORCAROUTER_API_KEY"
+
+    def test_setup_raises_when_env_var_missing(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("ORCAROUTER_API_KEY", raising=False)
+        with pytest.raises(RuntimeError, match="ORCAROUTER_API_KEY is not set"):
+            OrcaRouterInferenceClient().setup()
+
+    def test_setup_constructs_asyncopenai_with_resolved_key(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("ORCAROUTER_API_KEY", "key-orca")  # pragma: allowlist secret
+        with patch("nemo_curator.models.client.openai_client.AsyncOpenAI") as AsyncOpenAI:  # noqa: N806
+            OrcaRouterInferenceClient().setup()
+            kwargs = AsyncOpenAI.call_args.kwargs
+            assert kwargs["base_url"] == "https://api.orcarouter.ai/v1"
+            assert kwargs["api_key"] == "key-orca"  # pragma: allowlist secret
+
+    def test_streams_content_like_nv_client(self) -> None:
+        client = OrcaRouterInferenceClient()
+        inner = MagicMock()
+        inner.chat.completions.create = AsyncMock(
+            return_value=_AsyncStreamIter([_content_chunk("hello"), _content_chunk(None), _content_chunk("world")])
+        )
+        client.client = inner  # bypass setup()
+        out = _run_query(client, messages=[{"role": "user", "content": "p"}])
+        assert out == ["helloworld"]
+        call = inner.chat.completions.create.call_args.kwargs
+        assert call["model"] == "test/model"
+        assert call["stream"] is True

--- a/tests/stages/synthetic/omni/test_ocr_scoring_qa.py
+++ b/tests/stages/synthetic/omni/test_ocr_scoring_qa.py
@@ -91,6 +91,25 @@ class TestOCRScoringQAStage:
 
     # ----- build_prompt --------------------------------------------------
 
+    def test_custom_orcarouter_client_is_threaded_through(self) -> None:
+        custom_client = MagicMock()
+        with patch(
+            "nemo_curator.stages.synthetic.omni.ocr_scoring_qa.NVInferenceClient",
+            return_value=MagicMock(),
+        ):
+            stage = OCRScoringQAStage(client=custom_client)
+        assert stage.client is custom_client
+
+    def test_default_client_is_nv_inference(self) -> None:
+        nv_mock = MagicMock()
+        with patch(
+            "nemo_curator.stages.synthetic.omni.ocr_scoring_qa.NVInferenceClient",
+            return_value=nv_mock,
+        ) as mock_cls:
+            stage = OCRScoringQAStage()
+        assert stage.client is nv_mock
+        mock_cls.assert_called_once_with(priority_mode=False)
+
     def test_build_prompt_skips_when_no_bboxes(self) -> None:
         stage = _make_stage()
         for words in (None, []):

--- a/tutorials/synthetic/omni/ocr_pipeline.py
+++ b/tutorials/synthetic/omni/ocr_pipeline.py
@@ -24,6 +24,7 @@ from loguru import logger
 
 from nemo_curator.backends.xenna import XennaExecutor
 from nemo_curator.core.client import RayClient
+from nemo_curator.models.omni.base import OrcaRouterInferenceClient
 from nemo_curator.pipeline import Pipeline
 from nemo_curator.stages.synthetic.omni.io import (
     HFDatasetImageReaderStage,
@@ -53,6 +54,7 @@ def create_hf_ocr_pipeline(  # noqa: PLR0913
     scoring_qa_max_text_errors: int = 0,
     scoring_qa_fail_on_missing_text: bool = False,
     scoring_qa_dense_dump_prob: float = 0.05,
+    scoring_qa_use_orcarouter: bool = False,
 ) -> Pipeline:
     """Create the OCR pipeline reading images from a HuggingFace dataset.
 
@@ -85,6 +87,9 @@ def create_hf_ocr_pipeline(  # noqa: PLR0913
         scoring_qa_fail_on_missing_text: Mark image invalid when the verifier
             reports missing text regions.
         scoring_qa_dense_dump_prob: Probability of dense-dump vs multi-turn QA.
+        scoring_qa_use_orcarouter: Route verifier calls through the
+            [OrcaRouter](https://www.orcarouter.ai) gateway instead of the
+            NVIDIA Inference API. Requires ``ORCAROUTER_API_KEY`` to be set.
 
     Returns:
         Configured NeMo Curator Pipeline.
@@ -107,6 +112,9 @@ def create_hf_ocr_pipeline(  # noqa: PLR0913
     pipeline.add_stage(OCRNemotronV2Stage(model_dir=nemotron_model_dir))
 
     if run_scoring_qa:
+        scoring_qa_client = None
+        if scoring_qa_use_orcarouter:
+            scoring_qa_client = OrcaRouterInferenceClient()
         pipeline.add_stage(
             OCRScoringQAStage(
                 model_id=scoring_qa_model_id,
@@ -114,6 +122,7 @@ def create_hf_ocr_pipeline(  # noqa: PLR0913
                 max_text_errors=scoring_qa_max_text_errors,
                 fail_on_missing_text=scoring_qa_fail_on_missing_text,
                 dense_dump_prob=scoring_qa_dense_dump_prob,
+                client=scoring_qa_client,
             )
         )
 
@@ -243,6 +252,15 @@ def create_ocr_argparser() -> argparse.ArgumentParser:
         default=0.05,
         help="Probability of dense-dump conversation for complete-OCR images",
     )
+    parser.add_argument(
+        "--scoring-qa-use-orcarouter",
+        action="store_true",
+        default=False,
+        help=(
+            "Route verifier calls through the OrcaRouter gateway (https://www.orcarouter.ai) "
+            "instead of the NVIDIA Inference API. Requires ORCAROUTER_API_KEY to be set."
+        ),
+    )
 
     return parser
 
@@ -271,6 +289,7 @@ def build_pipeline(args: argparse.Namespace) -> Pipeline:
         scoring_qa_max_text_errors=args.scoring_qa_max_text_errors,
         scoring_qa_fail_on_missing_text=args.scoring_qa_fail_on_missing_text,
         scoring_qa_dense_dump_prob=args.scoring_qa_dense_dump_prob,
+        scoring_qa_use_orcarouter=args.scoring_qa_use_orcarouter,
     )
 
 


### PR DESCRIPTION
## Summary

Adds **OrcaRouter** as a named inference provider for the Nemotron OCR scoring-QA verifier.

[OrcaRouter](https://www.orcarouter.ai) is an OpenAI-compatible gateway that routes to many model providers behind a single endpoint (`https://api.orcarouter.ai/v1`). It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

## Changes

- **`nemo_curator/models/omni/base.py`**: extract the shared streaming client logic from `NVInferenceClient` into a private `_OpenAIStreamingClient`, then define `NVInferenceClient` (unchanged behavior) and the new `OrcaRouterInferenceClient` on top of it. `OrcaRouterInferenceClient` targets `https://api.orcarouter.ai/v1` and reads `ORCAROUTER_API_KEY` at worker setup.
- **`nemo_curator/stages/synthetic/omni/ocr_scoring_qa.py`**: `OCRScoringQAStage` now accepts an optional `client` override (defaults to `NVInferenceClient`). Pass `OrcaRouterInferenceClient()` to route verifier calls through OrcaRouter.
- **`tutorials/synthetic/omni/ocr_pipeline.py`**: new `--scoring-qa-use-orcarouter` CLI flag.
- **Docs**: `nemotron-ocr/index.mdx` and `tutorial.mdx` document the OrcaRouter option (CLI + Python API).
- **Tests**: unit tests for `OrcaRouterInferenceClient` (defaults, env-var resolution, streaming reassembly) and for the `client` override in `OCRScoringQAStage`.

## Verification

- `ruff check` / `ruff format --check` clean on changed files.
- `pytest tests/models/omni/test_base.py tests/stages/synthetic/omni/test_ocr_scoring_qa.py` → 32 passed.
- L3 live test: `OrcaRouterInferenceClient._query_model_impl` against the real endpoint (`https://api.orcarouter.ai/v1/chat/completions`, model `orcarouter/auto`) returned `HTTP 200` with content `ORCA-TEST-OK`; a direct curl to the same endpoint also returned `HTTP 200`.

Disclosure: I'm an engineer on the OrcaRouter team.
