### PR TITLE
feat(audio-metrics): in-memory input + agent-ready contracts

### DIFF
--- a/nemo_curator/stages/audio/metrics/bandwidth.py
+++ b/nemo_curator/stages/audio/metrics/bandwidth.py
@@ -21,12 +21,15 @@ import librosa
 import numpy as np
 from loguru import logger
 
+from nemo_curator.stages.audio._agent._agent_ready import AgentReady, ConditionalWrite, Gates, IOSpec, StageContract
+from nemo_curator.stages.audio._agent._residency import InputResidency, residency_read_specs
+from nemo_curator.stages.audio.common import ensure_mono, ensure_waveform_2d
 from nemo_curator.stages.base import ProcessingStage
 from nemo_curator.tasks import AudioTask
 
 
 @dataclass
-class BandwidthEstimationStage(ProcessingStage[AudioTask, AudioTask]):
+class BandwidthEstimationStage(AgentReady, ProcessingStage[AudioTask, AudioTask]):
     """
     Stage that estimates audio bandwidth by analyzing power spectra.
 
@@ -41,6 +44,10 @@ class BandwidthEstimationStage(ProcessingStage[AudioTask, AudioTask]):
         frequency_threshold: Threshold in dB below peak for bandwidth estimation. Defaults to -50.0.
         audio_filepath_key: Key for the audio file path in the manifest. Defaults to "audio_filepath".
         segments_key: Key for the segments in the manifest. Defaults to "segments".
+        waveform_key: Key for an in-memory waveform tensor. Defaults to "waveform".
+        sample_rate_key: Key for the in-memory waveform sample rate. Defaults to "sample_rate".
+        input_residency: Which input to use — "file" (audio_filepath only; default, unchanged),
+            "waveform" (in-memory only), or "auto" (waveform first, file fallback).
 
     Returns:
         The same data as in the input data, but with bandwidth estimates added to each segment.
@@ -52,6 +59,11 @@ class BandwidthEstimationStage(ProcessingStage[AudioTask, AudioTask]):
     frequency_threshold: float = -50.0
     audio_filepath_key: str = "audio_filepath"
     segments_key: str = "segments"
+    duration_key: str = "duration"
+    metrics_key: str = "metrics"
+    waveform_key: str = "waveform"
+    sample_rate_key: str = "sample_rate"
+    input_residency: InputResidency = "file"
 
     # Stage metadata
     name: str = "BandwidthEstimation"
@@ -60,17 +72,80 @@ class BandwidthEstimationStage(ProcessingStage[AudioTask, AudioTask]):
         return [], [self.audio_filepath_key]
 
     def outputs(self) -> tuple[list[str], list[str]]:
-        return [], [self.audio_filepath_key, "metrics"]
+        return [], [self.audio_filepath_key, self.metrics_key]
+
+    def describe(self) -> StageContract:
+        # An audio source (file or in-memory waveform, per input_residency) AND
+        # (segments OR duration). Each audio-source shape is paired with both refinements.
+        reads_one_of = []
+        for spec in residency_read_specs(
+            self.input_residency,
+            audio_filepath_key=self.audio_filepath_key,
+            waveform_key=self.waveform_key,
+            sample_rate_key=self.sample_rate_key,
+        ):
+            reads_one_of.append(IOSpec(data_keys=[*spec.data_keys, self.segments_key], accepts=list(spec.accepts)))
+            reads_one_of.append(IOSpec(data_keys=[*spec.data_keys, self.duration_key], accepts=list(spec.accepts)))
+        return StageContract(
+            reads_one_of=reads_one_of,
+            writes=IOSpec(data_keys=[self.metrics_key], segment_data_keys=[self.metrics_key]),
+            conditional_writes=[
+                ConditionalWrite(
+                    writes=IOSpec(data_keys=[self.metrics_key]),
+                    condition=(
+                        f"audio resolves, '{self.segments_key}' is absent, the top-level item is not skipped "
+                        "for speaker/text, its time range is valid, and bandwidth estimation completes"
+                    ),
+                    value_origin="augments_upstream_same_key",
+                ),
+                ConditionalWrite(
+                    writes=IOSpec(segment_data_keys=[self.metrics_key]),
+                    condition=(
+                        f"audio resolves, '{self.segments_key}' is present, and an individual segment is not "
+                        "skipped for speaker/text, has a valid range, and bandwidth estimation completes"
+                    ),
+                    value_origin="augments_upstream_same_key",
+                ),
+                ConditionalWrite(
+                    writes=IOSpec(segment_data_keys=[self.metrics_key]),
+                    condition=(
+                        f"'{self.segments_key}' is present, an individual segment raises a caught ValueError, "
+                        f"and '{self.metrics_key}.metric_skip_reason' is assigned"
+                    ),
+                    value_origin="augments_upstream_same_key",
+                ),
+            ],
+            # The threshold is measured against the peak of this clip's own power spectrum, not
+            # against a level taken over the corpus.
+            gates=Gates(per_row_independent=True),
+        )
 
     def validate_input(self, task: AudioTask) -> bool:
-        """OR-shaped: needs audio_filepath AND (segments OR duration)."""
+        """Needs an audio source AND (segments OR duration).
+
+        The audio source is ``audio_filepath_key`` (default) or, when ``input_residency``
+        allows it, an in-memory ``waveform_key``+``sample_rate_key``.
+        """
         data = task.data
-        if not hasattr(data, self.audio_filepath_key):
-            logger.error(f"Task {task.task_id} missing '{self.audio_filepath_key}'")
+        has_waveform = data.get(self.waveform_key) is not None and data.get(self.sample_rate_key) is not None
+        has_file = self.audio_filepath_key in data
+        if self.input_residency == "waveform":
+            has_audio = has_waveform
+        elif self.input_residency == "file":
+            has_audio = has_file
+        else:  # auto
+            has_audio = has_waveform or has_file
+        if not has_audio:
+            logger.error(
+                f"Task {task.task_id} missing audio input for input_residency={self.input_residency!r}: "
+                f"need '{self.audio_filepath_key}' or '{self.waveform_key}'+'{self.sample_rate_key}'"
+            )
             return False
-        if hasattr(data, self.segments_key) or hasattr(data, "duration"):
+        if self.segments_key in data or self.duration_key in data:
             return True
-        logger.error(f"Task {task.task_id} missing required attributes: need '{self.segments_key}' OR 'duration'")
+        logger.error(
+            f"Task {task.task_id} missing required attributes: need '{self.segments_key}' OR '{self.duration_key}'"
+        )
         return False
 
     def _estimate_bandwidth(self, audio: "np.ndarray", sample_rate: int) -> int:
@@ -112,14 +187,29 @@ class BandwidthEstimationStage(ProcessingStage[AudioTask, AudioTask]):
         segment_audio_array = audio[int(start * sample_rate) : int(end * sample_rate)]
         bandwidth = self._estimate_bandwidth(segment_audio_array, sample_rate)
 
-        if "metrics" not in audio_segment:
-            audio_segment["metrics"] = {}
+        if self.metrics_key not in audio_segment:
+            audio_segment[self.metrics_key] = {}
 
-        audio_segment["metrics"]["bandwidth"] = int(bandwidth)
+        audio_segment[self.metrics_key]["bandwidth"] = int(bandwidth)
 
-    def process(self, task: AudioTask) -> AudioTask:
-        """Estimate bandwidth for audio entry."""
-        data_entry = task.data
+    def _resolve_entry_audio(self, data_entry: dict[str, Any]) -> tuple["np.ndarray", int]:
+        """Return ``(mono_1d_audio, sample_rate)`` from a waveform or the file.
+
+        When ``input_residency`` allows it and an in-memory waveform is present, it is used
+        directly; otherwise the audio file is loaded at its native rate (default, unchanged).
+        """
+        if self.input_residency != "file":
+            waveform = data_entry.get(self.waveform_key)
+            sr = data_entry.get(self.sample_rate_key)
+            if waveform is not None and sr is not None:
+                audio = ensure_mono(ensure_waveform_2d(waveform)).squeeze(0)
+                return audio.detach().cpu().numpy(), int(sr)
+            if self.input_residency == "waveform":
+                msg = (
+                    f"[{self.name}] Missing '{self.waveform_key}'+'{self.sample_rate_key}' for entry: "
+                    f"{data_entry.get('audio_item_id', 'unknown')} (input_residency='waveform')"
+                )
+                raise ValueError(msg)
         audio_path = data_entry.get(self.audio_filepath_key)
         if not audio_path:
             msg = (
@@ -132,6 +222,12 @@ class BandwidthEstimationStage(ProcessingStage[AudioTask, AudioTask]):
         except Exception as ex:
             msg = f"[{self.name}] Failed to load audio: {audio_path}"
             raise RuntimeError(msg) from ex
+        return audio, sample_rate
+
+    def process(self, task: AudioTask) -> AudioTask:
+        """Estimate bandwidth for audio entry."""
+        data_entry = task.data
+        audio, sample_rate = self._resolve_entry_audio(data_entry)
 
         if self.segments_key in data_entry:
             for segment in data_entry[self.segments_key]:
@@ -139,7 +235,7 @@ class BandwidthEstimationStage(ProcessingStage[AudioTask, AudioTask]):
                     self.get_bandwidth(segment, audio, sample_rate)
                 except ValueError as ex:
                     logger.warning(f"[{self.name}] skipping segment in {task.task_id}: {ex}")
-                    segment.setdefault("metrics", {})["metric_skip_reason"] = str(ex)
+                    segment.setdefault(self.metrics_key, {})["metric_skip_reason"] = str(ex)
         else:
             self.get_bandwidth(data_entry, audio, sample_rate)
 

--- a/nemo_curator/stages/audio/metrics/squim.py
+++ b/nemo_curator/stages/audio/metrics/squim.py
@@ -26,13 +26,16 @@ from loguru import logger
 from torchaudio.pipelines import SQUIM_OBJECTIVE
 
 from nemo_curator.backends.base import NodeInfo, WorkerMetadata
+from nemo_curator.stages.audio._agent._agent_ready import AgentReady, ConditionalWrite, Gates, IOSpec, StageContract
+from nemo_curator.stages.audio._agent._residency import InputResidency, residency_read_specs
+from nemo_curator.stages.audio.common import ensure_mono, ensure_waveform_2d
 from nemo_curator.stages.base import ProcessingStage
 from nemo_curator.stages.resources import Resources
 from nemo_curator.tasks import AudioTask
 
 
 @dataclass
-class TorchSquimQualityMetricsStage(ProcessingStage[AudioTask, AudioTask]):
+class TorchSquimQualityMetricsStage(AgentReady, ProcessingStage[AudioTask, AudioTask]):
     """
     Stage that calculates Squim quality metrics for audio files.
 
@@ -45,6 +48,10 @@ class TorchSquimQualityMetricsStage(ProcessingStage[AudioTask, AudioTask]):
         batch_size: Number of audio tasks to be processed at once. Defaults to 32.
         compute_batch_size: Number of waveforms to process per GPU inference call. Defaults to 32.
         segments_key: Key for the segments in the manifest. Defaults to "segments".
+        waveform_key: Key for an in-memory waveform tensor. Defaults to "waveform".
+        sample_rate_key: Key for the in-memory waveform sample rate. Defaults to "sample_rate".
+        input_residency: Which input to use — "file" (audio_filepath only; default, unchanged),
+            "waveform" (in-memory only), or "auto" (waveform first, file fallback).
 
     Returns:
         The same data as in the input data, but with Squim quality metrics added to each segment.
@@ -55,9 +62,14 @@ class TorchSquimQualityMetricsStage(ProcessingStage[AudioTask, AudioTask]):
     batch_size: int = 32
     compute_batch_size: int = 32
     segments_key: str = "segments"
+    metrics_key: str = "metrics"
+    waveform_key: str = "waveform"
+    sample_rate_key: str = "sample_rate"
+    input_residency: InputResidency = "file"
 
     # Stage metadata
     name: str = "TorchSquimQualityMetrics"
+    BATCH_ONLY = True  # process() raises; only process_batch is implemented (agent-discovery hint)
     resources: Resources = field(default_factory=lambda: Resources(gpus=1.0))
 
     model: Any = field(default=None, repr=False)
@@ -66,18 +78,70 @@ class TorchSquimQualityMetricsStage(ProcessingStage[AudioTask, AudioTask]):
         return [], []
 
     def outputs(self) -> tuple[list[str], list[str]]:
-        return [], []
+        return [], [self.metrics_key]
+
+    def describe(self) -> StageContract:
+        # An audio source (file or in-memory waveform, per input_residency) is required;
+        # segments only refine WHERE metrics are attached (optional, read at runtime).
+        return StageContract(
+            reads_one_of=residency_read_specs(
+                self.input_residency,
+                audio_filepath_key=self.audio_filepath_key,
+                waveform_key=self.waveform_key,
+                sample_rate_key=self.sample_rate_key,
+            ),
+            writes=IOSpec(data_keys=[self.metrics_key], segment_data_keys=[self.metrics_key]),
+            conditional_writes=[
+                ConditionalWrite(
+                    writes=IOSpec(data_keys=[self.metrics_key]),
+                    condition=(
+                        f"'{self.segments_key}' is absent, top-level audio resolves to a waveform, "
+                        "and whole-batch model inference completes"
+                    ),
+                    value_origin="augments_upstream_same_key",
+                ),
+                ConditionalWrite(
+                    writes=IOSpec(segment_data_keys=[self.metrics_key]),
+                    condition=(
+                        f"'{self.segments_key}' is present; an individual segment is not marked no-speaker, "
+                        "has non-blank text and a positive requested frame span, its waveform is collected, "
+                        "and whole-batch model inference completes"
+                    ),
+                    value_origin="augments_upstream_same_key",
+                ),
+            ],
+            gates=Gates(
+                requires_gpu=self.resources.requires_gpu,
+                requires_internet_first_run=True,
+                # ``_compute_metrics_batched`` zero-pads each batch to its longest member and
+                # calls the model with no lengths, so padding reads as silence and a clip's
+                # scores depend on which clips sorted beside it. Pass lengths and this becomes True.
+                per_row_independent=False,
+            ),
+        )
 
     def validate_input(self, task: AudioTask) -> bool:
-        """OR-shaped validation: segments OR top-level audio_filepath keys must be present."""
+        """An audio source is required; segments are optional refinement.
+
+        When ``input_residency`` allows it, an in-memory ``waveform_key``+``sample_rate_key``
+        satisfies the requirement; otherwise ``audio_filepath_key`` must be present (the
+        default, unchanged behavior).
+        """
         data = task.data
-        if hasattr(data, self.segments_key):
-            return True
-        if hasattr(data, self.audio_filepath_key):
+        has_waveform = data.get(self.waveform_key) is not None and data.get(self.sample_rate_key) is not None
+        has_file = self.audio_filepath_key in data
+        if self.input_residency == "waveform":
+            ok = has_waveform
+        elif self.input_residency == "file":
+            ok = has_file
+        else:  # auto
+            ok = has_waveform or has_file
+        if ok:
             return True
         logger.error(
-            f"Task {task.task_id} missing required attributes: "
-            f"need '{self.segments_key}' OR '{self.audio_filepath_key}'"
+            f"Task {task.task_id} missing required audio input for input_residency={self.input_residency!r}: "
+            f"need '{self.audio_filepath_key}' or '{self.waveform_key}'+'{self.sample_rate_key}' "
+            f"(segments alone are not sufficient — SQUIM loads audio)"
         )
         return False
 
@@ -126,11 +190,27 @@ class TorchSquimQualityMetricsStage(ProcessingStage[AudioTask, AudioTask]):
                 )
         return results
 
-    def _collect_waveforms_for_entry(self, task_idx: int, data_entry: dict) -> list[tuple[int, int, torch.Tensor]]:
-        """Extract valid segment waveforms from a single audio entry.
+    def _resolve_entry_audio(self, data_entry: dict) -> tuple[Any, int]:
+        """Return ``(mono_1d_audio_ndarray, sample_rate)`` from a waveform or the file.
 
-        Returns a list of (task_idx, segment_idx, waveform) tuples.
+        When ``input_residency`` allows it and an in-memory ``waveform_key``+
+        ``sample_rate_key`` is present, that waveform is used directly; otherwise the
+        audio file is read at its native sample rate (the default, unchanged behavior).
+        Per-segment slicing downstream is identical for either source.
         """
+        if self.input_residency != "file":
+            waveform = data_entry.get(self.waveform_key)
+            sr = data_entry.get(self.sample_rate_key)
+            if waveform is not None and sr is not None:
+                audio = ensure_mono(ensure_waveform_2d(waveform)).squeeze(0)
+                return audio.detach().cpu().numpy(), int(sr)
+            if self.input_residency == "waveform":
+                msg = (
+                    f"[{self.name}] Missing '{self.waveform_key}'+'{self.sample_rate_key}' for entry: "
+                    f"{data_entry.get('audio_item_id', 'unknown')} (input_residency='waveform')"
+                )
+                raise ValueError(msg)
+
         audio_path = data_entry.get(self.audio_filepath_key)
         if not audio_path:
             msg = (
@@ -138,19 +218,30 @@ class TorchSquimQualityMetricsStage(ProcessingStage[AudioTask, AudioTask]):
                 f"{data_entry.get('audio_item_id', 'unknown')}"
             )
             raise ValueError(msg)
-
         try:
             info = sf.info(audio_path)
             sr = info.samplerate
         except Exception as ex:
             msg = f"[{self.name}] Failed to read audio info: {audio_path}"
             raise RuntimeError(msg) from ex
-
         try:
             audio, _ = librosa.load(path=audio_path, sr=sr)
         except Exception as ex:
             msg = f"[{self.name}] Failed to load audio: {audio_path}"
             raise RuntimeError(msg) from ex
+        return audio, sr
+
+    def _collect_waveforms_for_entry(self, task_idx: int, data_entry: dict) -> list[tuple[int, int, torch.Tensor]]:
+        """Extract valid segment waveforms from a single audio entry.
+
+        Returns a list of (task_idx, segment_idx, waveform) tuples.
+        """
+        audio, sr = self._resolve_entry_audio(data_entry)
+        # Names the entry in the zero-length-segment warning below. Not the path directly:
+        # ``_resolve_entry_audio`` also serves resident waveforms, which have no file, and the
+        # binding it once shared with this method moved inside it when it was extracted --
+        # leaving the warning referring to an ``audio_path`` that no longer existed here.
+        source = data_entry.get(self.audio_filepath_key) or data_entry.get("audio_item_id", "unknown")
 
         collected: list[tuple[int, int, torch.Tensor]] = []
         if self.segments_key in data_entry:
@@ -165,7 +256,7 @@ class TorchSquimQualityMetricsStage(ProcessingStage[AudioTask, AudioTask]):
                 end_frame = math.floor(end * sr)
 
                 if end_frame - start_frame <= 0:
-                    logger.warning(f"[{self.name}] Zero-length segment at {start}-{end}s in {audio_path}, skipping")
+                    logger.warning(f"[{self.name}] Zero-length segment at {start}-{end}s in {source}, skipping")
                     continue
 
                 y = torch.from_numpy(audio[start_frame:end_frame])
@@ -184,11 +275,11 @@ class TorchSquimQualityMetricsStage(ProcessingStage[AudioTask, AudioTask]):
         self, audio_segment: dict[str, Any], pesq_val: float, stoi_val: float, sisdr_val: float
     ) -> None:
         """Update the metrics for an audio segment."""
-        if "metrics" not in audio_segment:
-            audio_segment["metrics"] = {}
-        audio_segment["metrics"]["pesq_squim"] = pesq_val
-        audio_segment["metrics"]["stoi_squim"] = stoi_val
-        audio_segment["metrics"]["sisdr_squim"] = sisdr_val
+        if self.metrics_key not in audio_segment:
+            audio_segment[self.metrics_key] = {}
+        audio_segment[self.metrics_key]["pesq_squim"] = pesq_val
+        audio_segment[self.metrics_key]["stoi_squim"] = stoi_val
+        audio_segment[self.metrics_key]["sisdr_squim"] = sisdr_val
 
     def process(self, task: AudioTask) -> AudioTask:
         """Delegate single-task processing to process_batch."""

--- a/nemo_curator/stages/audio/metrics/wer.py
+++ b/nemo_curator/stages/audio/metrics/wer.py
@@ -23,12 +23,13 @@ from nemo.collections.asr.metrics.wer import word_error_rate_detail
 from nemo_text_processing.text_normalization import Normalizer
 
 from nemo_curator.backends.base import WorkerMetadata
+from nemo_curator.stages.audio._agent._agent_ready import AgentReady, ConditionalWrite, Gates, IOSpec, StageContract
 from nemo_curator.stages.base import ProcessingStage
 from nemo_curator.tasks import AudioTask
 
 
 @dataclass
-class ComputeWERStage(ProcessingStage[AudioTask, AudioTask]):
+class ComputeWERStage(AgentReady, ProcessingStage[AudioTask, AudioTask]):
     """
     Stage that computes Word Error Rate (WER), CER, edge CER, and optionally PNC WER/CER.
     This stage cleans the text and normalizes it using NeMo text processing (numbers to words, etc).
@@ -40,7 +41,7 @@ class ComputeWERStage(ProcessingStage[AudioTask, AudioTask]):
     Args:
         language: Language of the text. Defaults to "en".
         hypothesis_text_key: Key to the hypothesis text. Defaults to "text".
-        reference_text_key: Key to the reference text. Defaults to "text".
+        reference_text_key: Key to the reference text. Defaults to "text_ref".
         num_words_threshold: Number of words to use for normalization. Defaults to 200.
         num_words_look_back: Number of words to look back for normalization. Defaults to 5.
         compute_pnc_wer: Whether to compute PNC WER/CER. Defaults to False.
@@ -62,6 +63,7 @@ class ComputeWERStage(ProcessingStage[AudioTask, AudioTask]):
     edge_length: int = 12
 
     segments_key: str = "segments"
+    metrics_key: str = "metrics"
 
     # Stage metadata
     name: str = "ComputeWER"
@@ -81,7 +83,48 @@ class ComputeWERStage(ProcessingStage[AudioTask, AudioTask]):
         return [], []
 
     def outputs(self) -> tuple[list[str], list[str]]:
-        return [], ["metrics"]
+        return [], [self.metrics_key]
+
+    def describe(self) -> StageContract:
+        # Mirrors validate_input's OR shape: per-segment WER over ``segments``,
+        # OR top-level WER over hypothesis+reference keys on the row.
+        return StageContract(
+            reads_one_of=[
+                IOSpec(data_keys=[self.segments_key]),
+                IOSpec(data_keys=[self.hypothesis_text_key, self.reference_text_key]),
+            ],
+            writes=IOSpec(data_keys=[self.metrics_key], segment_data_keys=[self.metrics_key]),
+            conditional_writes=[
+                ConditionalWrite(
+                    writes=IOSpec(data_keys=[self.metrics_key]),
+                    condition=(
+                        f"'{self.segments_key}' is absent and the top-level "
+                        f"'{self.hypothesis_text_key}' and '{self.reference_text_key}' values are valid text; "
+                        "normalization completes and either empty-reference diagnostics or WER metrics are assigned"
+                    ),
+                    value_origin="augments_upstream_same_key",
+                ),
+                ConditionalWrite(
+                    writes=IOSpec(segment_data_keys=[self.metrics_key]),
+                    condition=(
+                        f"'{self.segments_key}' is present and an individual segment has valid text in "
+                        f"'{self.hypothesis_text_key}' and '{self.reference_text_key}'; normalization completes "
+                        "and either empty-reference diagnostics or WER metrics are assigned"
+                    ),
+                    value_origin="augments_upstream_same_key",
+                ),
+                ConditionalWrite(
+                    writes=IOSpec(segment_data_keys=[self.metrics_key]),
+                    condition=(
+                        f"'{self.segments_key}' is present, segment computation raises a caught KeyError "
+                        f"or ValueError, and '{self.metrics_key}.metric_skip_reason' is assigned"
+                    ),
+                    value_origin="augments_upstream_same_key",
+                ),
+            ],
+            # Each metric compares one hypothesis against its own reference, a segment at a time.
+            gates=Gates(per_row_independent=True),
+        )
 
     def validate_input(self, task: AudioTask) -> bool:
         """OR-shaped validation: segments OR top-level text keys must be present."""
@@ -193,7 +236,7 @@ class ComputeWERStage(ProcessingStage[AudioTask, AudioTask]):
         if self.hypothesis_text_key not in audio_segment or self.reference_text_key not in audio_segment:
             return
 
-        metrics = audio_segment.get("metrics", {})
+        metrics = audio_segment.get(self.metrics_key, {})
 
         hypothesis_pnc, hypothesis_clean = self.normalize_and_clean_text(audio_segment[self.hypothesis_text_key])
         reference_pnc, reference_clean = self.normalize_and_clean_text(audio_segment[self.reference_text_key])
@@ -202,7 +245,7 @@ class ComputeWERStage(ProcessingStage[AudioTask, AudioTask]):
             metrics["wer"] = None
             metrics["cer"] = None
             metrics["metric_skip_reason"] = "empty_reference"
-            audio_segment["metrics"] = metrics
+            audio_segment[self.metrics_key] = metrics
             return
 
         metrics["char_rate"] = self.get_char_rate(audio_segment[self.hypothesis_text_key], duration)
@@ -299,7 +342,7 @@ class ComputeWERStage(ProcessingStage[AudioTask, AudioTask]):
                 "sub_rate": round(sub_rate_pnc, 4),
             }
 
-        audio_segment["metrics"] = metrics
+        audio_segment[self.metrics_key] = metrics
 
     def process(self, task: AudioTask) -> AudioTask:
         """Compute WER, CER, edge CER, and optionally PNC WER/CER per segment."""
@@ -310,14 +353,14 @@ class ComputeWERStage(ProcessingStage[AudioTask, AudioTask]):
                     self.get_wer(audio_segment)
                 except (KeyError, ValueError) as ex:
                     logger.warning(f"[{self.name}] skipping segment in {task.task_id}: {ex}")
-                    audio_segment.setdefault("metrics", {})["metric_skip_reason"] = str(ex)
+                    audio_segment.setdefault(self.metrics_key, {})["metric_skip_reason"] = str(ex)
         else:
             self.get_wer(data_entry)
         return task
 
 
 @dataclass
-class GetPairwiseWerStage(ProcessingStage[AudioTask, AudioTask]):
+class GetPairwiseWerStage(AgentReady, ProcessingStage[AudioTask, AudioTask]):
     """Compute pairwise word-error-rate (WER) as a percentage for each pair of text and pred_text.
 
     WER is measured between ``data[self.text_key]`` and ``data[self.pred_text_key]``
@@ -339,6 +382,22 @@ class GetPairwiseWerStage(ProcessingStage[AudioTask, AudioTask]):
 
     def outputs(self) -> tuple[list[str], list[str]]:
         return [], [self.text_key, self.pred_text_key, self.wer_key]
+
+    def describe(self) -> StageContract:
+        return StageContract(
+            reads=IOSpec(data_keys=[self.text_key, self.pred_text_key]),
+            writes=IOSpec(data_keys=[self.wer_key]),
+            conditional_writes=[
+                ConditionalWrite(
+                    writes=IOSpec(data_keys=[self.wer_key]),
+                    condition=(
+                        f"both '{self.text_key}' and '{self.pred_text_key}' resolve to valid non-null text "
+                        "and pairwise WER computation completes"
+                    ),
+                )
+            ],
+            gates=Gates(per_row_independent=True),
+        )
 
     def process(self, task: AudioTask) -> AudioTask:
         """Compute WER percentage between hypothesis and reference text."""

--- a/tests/stages/audio/metrics/test_metrics.py
+++ b/tests/stages/audio/metrics/test_metrics.py
@@ -51,6 +51,85 @@ class TestBandwidthEstimationStage:
         assert "bandwidth" in result.data["metrics"]
         assert result.data["metrics"]["bandwidth"] > 0
 
+    def test_waveform_residency_matches_file(self, audio_task: Callable[..., AudioTask], tmp_path: Path) -> None:
+        """Bandwidth from an in-memory waveform equals the file result (input_residency)."""
+        import numpy as np
+        import soundfile as sf
+
+        sr = 16000
+        audio = (np.random.default_rng(0).standard_normal(sr) * 0.1).astype("float32")
+        wav = tmp_path / "a.wav"
+        sf.write(str(wav), audio, sr)
+
+        file_stage = BandwidthEstimationStage()
+        file_stage.setup()
+        file_bw = file_stage.process(audio_task(audio_filepath=str(wav), duration=1.0)).data["metrics"]["bandwidth"]
+
+        wf_stage = BandwidthEstimationStage(input_residency="waveform")
+        wf_stage.setup()
+        wf_bw = wf_stage.process(
+            audio_task(waveform=torch.from_numpy(audio).unsqueeze(0), sample_rate=sr, duration=1.0)
+        ).data["metrics"]["bandwidth"]
+
+        assert wf_bw == file_bw
+
+    def test_residency_validate_input(self) -> None:
+        wf_stage = BandwidthEstimationStage(input_residency="waveform")
+        assert wf_stage.validate_input(
+            AudioTask(data={"waveform": torch.randn(1, 16000), "sample_rate": 16000, "duration": 1.0})
+        )
+        assert not wf_stage.validate_input(AudioTask(data={"audio_filepath": "/a.wav", "duration": 1.0}))
+        # default (file) mode unchanged: needs audio_filepath AND (segments OR duration)
+        file_stage = BandwidthEstimationStage()
+        assert file_stage.validate_input(AudioTask(data={"audio_filepath": "/a.wav", "duration": 1.0}))
+        assert not file_stage.validate_input(AudioTask(data={"audio_filepath": "/a.wav"}))
+
+
+class TestSquimResidency:
+    """SQUIM input_residency contract/validation (no model needed)."""
+
+    def test_default_is_file_only(self) -> None:
+        stage = TorchSquimQualityMetricsStage()
+        assert stage.input_residency == "file"
+        forms = {a for s in stage.describe().reads_one_of for a in s.accepts}
+        assert forms == {"file"}
+        assert stage.validate_input(AudioTask(data={"resampled_audio_filepath": "/a.wav"})) is True
+        assert stage.validate_input(AudioTask(data={"waveform": torch.randn(1, 16000), "sample_rate": 16000})) is False
+
+    def test_waveform_and_auto_residency(self) -> None:
+        wf_stage = TorchSquimQualityMetricsStage(input_residency="waveform")
+        assert {a for s in wf_stage.describe().reads_one_of for a in s.accepts} == {"waveform"}
+        assert (
+            wf_stage.validate_input(AudioTask(data={"waveform": torch.randn(1, 16000), "sample_rate": 16000})) is True
+        )
+        assert wf_stage.validate_input(AudioTask(data={"resampled_audio_filepath": "/a.wav"})) is False
+        auto = TorchSquimQualityMetricsStage(input_residency="auto")
+        assert {a for s in auto.describe().reads_one_of for a in s.accepts} == {"file", "waveform"}
+
+
+class TestSquimZeroLengthSegments:
+    """A degenerate segment must be skipped, not crash the stage."""
+
+    def test_a_zero_length_segment_is_skipped_and_named(self, tmp_path: Path) -> None:
+        """Extracting ``_resolve_entry_audio`` moved the ``audio_path`` binding out of this
+        method but left the warning referring to it, so the first zero-length segment raised
+        ``NameError``. Only the error path reached it, so ordinary audio never surfaced it.
+        """
+        import numpy as np
+        import soundfile as sf
+
+        wav = tmp_path / "a.wav"
+        sf.write(str(wav), np.zeros(16000, dtype="float32"), 16000)
+        entry = {
+            "resampled_audio_filepath": str(wav),
+            "segments": [
+                {"start": 0.0, "end": 0.0, "text": "degenerate", "speaker": "s0"},
+                {"start": 0.0, "end": 0.5, "text": "usable", "speaker": "s0"},
+            ],
+        }
+        collected = TorchSquimQualityMetricsStage()._collect_waveforms_for_entry(0, entry)
+        assert [seg_idx for _, seg_idx, _ in collected] == [1]  # the zero-length one is skipped
+
 
 class TestComputeWERStage:
     """Tests for ComputeWERStage helpers and process."""


### PR DESCRIPTION
**Contracts:** `describe()` + `*_key` params on the bandwidth, SQUIM and WER metric stages, including `conditional_writes` (a metric is only written when the audio resolves and estimation succeeds).

**New functionality**
- **In-memory input** (`input_residency`) — read the waveform already in the task rather than re-opening the file for every metric stage. On a chain of several metric stages this removes one file read per stage per row.

Per-segment scoring and `metric_skip_reason` already existed upstream; the contracts here just declare them, so the planner knows a metric is written only when the audio resolves and estimation succeeds.

Depends on the agent-ready foundation, #2332 — that must merge first (this branch imports `nemo_curator/stages/audio/_agent/`, so CI here stays red until it lands).
Missing configured WER text-key handling is intentionally out of scope here and remains in draft #2353. This PR can merge independently; #2353 can rebase onto main afterward.