### PR TITLE
ci: run runtime environment tests on CPU

### DIFF
--- a/.github/workflows/cicd-main.yml
+++ b/.github/workflows/cicd-main.yml
@@ -68,6 +68,7 @@ jobs:
     name: Unit_Test_${{ matrix.folder }}_CPU
     env:
       HF_TOKEN: ${{ secrets.HF_TOKEN }}
+      PYTEST_ADDOPTS: --basetemp=${{ github.workspace }}/pytest-tmp
     environment: nemo-ci
     if: |
       (

--- a/tests/gpu_test_groups.json
+++ b/tests/gpu_test_groups.json
@@ -5,7 +5,7 @@
   },
   "text": {
     "extras": ["text_cuda12", "lance"],
-    "paths": ["tests/stages/text", "tests/pipelines/test_per_stage_runtime_env.py"]
+    "paths": ["tests/stages/text"]
   },
   "image": {
     "extras": ["image_cuda12"],

--- a/tests/pipelines/test_per_stage_runtime_env.py
+++ b/tests/pipelines/test_per_stage_runtime_env.py
@@ -79,12 +79,6 @@ def _make_initial_task() -> DocumentBatch:
     )
 
 
-# TODO: Remove @pytest.mark.gpu once CPU CI disk space is resolved.
-# These tests trigger Ray's venv-clone mechanism: for each unique runtime_env spec,
-# Ray copies the full .venv into /tmp. With 3 unique specs this exhausts /tmp on
-# GitHub-hosted CPU runners ([Errno 28] No space left on device).
-# GPU runners have more disk headroom.
-@pytest.mark.gpu
 @pytest.mark.parametrize(
     "backend_config",
     [


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->

Redirect the CPU test job's pytest base directory into the GitHub workspace so Ray's per-stage runtime-environment clones do not exhaust `/tmp`. With that disk-space workaround in place, return the per-stage runtime-environment coverage to CPU CI and remove its duplicate GPU-matrix entry.

Closes #1775.

## Usage
<!-- Potentially add a usage example below -->
```yaml
# No user-facing usage changes; CPU CI now sets PYTEST_ADDOPTS with a workspace-backed --basetemp.
```
## Checklist
<!--
Note: All commits need to be signed and signed off. This can be done via `-sS` flags while commiting
`git commit -sS -m "...."
-->
- [x] I am familiar with the [Contributing Guide](https://github.com/NVIDIA-NeMo/Curator/blob/main/CONTRIBUTING.md).
- [x] New or Existing tests cover these changes.
- [x] The documentation is up to date with these changes.

## Validation

- `python -m pytest tests/pipelines/test_per_stage_runtime_env.py -q --basetemp=/workspace-tmp/pytest-tmp3` (Linux Docker, Python 3.11): 12 passed.
- `pre-commit run --files .github/workflows/cicd-main.yml tests/gpu_test_groups.json tests/pipelines/test_per_stage_runtime_env.py`: passed.
- `python3 .github/scripts/check_gpu_test_coverage.py`: all 47 GPU test files covered.
