### PR TITLE
Disable Rapids kvikio direct write

### DIFF
--- a/fern/versions/main/pages/curate-text/process-data/deduplication/exact.mdx
+++ b/fern/versions/main/pages/curate-text/process-data/deduplication/exact.mdx
@@ -167,13 +167,17 @@ The workflow produces these output files:
 - Runs as a Ray-based workflow and writes duplicate IDs to the `ExactDuplicateIds/` directory
 - Stores only document IDs to remove in the output files, not full document content
 
+**Performance tuning**:
+
+- **Batch sizing**: Use smaller `input_blocksize` values (`256MiB` to `512MiB`) with a larger `identification_batchsize` to target 2-6 GB of overall batches as memory allows. For example, `input_blocksize="256MiB"` with `identification_batchsize=8` processes ~2 GB per insertion call. This improves both shuffle throughput and removal performance compared to the `2GiB` default.
+- **Shuffle partitions**: Setting `total_nparts` to smaller values (`256` or `512`) often leads to better shuffle performance compared to the defaults for really large runs.
+- **GPU memory**: For large cluster runs, tune `rmm_pool_size` and `spill_memory_limit` explicitly to match your hardware and dataset size.
+- **GPU writes**: NeMo Curator defaults `KVIKIO_AUTO_DIRECT_IO_WRITE=0` because KvikIO direct writes can reduce throughput on distributed filesystems such as Lustre. Setting it to `1` before importing NeMo Curator or starting the job may improve writes to a local SSD. Ensure every distributed worker inherits the same value, and benchmark both settings against the target filesystem. This affects GPU-backed cuDF writes from the exact deduplication workflow, not general CPU-based writes. See [Tune GPU Writes for the Target Filesystem](/reference/infra/gpu-processing#tune-gpu-writes-for-the-target-filesystem) for details.
+
 **Best practices**:
 
-- Use smaller `input_blocksize` values (`256MiB` to `512MiB`) with a larger `identification_batchsize` to target 2-6 GB of overall batches as memory allows. For example, `input_blocksize="256MiB"` with `identification_batchsize=8` processes ~2 GB per insertion call. This improves both shuffle throughput and removal performance compared to the `2GiB` default.
-- Clear output directory between runs
-- Use `assign_id=True` for consistent ID tracking
-- Setting `total_nparts` to smaller values (`256` or `512`) often leads to better shuffle performance compared to the defaults for really large runs
-- For large cluster runs, tune `rmm_pool_size` and `spill_memory_limit` explicitly to match your hardware and dataset size
+- Clear the output directory between runs.
+- Use `assign_id=True` for consistent ID tracking.
 </Accordion>
 
 For comparison with other deduplication methods and guidance on when to use exact deduplication, refer to the [Deduplication overview ](/curate-text/process-data/deduplication).

--- a/fern/versions/main/pages/curate-text/process-data/deduplication/fuzzy.mdx
+++ b/fern/versions/main/pages/curate-text/process-data/deduplication/fuzzy.mdx
@@ -226,6 +226,7 @@ The workflow produces these output files:
 - **Memory**: Adjust `bands_per_iteration` (lower = less memory, more iterations)
 - **GPU memory (LSH)**: Use `lsh_rmm_pool_size` to control GPU memory allocation and `lsh_spill_memory_limit` to tune host-spilling behavior during the LSH stage. Reducing the pool size or lowering the spill threshold can prevent out-of-memory errors on smaller GPUs.
 - **Shuffle partitions**: Set `lsh_num_output_partitions` to control the number of output partitions during the LSH shuffle. More partitions reduce per-partition memory but increase I/O overhead.
+- **GPU writes**: NeMo Curator defaults `KVIKIO_AUTO_DIRECT_IO_WRITE=0` because KvikIO direct writes can reduce throughput on distributed filesystems such as Lustre. Setting it to `1` before importing NeMo Curator or starting the job may improve writes to a local SSD. Ensure every distributed worker inherits the same value, and benchmark both settings against the target filesystem. This affects GPU-backed cuDF intermediate and output writes in the workflow, not general CPU-based writes. See [Tune GPU Writes for the Target Filesystem](/reference/infra/gpu-processing#tune-gpu-writes-for-the-target-filesystem) for details.
 - **Accuracy**: Use `char_ngrams &gt;= 20` to reduce false positives
 - **Best practices**: Clear cache between runs, use `input_blocksize="1GiB"`
 

--- a/fern/versions/main/pages/curate-text/process-data/deduplication/semdedup.mdx
+++ b/fern/versions/main/pages/curate-text/process-data/deduplication/semdedup.mdx
@@ -343,6 +343,22 @@ workflow = TextSemanticDeduplicationWorkflow(
     perform_removal=True,
 )
 ```
+
+**GPU write tuning**:
+
+NeMo Curator defaults `KVIKIO_AUTO_DIRECT_IO_WRITE=0` because KvikIO direct
+writes can reduce throughput on distributed filesystems such as Lustre. If the
+workflow writes to a local SSD, setting the variable to `1` may improve
+throughput:
+
+```bash
+export KVIKIO_AUTO_DIRECT_IO_WRITE=1
+```
+
+Set the variable before importing NeMo Curator or starting the job, ensure every
+distributed worker inherits it, and benchmark both values against the target
+filesystem. The setting affects the workflow's GPU-backed cuDF intermediate and
+output writes, not general CPU-based writes. See [Tune GPU Writes for the Target Filesystem](/reference/infra/gpu-processing#tune-gpu-writes-for-the-target-filesystem) for details.
 </Accordion>
 
 ## Output Format
@@ -387,7 +403,7 @@ The workflow produces these output files:
    - **Important**: Contains only the IDs of documents to remove, not the full document content
    - When `perform_removal=True`, clean dataset is saved to `output_path/deduplicated/`
 
- 
+
 
 <Accordion title="Performance Considerations">
 

--- a/fern/versions/main/pages/reference/infrastructure/gpu-processing.mdx
+++ b/fern/versions/main/pages/reference/infrastructure/gpu-processing.mdx
@@ -70,6 +70,25 @@ workflow = FuzzyDeduplicationWorkflow(
 workflow.run()
 ```
 
+## Tune GPU Writes for the Target Filesystem
+
+NeMo Curator sets `KVIKIO_AUTO_DIRECT_IO_WRITE=0` by default. This disables
+KvikIO direct writes because they can reduce write throughput on distributed
+filesystems such as Lustre. Enabling direct writes may improve throughput when
+writing to a local SSD:
+
+```bash
+export KVIKIO_AUTO_DIRECT_IO_WRITE=1
+```
+
+Set the variable before importing NeMo Curator or starting the job. For a
+distributed job, make sure every worker inherits the same value. Benchmark both
+values with the target filesystem and workload before changing the default.
+
+This setting applies to GPU-backed writes performed through cuDF and KvikIO,
+primarily the intermediate and output writes in deduplication workflows. It
+does not affect general CPU-based file writes.
+
 ## GPU-Accelerated Modules
 
 NVIDIA NeMo Curator provides these GPU-accelerated modules:

--- a/nemo_curator/__init__.py
+++ b/nemo_curator/__init__.py
@@ -30,6 +30,7 @@ from .package_info import (
 )
 
 os.environ["RAPIDS_NO_INITIALIZE"] = "1"
+os.environ.setdefault("KVIKIO_AUTO_DIRECT_IO_WRITE", "0")
 
 from cosmos_xenna.ray_utils.cluster import API_LIMIT
 

--- a/nemo_curator/__init__.py
+++ b/nemo_curator/__init__.py
@@ -30,6 +30,8 @@ from .package_info import (
 )
 
 os.environ["RAPIDS_NO_INITIALIZE"] = "1"
+# Kvikio direct write is used by default in cuDF and can lead to degraded write performance on lustre like filesystems
+# Curator defaults to disabling it to maintain existing performance
 os.environ.setdefault("KVIKIO_AUTO_DIRECT_IO_WRITE", "0")
 
 from cosmos_xenna.ray_utils.cluster import API_LIMIT

--- a/tests/core/test___init__.py
+++ b/tests/core/test___init__.py
@@ -12,9 +12,36 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import importlib
+import os
 import sys
 
 import pytest
+
+
+@pytest.mark.parametrize(
+    ("configured_value", "expected_value"),
+    [(None, "0"), ("1", "1")],
+)
+def test_kvikio_auto_direct_io_write_default(
+    monkeypatch: pytest.MonkeyPatch,
+    configured_value: str | None,
+    expected_value: str,
+):
+    if configured_value is None:
+        monkeypatch.delenv("KVIKIO_AUTO_DIRECT_IO_WRITE", raising=False)
+    else:
+        monkeypatch.setenv("KVIKIO_AUTO_DIRECT_IO_WRITE", configured_value)
+
+    saved_module = sys.modules.pop("nemo_curator", None)
+    try:
+        importlib.import_module("nemo_curator")
+        assert os.environ["KVIKIO_AUTO_DIRECT_IO_WRITE"] == expected_value
+    finally:
+        if saved_module is not None:
+            sys.modules["nemo_curator"] = saved_module
+        else:
+            sys.modules.pop("nemo_curator", None)
 
 
 def test_raises_system_error(monkeypatch: pytest.MonkeyPatch):


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->

- This PR disables kvikio direct writes which have been shown to impact write performance on lustre like filesystems. 

- On benchmarks on Lustre, automatic Direct I/O writes were 1.9–5.5× slower where both 26.08 runs completed with metrics, while disabling them restored MinHash write performance to approximately the RAPIDS 25.10 level. On local NVMe, automatic Direct I/O writes were 2.1–2.6× faster. 

- Therefore as an overall tradeoff the plan is the disable it for the time being and document/revisit a more complex setup/recommendations if we see different performance with cloud storage/IO



## Benchmarking

Write-time cells use the format **mean per task / total worker time**, in seconds. Total worker time is summed across parallel tasks and is not wall-clock duration. The comparison columns report elapsed-time ratios: `slower` means more time and `faster` means less time.

Combined predict/write measurements are excluded because prediction time cannot be separated from write time.

### Lustre

Runs:

- RAPIDS 25.10: `nightly-2026_08_20__06_39_17_UTC`
- RAPIDS 26.08, KvikIO automatic Direct I/O writes enabled: `adhoc-adattagupta-...-2026_08_20__15_00_02_UTC-6a0f2131`
- RAPIDS 26.08, `KVIKIO_AUTO_DIRECT_IO_WRITE=0`: `adhoc-adattagupta-...-2026_08_20__18_22_00_UTC-6a0f2131`

| Benchmark | Write metric | RAPIDS 25.10 (mean / total s) | 26.08 DIO on (mean / total s) | 26.08 DIO off (mean / total s) | DIO on vs off | DIO off vs 25.10 |
|---|---|---:|---:|---:|---:|---:|
| `fuzzy_dedup_identification` | MinHash write | 0.375 / 359.2 | 1.512 / 1,446.6 | 0.372 / 355.6 | **4.1× slower** | 1.01× faster |
| `minhash_document_batch_ray_data` | MinHash write | 0.329 / 1,546.0 | 0.607 / 2,858.6¹ | 0.322 / 1,513.5 | **1.9× slower** | 1.02× faster |
| `minhash_document_batch_xenna` | MinHash write | 0.343 / 1,612.9 | Timeout; no metric | 0.334 / 1,570.9 | — | 1.03× faster |
| `minhash_file_group_task_ray_actors` | MinHash write | 0.260 / 1,225.8 | Timeout; no metric | 0.251 / 1,180.0 | — | 1.04× faster |
| `semdedup_identification_xenna_dataset_size_ratio` | KMeans write | 49.105 / 392.8 | 175.384 / 1,403.1 | 31.875 / 255.0 | **5.5× slower** | 1.54× faster |


### Local NVMe

| Benchmark | Write metric | RAPIDS 25.10 (mean / total s) | 26.08 DIO on (mean / total s) | 26.08 DIO off (mean / total s) | DIO on vs off | DIO off vs 25.10 |
|---|---|---:|---:|---:|---:|---:|
| `fuzzy_dedup_identification` | MinHash write | 0.483 / 462.4 | 0.184 / 176.6 | 0.470 / 449.4 | **2.6× faster** | 1.03× faster |
| `minhash_file_group_task_ray_actors`² | MinHash write | 0.338 / 1,591.3 | 0.148 / 697.9 | 0.317 / 1,491.9 | **2.1× faster** | 1.07× faster |


## Usage
<!-- Potentially add a usage example below -->
```python
# Add snippet demonstrating usage
```
## Checklist
<!--
Note: All commits need to be signed and signed off. This can be done via `-sS` flags while commiting
`git commit -sS -m "...."
-->
- [X] I am familiar with the [Contributing Guide](https://github.com/NVIDIA-NeMo/Curator/blob/main/CONTRIBUTING.md).
- [X] New or Existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
