### PR TITLE
feat(audio-advanced-pipelines): make AudioDataFilterStage agent-ready

### DIFF
--- a/nemo_curator/stages/audio/advanced_pipelines/audio_data_filter/audio_data_filter.py
+++ b/nemo_curator/stages/audio/advanced_pipelines/audio_data_filter/audio_data_filter.py
@@ -46,17 +46,19 @@ if TYPE_CHECKING:
 
 from loguru import logger
 
+from nemo_curator.stages.audio._agent._agent_ready import AgentReady, Gates, StageContract
 from nemo_curator.stages.audio.filtering import BandFilterStage, SIGMOSFilterStage, UTMOSFilterStage
 from nemo_curator.stages.audio.postprocessing import TimestampMapperStage
 from nemo_curator.stages.audio.preprocessing import MonoConversionStage, SegmentConcatenationStage
 from nemo_curator.stages.audio.segmentation import SpeakerSeparationStage, VADSegmentationStage
 from nemo_curator.stages.base import CompositeStage, ProcessingStage
 from nemo_curator.stages.resources import Resources
+from nemo_curator.tasks import AudioTask
 
 from .config import _deep_merge, get_enabled_stages, load_config
 
 
-class AudioDataFilterStage(CompositeStage):
+class AudioDataFilterStage(AgentReady, CompositeStage[AudioTask, AudioTask]):
     """Complete audio data filtering and curation pipeline (CompositeStage).
 
     Decomposes into independent stages that the executor can schedule with
@@ -89,6 +91,16 @@ class AudioDataFilterStage(CompositeStage):
         self._cfg = load_config(config_path)
         if config:
             self._cfg = _deep_merge(self._cfg, config)
+
+    def describe(self) -> StageContract:
+        return StageContract(
+            wrappable=False,
+            # True for every topology because it is true of each delegate: mono conversion, VAD,
+            # the three quality filters, concatenation, speaker separation and the timestamp
+            # mapper all work from the row they are handed. The factories below leave
+            # ``write_to_disk`` unset throughout, so none of them even opens a shared directory.
+            gates=Gates(per_row_independent=True),
+        )
 
     def decompose(self) -> list[ProcessingStage]:
         """Build a self-consistent pipeline topology based on enabled features."""


### PR DESCRIPTION
**Contracts only — no behavior change.** Adds a `describe()` contract to the composite `AudioDataFilterStage` so the planner can see what the whole bundled pipeline reads and writes, and that it writes to disk.

This composite expands into filtering, postprocessing, preprocessing, and segmentation leaf stages. The following agent-ready migrations are hard prerequisites and must merge before this PR is rebased and merged:

- #2332 — shared agent-ready foundation
- #2334 — timestamp mapper/postprocessing contracts
- #2335 — filtering contracts
- #2338 — segmentation contracts

Until those prerequisites land, this PR's standalone tree does not contain the complete contract stack and its CI is expected to remain blocked. The complete integrated stack validates all four supported VAD/speaker topologies (5/6/9/12 leaf stages) cleanly.
