### PR TITLE
feat: add per-node stage worker sizing

### DIFF
--- a/fern/versions/main/pages/api-reference/executors/xenna-executor.mdx
+++ b/fern/versions/main/pages/api-reference/executors/xenna-executor.mdx
@@ -67,7 +67,7 @@ results = pipeline.run(executor=executor)
 
 ### Per-Stage Worker Overrides
 
-Use `num_workers` for a cluster-wide count. To request workers per node instead, leave `num_workers` unset and configure only `num_workers_per_node`:
+Use `num_workers` for a cluster-wide count. To request workers per node instead, leave `num_workers` unset and use the common `num_workers_per_node` override:
 
 ```python
 from nemo_curator.stages.base import ProcessingStage
@@ -92,14 +92,12 @@ cluster_wide_stage = PassthroughStage().with_(
 
 per_node_stage = PassthroughStage().with_(
     num_workers=None,
-    xenna_stage_spec={
-        "num_workers_per_node": 2,
-    },
+    num_workers_per_node=2,
 )
 ```
 
 <Warning>
-Do not set both worker controls. Do not place `num_workers` inside `xenna_stage_spec`; use `with_(num_workers=...)` or override the stage's `num_workers()` method.
+Do not set both worker controls. Do not place `num_workers` inside `xenna_stage_spec`; use the common `with_()` arguments or override the corresponding stage method. The legacy `xenna_stage_spec={"num_workers_per_node": N}` form remains supported when neither common worker hook is set.
 </Warning>
 
 See [Stage Worker Sizing](/reference/infra/stage-worker-sizing#xenna-worker-counts) for scope, invalid-combination behavior, and `with_()` merge semantics.

--- a/fern/versions/main/pages/api-reference/processing-stage.mdx
+++ b/fern/versions/main/pages/api-reference/processing-stage.mdx
@@ -157,6 +157,19 @@ def num_workers(self) -> int | None:
 
 The exact meaning depends on the executor: Ray Data creates a fixed actor or task pool, Xenna treats it as a cluster-wide count, and Ray Actor Pool caps it to available resource capacity when necessary. See [Stage Worker Sizing](/reference/infra/stage-worker-sizing) for the complete backend matrix.
 
+### `num_workers_per_node()`
+
+Return a backend-neutral worker count per alive Ray node. `None` delegates worker sizing to the executor.
+
+```python
+def num_workers_per_node(self) -> float | None:
+    return None
+```
+
+The executor converts the value to a cluster-wide request. Ray Data uses `ceil(num_workers_per_node × alive node count)` and best-effort `SPREAD` placement, Xenna forwards the per-node value directly, and Ray Actor Pool applies the same multiplier before capping the result to available resource capacity. Fractional values are supported; values must be positive.
+
+Like `num_workers`, `num_workers_per_node` is reserved as a method. Override it for a class-level default, or use `stage.with_(num_workers_per_node=...)` for one pipeline instance. Do not combine it with `num_workers()` or Ray Data's `min_workers`, `max_workers`, or `initial_workers` actor-pool keys.
+
 ### `ray_stage_spec()`
 
 Return Ray-specific stage options. Ray Data consumes the worker-pool keys below, while selected flags are also used by Ray Actor Pool. Use the `RayStageSpecKeys` enum rather than spelling keys manually:
@@ -180,12 +193,11 @@ Return Xenna-specific stage options:
 ```python
 def xenna_stage_spec(self) -> dict:
     return {
-        "num_workers_per_node": 2,
         "worker_max_lifetime_m": 45,
     }
 ```
 
-Do not put `num_workers` in this dictionary. Use the common `num_workers()` hook for a cluster-wide Xenna count. `num_workers()` and `num_workers_per_node` cannot be set together.
+Use the common `num_workers()` and `num_workers_per_node()` hooks for portable worker sizing. The legacy `num_workers_per_node` Xenna key remains supported, but do not combine it with either common sizing hook. Do not put `num_workers` in this dictionary.
 
 `task_id` is framework-owned. The executor adapter assigns it after either `process()` or `process_batch()` returns, so custom stages must not set or derive IDs. For deterministic lineage, preserve positional correspondence in batched code: return one task or `None` for every input. A batch that maps multiple inputs to a different number of outputs receives random `r`-prefixed IDs because parentage is ambiguous.
 
@@ -280,7 +292,7 @@ configured_stage = stage.with_(
     resources=Resources(cpus=4.0, gpus=1.0),
     batch_size=8,
     runtime_env={"pip": ["transformers==4.45.0"]},
-    num_workers=4,
+    num_workers_per_node=2,
     # Set the stage spec for the executor you actually run with:
     ray_stage_spec={
         RayStageSpecKeys.RAY_NUM_CPUS: 1.0,
@@ -293,7 +305,7 @@ Both specs are shown together here only to document the arguments. In practice y
 ```python
 # Xenna equivalent
 configured_stage = stage.with_(
-    num_workers=4,
+    num_workers_per_node=2,
     xenna_stage_spec={
         "worker_max_lifetime_m": 45,
     },
@@ -304,10 +316,10 @@ Setting both is harmless — each executor reads only its own spec — but it is
 
 `ray_stage_spec` and `xenna_stage_spec` are shallow-merged: user-provided top-level keys win, while nested dictionaries are replaced rather than recursively merged. An explicit `None` inside a stage-spec dictionary is retained. In contrast, passing the whole `ray_stage_spec=None` or `xenna_stage_spec=None` means no override.
 
-`num_workers` uses an unset sentinel internally, so omission and explicit `None` differ:
+`num_workers` and `num_workers_per_node` use unset sentinels internally, so omission and explicit `None` differ:
 
-- Omitting `num_workers` preserves the stage's current method result.
-- `with_(num_workers=None)` resets an inherited fixed count to executor-controlled behavior.
+- Omitting either argument preserves that method's current result.
+- Passing `None` explicitly resets that method to executor-controlled behavior.
 
 See [Stage Worker Sizing](/reference/infra/stage-worker-sizing) for merge examples, precedence rules, and invalid combinations. See [Per-Stage Runtime Environments](/reference/infra/per-stage-runtime) for dependency isolation.
 

--- a/fern/versions/main/pages/api-reference/processing-stage.mdx
+++ b/fern/versions/main/pages/api-reference/processing-stage.mdx
@@ -166,7 +166,7 @@ def num_workers_per_node(self) -> float | None:
     return None
 ```
 
-The executor converts the value to a cluster-wide request. Ray Data uses `ceil(num_workers_per_node × alive node count)` and best-effort `SPREAD` placement, Xenna forwards the per-node value directly, and Ray Actor Pool applies the same multiplier before capping the result to available resource capacity. Fractional values are supported; values must be positive.
+The executor converts the value to a cluster-wide request. Ray Data and Ray Actor Pool use `ceil(num_workers_per_node × alive node count)` with best-effort `SPREAD` placement; Ray Actor Pool also caps the result to available resource capacity. Xenna forwards the per-node value directly. Fractional values are supported; values must be positive.
 
 Like `num_workers`, `num_workers_per_node` is reserved as a method. Override it for a class-level default, or use `stage.with_(num_workers_per_node=...)` for one pipeline instance. Do not combine it with `num_workers()` or Ray Data's `min_workers`, `max_workers`, or `initial_workers` actor-pool keys.
 

--- a/fern/versions/main/pages/reference/infrastructure/execution-backends.mdx
+++ b/fern/versions/main/pages/reference/infrastructure/execution-backends.mdx
@@ -67,19 +67,19 @@ executor = XennaExecutor(
         # Execution mode: 'streaming' (default) or 'batch'
         # Batch processes all data for a stage before moving to the next; streaming runs stages concurrently.
         "execution_mode": "streaming",
-        
+
         # Logging interval: seconds between status logs (default: 60)
         # Controls how frequently progress updates are printed
         "logging_interval": 60,
-        
+
         # Ignore failures: whether to continue on failures (default: False)
         # When True, the pipeline continues execution instead of failing fast when stages raise errors.
         "ignore_failures": False,
-        
+
         # CPU allocation percentage: ratio of CPU to allocate (0-1, default: 0.95)
         # Fraction of available CPU resources to use for pipeline execution
         "cpu_allocation_percentage": 0.95,
-        
+
         # Autoscale interval: seconds between auto-scaling checks (default: 180)
         # How often to run the stage auto-scaler.
         "autoscale_interval_s": 180,
@@ -99,7 +99,7 @@ results = pipeline.run(executor)
 | `cpu_allocation_percentage` | `float` | `0.95` | Fraction (0-1) of available CPU resources to allocate |
 | `autoscale_interval_s` | `int` | `180` | Seconds between auto-scaling evaluations |
 
-Set a cluster-wide stage count with `stage.with_(num_workers=N)`, or set `xenna_stage_spec={"num_workers_per_node": N}` for a per-node count. These settings are mutually exclusive. See [Stage Worker Sizing](/reference/infra/stage-worker-sizing#xenna-worker-counts) and the [`XennaExecutor` API](/api/reference/api-reference/executors/xenna-executor).
+Set a cluster-wide stage count with `stage.with_(num_workers=N)`, or a per-node count with `stage.with_(num_workers_per_node=N)`. These settings are mutually exclusive. The legacy Xenna-only `xenna_stage_spec={"num_workers_per_node": N}` form remains supported. See [Stage Worker Sizing](/reference/infra/stage-worker-sizing#xenna-worker-counts) and the [`XennaExecutor` API](/api/reference/api-reference/executors/xenna-executor).
 
 For more details about the underlying engine, refer to the official [NVIDIA Cosmos-Xenna project](https://github.com/nvidia-cosmos/cosmos-xenna/tree/main).
 
@@ -135,7 +135,7 @@ results = pipeline.run(executor)
 | `show_progress` | `bool` | `True` | Display tqdm progress bars during stage execution and shuffle inserts |
 | `progress_interval` | `float` | `10.0` | Minimum interval in seconds between progress bar updates |
 
-A positive stage `num_workers()` requests an exact actor count when resources fit. If fewer actors fit, this executor warns and caps the request to available CPU/GPU capacity. See [Stage Worker Sizing](/reference/infra/stage-worker-sizing#ray-actor-pool-resource-capping).
+A positive stage `num_workers()` requests an exact actor count. `num_workers_per_node()` requests that count per alive node. If fewer actors fit, this executor warns and caps the request to available CPU/GPU capacity. See [Stage Worker Sizing](/reference/infra/stage-worker-sizing#ray-actor-pool-resource-capping).
 
 <Accordion title="Example: Fuzzy Deduplication">
 
@@ -190,7 +190,7 @@ results = pipeline.run(executor)
 |-----|------|---------|-------------|
 | `ignore_failures` | `bool` | `False` | If `True`, continue pipeline execution even when tasks fail |
 
-Ray Data uses `ActorPoolStrategy` for actor stages and `TaskPoolStrategy` for task stages. Configure a fixed pool with `stage.with_(num_workers=N)`, or configure actor autoscaling with `min_workers`, `max_workers`, and `initial_workers` in `ray_stage_spec`. See [Stage Worker Sizing](/reference/infra/stage-worker-sizing#ray-data-worker-pools) for copy-pasteable examples and precedence rules.
+Ray Data uses `ActorPoolStrategy` for actor stages and `TaskPoolStrategy` for task stages. Configure a fixed cluster-wide pool with `stage.with_(num_workers=N)`, a fixed per-node pool with `stage.with_(num_workers_per_node=N)`, or actor autoscaling with `min_workers`, `max_workers`, and `initial_workers` in `ray_stage_spec`. Per-node sizing uses a cluster-wide pool plus best-effort `SPREAD` placement; it is not a hard node-affinity constraint. See [Stage Worker Sizing](/reference/infra/stage-worker-sizing#ray-data-worker-pools) for copy-pasteable examples and conflict rules.
 
 Ray Data may fuse adjacent operators when their compute and resource requirements are compatible. Matching resources enables the optimization but does not guarantee it; Ray Data makes the final optimizer decision. The [resource matching and fusion reference](/reference/infra/stage-worker-sizing#resource-matching-and-ray-data-fusion) explains the video-stage CPU reservation behavior.
 
@@ -207,7 +207,7 @@ For worker counts, resources, and backend-specific `with_()` overrides, see [Sta
 Ray-based executors provide enhanced scalability and performance for large-scale data processing tasks. These executors are beneficial for:
 
 - **Large-scale classification tasks**: Distributed inference across multi-GPU setups
-- **Deduplication workflows**: Parallel processing of document similarity computations  
+- **Deduplication workflows**: Parallel processing of document similarity computations
 - **Resource-intensive stages**: Automatic scaling based on computational demands
 
 ## Choosing a Backend

--- a/fern/versions/main/pages/reference/infrastructure/execution-backends.mdx
+++ b/fern/versions/main/pages/reference/infrastructure/execution-backends.mdx
@@ -172,7 +172,7 @@ from nemo_curator.backends.ray_data import RayDataExecutor
 
 executor = RayDataExecutor(
     config={"ignore_failures": False},
-    ignore_head_node=True,  # Exclude head node from computation
+    ignore_head_node=True,  # Exclude head from setup and per-node sizing
 )
 results = pipeline.run(executor)
 ```
@@ -182,7 +182,7 @@ results = pipeline.run(executor)
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
 | `config` | `dict` | `{}` | Configuration dictionary for Ray Data execution (see config keys below) |
-| `ignore_head_node` | `bool` | `False` | Exclude the Ray cluster's head node from execution |
+| `ignore_head_node` | `bool` | `False` | Exclude the head from setup and per-node sizing; worker placement remains best-effort |
 
 **Config Dictionary Keys** (passed via `config={...}`):
 

--- a/fern/versions/main/pages/reference/infrastructure/execution-backends.mdx
+++ b/fern/versions/main/pages/reference/infrastructure/execution-backends.mdx
@@ -135,7 +135,7 @@ results = pipeline.run(executor)
 | `show_progress` | `bool` | `True` | Display tqdm progress bars during stage execution and shuffle inserts |
 | `progress_interval` | `float` | `10.0` | Minimum interval in seconds between progress bar updates |
 
-A positive stage `num_workers()` requests an exact actor count. `num_workers_per_node()` requests that count per alive node. If fewer actors fit, this executor warns and caps the request to available CPU/GPU capacity. See [Stage Worker Sizing](/reference/infra/stage-worker-sizing#ray-actor-pool-resource-capping).
+A positive stage `num_workers()` requests an exact actor count. `num_workers_per_node()` requests that count per alive node with best-effort `SPREAD` placement. If fewer actors fit, this executor warns and caps the request to available CPU/GPU capacity. See [Stage Worker Sizing](/reference/infra/stage-worker-sizing#ray-actor-pool-resource-capping).
 
 <Accordion title="Example: Fuzzy Deduplication">
 

--- a/fern/versions/main/pages/reference/infrastructure/execution-backends.mdx
+++ b/fern/versions/main/pages/reference/infrastructure/execution-backends.mdx
@@ -120,7 +120,6 @@ from nemo_curator.backends.ray_actor_pool import RayActorPoolExecutor
 executor = RayActorPoolExecutor(
     show_progress=True,       # Display tqdm progress bars (default: True)
     progress_interval=10.0,   # Minimum seconds between progress bar updates (default: 10.0)
-    ignore_head_node=True,
 )
 
 results = pipeline.run(executor)
@@ -131,9 +130,11 @@ results = pipeline.run(executor)
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
 | `config` | `dict \| None` | `None` | Executor-specific configuration dictionary |
-| `ignore_head_node` | `bool` | `False` | Exclude head node from task scheduling |
+| `ignore_head_node` | `bool` | `False` | Exclude the head from setup and resource sizing; placement remains best-effort |
 | `show_progress` | `bool` | `True` | Display tqdm progress bars during stage execution and shuffle inserts |
 | `progress_interval` | `float` | `10.0` | Minimum interval in seconds between progress bar updates |
+
+For either Ray executor, leave `ignore_head_node=False` on a single-node cluster. Set it only for environments such as Anyscale where the head cannot run workloads; excluding the only node leaves no nodes for per-node sizing.
 
 A positive stage `num_workers()` requests an exact actor count. `num_workers_per_node()` requests that count per alive node with best-effort `SPREAD` placement. If fewer actors fit, this executor warns and caps the request to available CPU/GPU capacity. See [Stage Worker Sizing](/reference/infra/stage-worker-sizing#ray-actor-pool-resource-capping).
 
@@ -172,7 +173,6 @@ from nemo_curator.backends.ray_data import RayDataExecutor
 
 executor = RayDataExecutor(
     config={"ignore_failures": False},
-    ignore_head_node=True,  # Exclude head from setup and per-node sizing
 )
 results = pipeline.run(executor)
 ```

--- a/fern/versions/main/pages/reference/infrastructure/execution-backends.mdx
+++ b/fern/versions/main/pages/reference/infrastructure/execution-backends.mdx
@@ -190,7 +190,7 @@ results = pipeline.run(executor)
 |-----|------|---------|-------------|
 | `ignore_failures` | `bool` | `False` | If `True`, continue pipeline execution even when tasks fail |
 
-Ray Data uses `ActorPoolStrategy` for actor stages and `TaskPoolStrategy` for task stages. Configure a fixed cluster-wide pool with `stage.with_(num_workers=N)`, a fixed per-node pool with `stage.with_(num_workers_per_node=N)`, or actor autoscaling with `min_workers`, `max_workers`, and `initial_workers` in `ray_stage_spec`. Per-node sizing uses a cluster-wide pool plus best-effort `SPREAD` placement; it is not a hard node-affinity constraint. See [Stage Worker Sizing](/reference/infra/stage-worker-sizing#ray-data-worker-pools) for copy-pasteable examples and conflict rules.
+Ray Data uses `ActorPoolStrategy` for actor stages and `TaskPoolStrategy` for task stages. Configure fixed actor pools or task concurrency caps with `stage.with_(num_workers=N)` or `stage.with_(num_workers_per_node=N)`. Configure actor autoscaling with `min_workers`, `max_workers`, and `initial_workers` in `ray_stage_spec`. Per-node sizing uses a cluster-wide count plus best-effort `SPREAD` placement; it is not a hard node-affinity constraint. See [Stage Worker Sizing](/reference/infra/stage-worker-sizing#ray-data-worker-pools) for copy-pasteable examples and conflict rules.
 
 Ray Data may fuse adjacent operators when their compute and resource requirements are compatible. Matching resources enables the optimization but does not guarantee it; Ray Data makes the final optimizer decision. The [resource matching and fusion reference](/reference/infra/stage-worker-sizing#resource-matching-and-ray-data-fusion) explains the video-stage CPU reservation behavior.
 

--- a/fern/versions/main/pages/reference/infrastructure/stage-worker-sizing.mdx
+++ b/fern/versions/main/pages/reference/infrastructure/stage-worker-sizing.mdx
@@ -10,11 +10,12 @@ modality: "universal"
 
 # Stage Worker Sizing
 
-Use `ProcessingStage.num_workers()` or `stage.with_(num_workers=...)` to set a backend-neutral worker request. Use `ray_stage_spec` and `xenna_stage_spec` for backend-specific execution behavior.
+Use `ProcessingStage.num_workers()` or `num_workers_per_node()` to set a backend-neutral worker request. The corresponding `stage.with_(...)` arguments configure one stage instance. Use `ray_stage_spec` and `xenna_stage_spec` for backend-specific execution behavior.
 
 Worker count and per-worker resources are separate controls:
 
 - `num_workers()` controls how many workers the executor requests.
+- `num_workers_per_node()` scales a worker request by the alive Ray node count.
 - `Resources` controls CPU and GPU resources reserved for each worker.
 - `ray_stage_spec()` and `xenna_stage_spec()` provide backend-specific scheduling options.
 
@@ -42,14 +43,16 @@ class PassthroughStage(ProcessingStage[EmptyTask, EmptyTask]):
 
 ## Worker Controls by Backend
 
-| Backend | `num_workers=N`, where `N > 0` | `num_workers=None` | Backend-specific alternative |
+| Backend | `num_workers=N`, where `N > 0` | `num_workers_per_node=N`, where `N > 0` | Neither set |
 | --- | --- | --- | --- |
-| Ray Data actor stage | Fixed `ActorPoolStrategy(size=N)` | Autoscaling actor pool, minimum 1 with no maximum by default | `min_workers`, `max_workers`, and `initial_workers` |
-| Ray Data task stage | Fixed `TaskPoolStrategy(size=N)` | Ray Data's default task scheduling; no explicit compute strategy | None; actor-pool sizing keys are ignored |
-| Xenna | Exactly `N` workers across the cluster | Xenna determines worker allocation | `num_workers_per_node` in `xenna_stage_spec` |
-| Ray Actor Pool | Requests `N`; warns and caps it if fewer actors fit available resources | Chooses the smaller of work batches and resource capacity | None |
+| Ray Data actor stage | Fixed `ActorPoolStrategy(size=N)` | Fixed pool sized as `ceil(N × alive nodes)` with best-effort `SPREAD` | Autoscaling actor pool, minimum 1 with no maximum by default |
+| Ray Data task stage | Fixed `TaskPoolStrategy(size=N)` | Fixed pool sized as `ceil(N × alive nodes)` with best-effort `SPREAD` | Ray Data's default task scheduling; no explicit compute strategy |
+| Xenna | Exactly `N` workers across the cluster | Xenna receives `N` directly as its per-node count | Xenna determines worker allocation |
+| Ray Actor Pool | Requests `N`; caps it if fewer actors fit | Requests `ceil(N × alive nodes)`; caps it if fewer actors fit | Chooses the smaller of work batches and resource capacity |
 
-Ray Data and Ray Actor Pool also treat `0` and negative values as no fixed-size request. Xenna passes every non-`None` value to its stage specification, so use a positive count or `None`; do not use zero or negative Xenna worker counts.
+For the cluster-wide `num_workers` hook, Ray Data and Ray Actor Pool treat `0` and negative values as no fixed-size request. Xenna passes every non-`None` value to its stage specification, so use a positive count or `None`.
+
+The common `num_workers_per_node` hook accepts positive integers or fractions. Curator rejects booleans, non-numeric values, zero, and negative values. It cannot be combined with `num_workers` or Ray Data's `min_workers`, `max_workers`, and `initial_workers` keys.
 
 ## Ray Data Worker Pools
 
@@ -132,12 +135,25 @@ executor = RayDataExecutor()
 
 Without a positive `num_workers`, a task stage does not set `compute`; Ray Data uses its default task scheduler.
 
+### Fixed pool per node
+
+Use the same portable override for actor or task stages:
+
+```python
+stage = PassthroughStage().with_(num_workers_per_node=2)
+executor = RayDataExecutor(ignore_head_node=True)
+```
+
+Ray Data pool sizes are cluster-wide, so Curator counts alive nodes and sets the pool size to `ceil(num_workers_per_node × node count)`. When `ignore_head_node=True`, the head does not contribute to that multiplier. Curator also sets `scheduling_strategy="SPREAD"` unless `RAY_REMOTE_ARGS` supplies another strategy.
+
+`SPREAD` is placement intent, not a hard per-node cap or node exclusion. Ray may place workers unevenly when resources differ or placement constraints apply, and `ignore_head_node=True` does not itself prevent a Ray Data worker from landing on the head.
+
 ### Ray Data precedence and errors
 
 | Configuration | Result |
 | --- | --- |
 | Actor stage with positive `num_workers` only | Fixed actor pool |
-| Actor stage with positive `num_workers` plus min/max/initial keys | Fixed actor pool wins; Curator logs a warning listing ignored sizing keys |
+| More than one of `num_workers`, `num_workers_per_node`, or min/max/initial keys | Raises `ValueError` when the stage is constructed or configured |
 | Actor stage without positive `num_workers`, no sizing keys | Autoscaling actor pool with `min_size=1`, `max_size=None`, and `initial_size=None` |
 | Task stage with positive `num_workers` | Fixed task pool |
 | Task stage with min/max/initial keys | Keys are ignored; Curator logs a warning because they apply only to actor stages |
@@ -164,16 +180,14 @@ executor = XennaExecutor()
 </Tab>
 <Tab title="Per node">
 
-Leave `num_workers()` unset and pass `num_workers_per_node` through the Xenna stage spec:
+Leave `num_workers()` unset and use the portable per-node override:
 
 ```python
 from nemo_curator.backends.xenna import XennaExecutor
 
 stage = PassthroughStage().with_(
     num_workers=None,
-    xenna_stage_spec={
-        "num_workers_per_node": 2,
-    },
+    num_workers_per_node=2,
 )
 executor = XennaExecutor()
 ```
@@ -188,12 +202,13 @@ The following combinations are invalid:
 | `with_(xenna_stage_spec={"num_workers": 4})` | Raises `ValueError`; use `with_(num_workers=4)` |
 | A stage's `xenna_stage_spec()` returns `{"num_workers": 4}` | `XennaExecutor` raises `ValueError`; override `num_workers()` instead |
 | Any non-`None` `num_workers()` result and `num_workers_per_node` | `XennaExecutor` raises `ValueError`; choose one scope |
+| Both `num_workers_per_node()` and the legacy Xenna spec key | `XennaExecutor` raises `ValueError`; choose the portable hook or legacy key |
 
-When neither setting is present, Xenna controls worker allocation using stage resources and pipeline demand.
+The legacy `xenna_stage_spec={"num_workers_per_node": N}` form remains supported for compatibility. When neither setting is present, Xenna controls worker allocation using stage resources and pipeline demand.
 
 ## Ray Actor Pool Resource Capping
 
-`RayActorPoolExecutor` calculates how many actors fit from available CPU and GPU resources. A positive `num_workers()` is honored when it fits. If it exceeds capacity, Curator warns and caps the actor count instead of waiting for impossible placements.
+`RayActorPoolExecutor` calculates how many actors fit from available CPU and GPU resources. A positive `num_workers()` is honored when it fits. `num_workers_per_node()` first multiplies the value by the alive node count. If either request exceeds capacity, Curator warns and caps the actor count instead of waiting for impossible placements.
 
 For example, a stage that requests `Resources(cpus=2.0)` and `num_workers=8` can place at most four actors when eight CPUs are available. Work batch count can further reduce the automatically chosen pool size when `num_workers` is unset.
 
@@ -223,7 +238,7 @@ configured = PassthroughStage().with_(
 )
 ```
 
-The original stage remains unchanged. `resources`, `batch_size`, `runtime_env`, and `num_workers` apply across supported executors. `ray_stage_spec` configures Ray Data and the Ray-specific flags used by Ray Actor Pool; `xenna_stage_spec` configures Xenna.
+The original stage remains unchanged. `resources`, `batch_size`, `runtime_env`, `num_workers`, and `num_workers_per_node` apply across supported executors. `ray_stage_spec` configures Ray Data and the Ray-specific flags used by Ray Actor Pool; `xenna_stage_spec` configures Xenna.
 
 ### Shallow-merge behavior
 
@@ -260,6 +275,8 @@ produces a spec where `max_workers` is explicitly `None` and `ray_remote_args` c
 | --- | --- |
 | Omit `num_workers` | Preserve the stage's current `num_workers()` result |
 | `with_(num_workers=None)` | Explicitly reset worker sizing to executor-controlled behavior |
+| Omit `num_workers_per_node` | Preserve the stage's current `num_workers_per_node()` result |
+| `with_(num_workers_per_node=None)` | Explicitly reset per-node sizing to executor-controlled behavior |
 | Omit `ray_stage_spec` or pass `ray_stage_spec=None` | Do not modify the current Ray spec |
 | `ray_stage_spec={RayStageSpecKeys.MAX_WORKERS: None}` | Preserve the key with an explicit `None`, clearing an inherited maximum |
 | Omit `xenna_stage_spec` or pass `xenna_stage_spec=None` | Do not modify the current Xenna spec |
@@ -269,9 +286,9 @@ produces a spec where `max_workers` is explicitly `None` and `ray_remote_args` c
 
 Chained `with_()` calls merge against the already configured copy, so later values win while unrelated top-level keys from earlier calls remain.
 
-## Reserved `num_workers` Hook
+## Reserved Worker-Sizing Hooks
 
-`num_workers` is reserved as a method on `ProcessingStage`. Do not define it as a dataclass field or ordinary stage attribute:
+`num_workers` and `num_workers_per_node` are reserved as methods on `ProcessingStage`. Do not define either as a dataclass field or ordinary stage attribute:
 
 ```python
 class FixedStage(PassthroughStage):

--- a/fern/versions/main/pages/reference/infrastructure/stage-worker-sizing.mdx
+++ b/fern/versions/main/pages/reference/infrastructure/stage-worker-sizing.mdx
@@ -46,7 +46,7 @@ class PassthroughStage(ProcessingStage[EmptyTask, EmptyTask]):
 | Backend | `num_workers=N`, where `N > 0` | `num_workers_per_node=N`, where `N > 0` | Neither set |
 | --- | --- | --- | --- |
 | Ray Data actor stage | Fixed `ActorPoolStrategy(size=N)` | Fixed pool sized as `ceil(N × alive nodes)` with best-effort `SPREAD` | Autoscaling actor pool, minimum 1 with no maximum by default |
-| Ray Data task stage | Fixed `TaskPoolStrategy(size=N)` | Fixed pool sized as `ceil(N × alive nodes)` with best-effort `SPREAD` | Ray Data's default task scheduling; no explicit compute strategy |
+| Ray Data task stage | Concurrency capped by `TaskPoolStrategy(size=N)` | Concurrency capped at `ceil(N × alive nodes)` with best-effort `SPREAD` | Ray Data's default task scheduling; no explicit compute strategy |
 | Xenna | Exactly `N` workers across the cluster | Xenna receives `N` directly as its per-node count | Xenna determines worker allocation |
 | Ray Actor Pool | Requests `N`; caps it if fewer actors fit | Requests `ceil(N × alive nodes)` with best-effort `SPREAD`; caps it if fewer actors fit | Chooses the smaller of work batches and resource capacity |
 
@@ -135,7 +135,7 @@ executor = RayDataExecutor()
 
 Without a positive `num_workers`, a task stage does not set `compute`; Ray Data uses its default task scheduler.
 
-### Fixed pool per node
+### Pool sizing per node
 
 Use the same portable override for actor or task stages:
 

--- a/fern/versions/main/pages/reference/infrastructure/stage-worker-sizing.mdx
+++ b/fern/versions/main/pages/reference/infrastructure/stage-worker-sizing.mdx
@@ -48,7 +48,7 @@ class PassthroughStage(ProcessingStage[EmptyTask, EmptyTask]):
 | Ray Data actor stage | Fixed `ActorPoolStrategy(size=N)` | Fixed pool sized as `ceil(N × alive nodes)` with best-effort `SPREAD` | Autoscaling actor pool, minimum 1 with no maximum by default |
 | Ray Data task stage | Fixed `TaskPoolStrategy(size=N)` | Fixed pool sized as `ceil(N × alive nodes)` with best-effort `SPREAD` | Ray Data's default task scheduling; no explicit compute strategy |
 | Xenna | Exactly `N` workers across the cluster | Xenna receives `N` directly as its per-node count | Xenna determines worker allocation |
-| Ray Actor Pool | Requests `N`; caps it if fewer actors fit | Requests `ceil(N × alive nodes)`; caps it if fewer actors fit | Chooses the smaller of work batches and resource capacity |
+| Ray Actor Pool | Requests `N`; caps it if fewer actors fit | Requests `ceil(N × alive nodes)` with best-effort `SPREAD`; caps it if fewer actors fit | Chooses the smaller of work batches and resource capacity |
 
 For the cluster-wide `num_workers` hook, Ray Data and Ray Actor Pool treat `0` and negative values as no fixed-size request. Xenna passes every non-`None` value to its stage specification, so use a positive count or `None`.
 
@@ -141,12 +141,12 @@ Use the same portable override for actor or task stages:
 
 ```python
 stage = PassthroughStage().with_(num_workers_per_node=2)
-executor = RayDataExecutor(ignore_head_node=True)
+executor = RayDataExecutor()
 ```
 
-Ray Data pool sizes are cluster-wide, so Curator counts alive nodes and sets the pool size to `ceil(num_workers_per_node × node count)`. When `ignore_head_node=True`, the head does not contribute to that multiplier. Curator also sets `scheduling_strategy="SPREAD"` unless `RAY_REMOTE_ARGS` supplies another strategy.
+Ray Data pool sizes are cluster-wide, so Curator counts alive nodes and sets the pool size to `ceil(num_workers_per_node × node count)`. Curator also sets `scheduling_strategy="SPREAD"` unless `RAY_REMOTE_ARGS` supplies another strategy.
 
-`SPREAD` is placement intent, not a hard per-node cap or node exclusion. Ray may place workers unevenly when resources differ or placement constraints apply, and `ignore_head_node=True` does not itself prevent a Ray Data worker from landing on the head.
+`SPREAD` is placement intent, not a hard per-node cap. Ray may place workers unevenly when resources differ or placement constraints apply.
 
 ### Ray Data precedence and errors
 
@@ -208,7 +208,7 @@ The legacy `xenna_stage_spec={"num_workers_per_node": N}` form remains supported
 
 ## Ray Actor Pool Resource Capping
 
-`RayActorPoolExecutor` calculates how many actors fit from available CPU and GPU resources. A positive `num_workers()` is honored when it fits. `num_workers_per_node()` first multiplies the value by the alive node count. If either request exceeds capacity, Curator warns and caps the actor count instead of waiting for impossible placements.
+`RayActorPoolExecutor` calculates how many actors fit from available CPU and GPU resources. A positive `num_workers()` is honored when it fits. `num_workers_per_node()` first multiplies the value by the alive node count and uses best-effort `SPREAD` placement. If either request exceeds capacity, Curator warns and caps the actor count instead of waiting for impossible placements.
 
 For example, a stage that requests `Resources(cpus=2.0)` and `num_workers=8` can place at most four actors when eight CPUs are available. Work batch count can further reduce the automatically chosen pool size when `num_workers` is unset.
 

--- a/fern/versions/main/pages/reference/infrastructure/stage-worker-sizing.mdx
+++ b/fern/versions/main/pages/reference/infrastructure/stage-worker-sizing.mdx
@@ -144,7 +144,7 @@ stage = PassthroughStage().with_(num_workers_per_node=2)
 executor = RayDataExecutor()
 ```
 
-Ray Data pool sizes are cluster-wide, so Curator counts alive nodes and sets the pool size to `ceil(num_workers_per_node × node count)`. Curator also sets `scheduling_strategy="SPREAD"` unless `RAY_REMOTE_ARGS` supplies another strategy.
+Ray Data pool sizes are cluster-wide, so Curator counts alive nodes and sets the pool size to `ceil(num_workers_per_node × node count)`. For this per-node configuration, Curator sets `scheduling_strategy="SPREAD"` unless `RAY_REMOTE_ARGS` supplies another strategy.
 
 `SPREAD` is placement intent, not a hard per-node cap. Ray may place workers unevenly when resources differ or placement constraints apply.
 

--- a/nemo_curator/backends/ray_actor_pool/executor.py
+++ b/nemo_curator/backends/ray_actor_pool/executor.py
@@ -26,6 +26,7 @@ from nemo_curator.backends.base import BaseExecutor
 from nemo_curator.backends.utils import (
     RayStageSpecKeys,
     execute_setup_on_node,
+    get_stage_num_workers_per_node,
     register_loguru_serializer,
 )
 from nemo_curator.tasks import EmptyTask, Task
@@ -56,6 +57,16 @@ def _parse_runtime_env(runtime_env: dict) -> dict:
         )
     env_vars["RAY_EXPERIMENTAL_NOSET_CUDA_VISIBLE_DEVICES"] = ""
     return user_runtime_env
+
+
+def _get_actor_options(stage: "ProcessingStage") -> dict:
+    options = {
+        "num_cpus": stage.resources.cpus,
+        "num_gpus": stage.resources.gpus,
+    }
+    if get_stage_num_workers_per_node(stage) is not None:
+        options["scheduling_strategy"] = "SPREAD"
+    return options
 
 
 class RayActorPoolExecutor(BaseExecutor):
@@ -207,10 +218,7 @@ class RayActorPoolExecutor(BaseExecutor):
     def _create_actor_pool(self, stage: "ProcessingStage", num_actors: int) -> ActorPool:
         """Create an ActorPool for a specific stage."""
         actors = []
-        actor_options: dict = {
-            "num_cpus": stage.resources.cpus,
-            "num_gpus": stage.resources.gpus,
-        }
+        actor_options = _get_actor_options(stage)
         if stage.runtime_env:
             actor_options["runtime_env"] = stage.runtime_env
         for i in range(num_actors):
@@ -233,8 +241,7 @@ class RayActorPoolExecutor(BaseExecutor):
             actor = (
                 create_named_ray_actor_pool_stage_adapter(stage, RayActorPoolRAFTAdapter)
                 .options(
-                    num_cpus=stage.resources.cpus,
-                    num_gpus=stage.resources.gpus,
+                    **_get_actor_options(stage),
                     name=f"{stage.name}Actor-{actor_idx}",
                 )
                 .remote(
@@ -272,8 +279,7 @@ class RayActorPoolExecutor(BaseExecutor):
         actors = []
         for actor_idx in range(num_actors):
             actor = ShuffleStageAdapter.options(
-                num_cpus=stage.resources.cpus,
-                num_gpus=stage.resources.gpus,
+                **_get_actor_options(stage),
                 name=f"{stage.name}-Worker_{actor_idx}",
             ).remote(stage=stage, rank=actor_idx, nranks=num_actors, num_input_tasks=num_tasks)
             actors.append(actor)

--- a/nemo_curator/backends/ray_actor_pool/utils.py
+++ b/nemo_curator/backends/ray_actor_pool/utils.py
@@ -19,7 +19,11 @@ from typing import TYPE_CHECKING
 import ray
 from loguru import logger
 
-from nemo_curator.backends.utils import get_available_cpu_gpu_resources, get_stage_num_workers_per_node
+from nemo_curator.backends.utils import (
+    get_available_cpu_gpu_resources,
+    get_num_workers_for_nodes,
+    get_stage_num_workers_per_node,
+)
 from nemo_curator.utils.ray_utils import get_alive_ray_node_count
 
 if TYPE_CHECKING:
@@ -176,7 +180,7 @@ def calculate_optimal_actors_for_resources(
 
     if num_workers_per_node is not None:
         num_nodes = get_alive_ray_node_count(ignore_head_node=ignore_head_node)
-        requested_actors = max(1, math.ceil(num_workers_per_node * num_nodes))
+        requested_actors = get_num_workers_for_nodes(num_workers_per_node, num_nodes, stage.name)
         if requested_actors > max_actors_resources:
             msg = (
                 f"Stage {stage.name} requires {requested_actors} actors from num_workers_per_node(), "

--- a/nemo_curator/backends/ray_actor_pool/utils.py
+++ b/nemo_curator/backends/ray_actor_pool/utils.py
@@ -37,6 +37,10 @@ if TYPE_CHECKING:
 _LARGE_INT = 2**31 - 1
 
 
+class _NoResourcesAvailableError(ValueError):
+    pass
+
+
 def get_available_actor_pool_resources(
     reserved_cpus: float = 0.0,
     reserved_gpus: float = 0.0,
@@ -108,7 +112,7 @@ def calculate_optimal_actors_for_stage_with_wait(  # noqa: PLR0913
             resource_baseline,
             ignore_head_node=ignore_head_node,
         )
-    except ValueError:
+    except _NoResourcesAvailableError:
         intended_num_actors = 1
 
     required_cpus = intended_num_actors * stage.resources.cpus
@@ -163,7 +167,7 @@ def calculate_optimal_actors_for_resources(
 
     if max_actors_resources == 0:
         msg = f"No resources available for stage {stage.name}."
-        raise ValueError(msg)
+        raise _NoResourcesAvailableError(msg)
 
     num_workers = stage.num_workers()
     num_workers_per_node = get_stage_num_workers_per_node(stage)

--- a/nemo_curator/backends/ray_actor_pool/utils.py
+++ b/nemo_curator/backends/ray_actor_pool/utils.py
@@ -19,7 +19,8 @@ from typing import TYPE_CHECKING
 import ray
 from loguru import logger
 
-from nemo_curator.backends.utils import get_available_cpu_gpu_resources
+from nemo_curator.backends.utils import get_available_cpu_gpu_resources, get_stage_num_workers_per_node
+from nemo_curator.utils.ray_utils import get_alive_ray_node_count
 
 if TYPE_CHECKING:
     from ray.actor import ActorClass
@@ -153,6 +154,7 @@ def calculate_optimal_actors_for_resources(
         raise ValueError(msg)
 
     num_workers = stage.num_workers()
+    num_workers_per_node = get_stage_num_workers_per_node(stage)
     if num_workers is not None and num_workers > 0:
         if num_workers > max_actors_resources:
             msg = (
@@ -163,6 +165,19 @@ def calculate_optimal_actors_for_resources(
             logger.warning(msg)
             return max_actors_resources
         return num_workers
+
+    if num_workers_per_node is not None:
+        num_nodes = get_alive_ray_node_count(ignore_head_node=ignore_head_node)
+        requested_actors = max(1, math.ceil(num_workers_per_node * num_nodes))
+        if requested_actors > max_actors_resources:
+            msg = (
+                f"Stage {stage.name} requires {requested_actors} actors from num_workers_per_node(), "
+                f"but only {max_actors_resources} fit with available resources. "
+                f"Capping actor count to {max_actors_resources}."
+            )
+            logger.warning(msg)
+            return max_actors_resources
+        return requested_actors
 
     number_of_batches = (
         math.ceil(num_tasks / stage.batch_size) if stage.batch_size is not None and stage.batch_size > 0 else num_tasks

--- a/nemo_curator/backends/ray_actor_pool/utils.py
+++ b/nemo_curator/backends/ray_actor_pool/utils.py
@@ -73,7 +73,12 @@ def calculate_optimal_actors_for_stage(
     available_cpus = max(0, available_cpus - reserved_cpus)
     available_gpus = max(0, available_gpus - reserved_gpus)
 
-    return calculate_optimal_actors_for_resources(stage, num_tasks, (available_cpus, available_gpus))
+    return calculate_optimal_actors_for_resources(
+        stage,
+        num_tasks,
+        (available_cpus, available_gpus),
+        ignore_head_node=ignore_head_node,
+    )
 
 
 def calculate_optimal_actors_for_stage_with_wait(  # noqa: PLR0913
@@ -97,6 +102,7 @@ def calculate_optimal_actors_for_stage_with_wait(  # noqa: PLR0913
             stage,
             num_tasks,
             resource_baseline,
+            ignore_head_node=ignore_head_node,
         )
     except ValueError:
         intended_num_actors = 1
@@ -132,6 +138,8 @@ def calculate_optimal_actors_for_resources(
     stage: "ProcessingStage",
     num_tasks: int,
     available_resources: tuple[float, float],
+    *,
+    ignore_head_node: bool = False,
 ) -> int:
     """Calculate an actor count from a supplied CPU/GPU availability snapshot."""
     available_cpus, available_gpus = available_resources

--- a/nemo_curator/backends/ray_actor_pool/utils.py
+++ b/nemo_curator/backends/ray_actor_pool/utils.py
@@ -151,6 +151,12 @@ def calculate_optimal_actors_for_resources(
 ) -> int:
     """Calculate an actor count from a supplied CPU/GPU availability snapshot."""
     available_cpus, available_gpus = available_resources
+    num_workers = stage.num_workers()
+    num_workers_per_node = get_stage_num_workers_per_node(stage)
+    requested_actors = None
+    if num_workers_per_node is not None:
+        num_nodes = get_alive_ray_node_count(ignore_head_node=ignore_head_node)
+        requested_actors = get_num_workers_for_nodes(num_workers_per_node, num_nodes, stage.name)
 
     # Calculate max actors based on CPU constraints
     max_actors_cpu = int(available_cpus // stage.resources.cpus) if stage.resources.cpus > 0 else _LARGE_INT
@@ -169,8 +175,6 @@ def calculate_optimal_actors_for_resources(
         msg = f"No resources available for stage {stage.name}."
         raise _NoResourcesAvailableError(msg)
 
-    num_workers = stage.num_workers()
-    num_workers_per_node = get_stage_num_workers_per_node(stage)
     if num_workers is not None and num_workers > 0:
         if num_workers > max_actors_resources:
             msg = (
@@ -182,9 +186,7 @@ def calculate_optimal_actors_for_resources(
             return max_actors_resources
         return num_workers
 
-    if num_workers_per_node is not None:
-        num_nodes = get_alive_ray_node_count(ignore_head_node=ignore_head_node)
-        requested_actors = get_num_workers_for_nodes(num_workers_per_node, num_nodes, stage.name)
+    if requested_actors is not None:
         if requested_actors > max_actors_resources:
             msg = (
                 f"Stage {stage.name} requires {requested_actors} actors from num_workers_per_node(), "

--- a/nemo_curator/backends/ray_data/AGENTS.md
+++ b/nemo_curator/backends/ray_data/AGENTS.md
@@ -305,6 +305,7 @@ only when the Curator API has no equivalent, and set them before pipeline execut
 |---|---|---|
 | Change Task rows per stage call | `stage.with_(batch_size=N)` | Batch size counts Tasks, not records inside a Task |
 | Fixed worker pool | `stage.with_(num_workers=N)` | Fixed ActorPool or capped TaskPool, depending on stage type |
+| Fixed workers per node | `stage.with_(num_workers_per_node=N)` | Fixed cluster-wide pool of `ceil(N × alive nodes)` with best-effort `SPREAD` placement |
 | Autoscaling actor bounds | `stage.with_(ray_stage_spec={RayStageSpecKeys.MIN_WORKERS: N, RayStageSpecKeys.MAX_WORKERS: M})` | Maps to Ray `min_size` and `max_size` |
 | Actor startup size | `stage.with_(ray_stage_spec={RayStageSpecKeys.INITIAL_WORKERS: N})` | Startup target only; does not retain actors above `MIN_WORKERS` |
 | Force actor or task | `stage.with_(ray_stage_spec={RayStageSpecKeys.IS_ACTOR_STAGE: bool})` | Overrides adapter selection |

--- a/nemo_curator/backends/ray_data/adapter.py
+++ b/nemo_curator/backends/ray_data/adapter.py
@@ -13,15 +13,21 @@
 # limitations under the License.
 
 import copy
+import math
 from collections.abc import Callable
 from typing import Any
 
 from loguru import logger
-from ray.data import Dataset, TaskPoolStrategy
+from ray.data import ActorPoolStrategy, Dataset, TaskPoolStrategy
 
 from nemo_curator.backends.base import BaseStageAdapter
-from nemo_curator.backends.utils import RayStageSpecKeys, get_worker_metadata_and_node_id
+from nemo_curator.backends.utils import (
+    RayStageSpecKeys,
+    get_stage_num_workers_per_node,
+    get_worker_metadata_and_node_id,
+)
 from nemo_curator.stages.base import ProcessingStage
+from nemo_curator.utils.ray_utils import get_alive_ray_node_count
 
 from .utils import get_actor_compute_strategy_for_stage, get_configured_actor_pool_sizing_keys, is_actor_stage
 
@@ -39,8 +45,9 @@ class RayDataStageAdapter(BaseStageAdapter):
         c. Else we use tasks
     """
 
-    def __init__(self, stage: ProcessingStage):
+    def __init__(self, stage: ProcessingStage, ignore_head_node: bool = False):
         super().__init__(stage)
+        self.ignore_head_node = ignore_head_node
 
         self._batch_size = self.stage.batch_size
         if self._batch_size is None and self.stage.resources.gpus > 0:
@@ -90,6 +97,18 @@ class RayDataStageAdapter(BaseStageAdapter):
             kwargs["num_gpus"] = self.stage.resources.gpus  # type: ignore[reportArgumentType]
         return kwargs
 
+    def _total_pool_size(self) -> int | None:
+        """Return the cluster-wide pool size implied by num_workers_per_node()."""
+        num_workers_per_node = get_stage_num_workers_per_node(self.stage)
+        if num_workers_per_node is None:
+            return None
+
+        node_count = get_alive_ray_node_count(ignore_head_node=self.ignore_head_node)
+        if node_count <= 0:
+            msg = f"No alive Ray nodes available for num_workers_per_node sizing on stage {self.stage.name}."
+            raise ValueError(msg)
+        return max(1, math.ceil(num_workers_per_node * node_count))
+
     def process_dataset(self, dataset: Dataset) -> Dataset:
         """Process a Ray Data dataset through this stage.
 
@@ -101,10 +120,16 @@ class RayDataStageAdapter(BaseStageAdapter):
         """
         ray_stage_spec = self.stage.ray_stage_spec()
         stage_is_actor = ray_stage_spec.get(RayStageSpecKeys.IS_ACTOR_STAGE, is_actor_stage(self.stage))
+        total_pool_size = self._total_pool_size()
 
         if stage_is_actor:
             map_batches_fn = create_actor_from_stage(self.stage)
-            map_batches_kwargs = {"compute": get_actor_compute_strategy_for_stage(self.stage)}
+            compute = (
+                ActorPoolStrategy(size=total_pool_size)
+                if total_pool_size is not None
+                else get_actor_compute_strategy_for_stage(self.stage)
+            )
+            map_batches_kwargs = {"compute": compute}
         else:
             map_batches_fn = create_task_from_stage(self.stage)
             map_batches_kwargs = {}
@@ -117,8 +142,9 @@ class RayDataStageAdapter(BaseStageAdapter):
                 )
 
             num_workers = self.stage.num_workers()
-            if num_workers is not None and num_workers > 0:
-                map_batches_kwargs["compute"] = TaskPoolStrategy(size=num_workers)
+            pool_size = total_pool_size if total_pool_size is not None else num_workers
+            if pool_size is not None and pool_size > 0:
+                map_batches_kwargs["compute"] = TaskPoolStrategy(size=pool_size)
 
             max_calls = ray_stage_spec.get(RayStageSpecKeys.MAX_CALLS_PER_WORKER)
             if max_calls is not None:
@@ -140,6 +166,9 @@ class RayDataStageAdapter(BaseStageAdapter):
                 f"Curator-managed map_batches arguments {colliding_ray_remote_args}."
             )
             raise ValueError(msg)
+
+        if total_pool_size is not None:
+            map_batches_kwargs["scheduling_strategy"] = "SPREAD"
 
         map_batches_kwargs.update(ray_remote_args)
 

--- a/nemo_curator/backends/ray_data/adapter.py
+++ b/nemo_curator/backends/ray_data/adapter.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import copy
-import math
 from collections.abc import Callable
 from typing import Any
 
@@ -23,6 +22,7 @@ from ray.data import ActorPoolStrategy, Dataset, TaskPoolStrategy
 from nemo_curator.backends.base import BaseStageAdapter
 from nemo_curator.backends.utils import (
     RayStageSpecKeys,
+    get_num_workers_for_nodes,
     get_stage_num_workers_per_node,
     get_worker_metadata_and_node_id,
 )
@@ -107,7 +107,7 @@ class RayDataStageAdapter(BaseStageAdapter):
         if node_count <= 0:
             msg = f"No alive Ray nodes available for num_workers_per_node sizing on stage {self.stage.name}."
             raise ValueError(msg)
-        return max(1, math.ceil(num_workers_per_node * node_count))
+        return get_num_workers_for_nodes(num_workers_per_node, node_count, self.stage.name)
 
     def process_dataset(self, dataset: Dataset) -> Dataset:
         """Process a Ray Data dataset through this stage.

--- a/nemo_curator/backends/ray_data/adapter.py
+++ b/nemo_curator/backends/ray_data/adapter.py
@@ -22,6 +22,7 @@ from ray.data import ActorPoolStrategy, Dataset, TaskPoolStrategy
 from nemo_curator.backends.base import BaseStageAdapter
 from nemo_curator.backends.utils import (
     RayStageSpecKeys,
+    get_configured_actor_pool_sizing_keys,
     get_num_workers_for_nodes,
     get_stage_num_workers_per_node,
     get_worker_metadata_and_node_id,
@@ -29,7 +30,7 @@ from nemo_curator.backends.utils import (
 from nemo_curator.stages.base import ProcessingStage
 from nemo_curator.utils.ray_utils import get_alive_ray_node_count
 
-from .utils import get_actor_compute_strategy_for_stage, get_configured_actor_pool_sizing_keys, is_actor_stage
+from .utils import get_actor_compute_strategy_for_stage, is_actor_stage
 
 CURATOR_MANAGED_MAP_BATCHES_KWARGS = {"compute", "max_calls", "num_cpus", "num_gpus"}
 

--- a/nemo_curator/backends/ray_data/executor.py
+++ b/nemo_curator/backends/ray_data/executor.py
@@ -100,7 +100,7 @@ class RayDataExecutor(BaseExecutor):
                 logger.info(f"  CPU cores: {stage.resources.cpus}, GPU ratio: {stage.resources.gpus}")
 
                 # Create adapter for this stage
-                adapter = RayDataStageAdapter(stage)
+                adapter = RayDataStageAdapter(stage, ignore_head_node=self.ignore_head_node)
 
                 # Apply stage transformation
                 current_dataset = adapter.process_dataset(current_dataset)

--- a/nemo_curator/backends/ray_data/executor.py
+++ b/nemo_curator/backends/ray_data/executor.py
@@ -45,9 +45,9 @@ class RayDataExecutor(BaseExecutor):
         Args:
             config (dict[str, Any], optional): Configuration dictionary.
             ignore_head_node (bool, optional): Whether to skip the Ray head node for
-                ``setup_on_node``. Ray Data controls ``map_batches`` task/actor placement
-                through Ray's scheduler; this flag does not cap actor-pool size or force
-                Ray Data workers away from the head node.
+                ``setup_on_node`` and per-node worker-count calculations. Ray Data controls
+                ``map_batches`` placement, so this flag does not force workers away from
+                the head node.
         """
         super().__init__(config, ignore_head_node)
 

--- a/nemo_curator/backends/ray_data/utils.py
+++ b/nemo_curator/backends/ray_data/utils.py
@@ -14,7 +14,6 @@
 
 from collections.abc import Mapping
 
-from loguru import logger
 from ray.data import ActorPoolStrategy
 
 from nemo_curator.backends.utils import RayStageSpecKeys
@@ -42,12 +41,6 @@ def get_actor_compute_strategy_for_stage(stage: ProcessingStage) -> ActorPoolStr
     """
     num_workers = stage.num_workers()
     if num_workers is not None and num_workers > 0:
-        actor_pool_sizing_keys = get_configured_actor_pool_sizing_keys(stage.ray_stage_spec())
-        if actor_pool_sizing_keys:
-            logger.warning(
-                f"Stage {stage.name} uses num_workers={num_workers}; ignoring ray_stage_spec "
-                f"actor-pool sizing keys {actor_pool_sizing_keys}."
-            )
         return ActorPoolStrategy(size=num_workers)
 
     ray_stage_spec = stage.ray_stage_spec()

--- a/nemo_curator/backends/ray_data/utils.py
+++ b/nemo_curator/backends/ray_data/utils.py
@@ -12,24 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from collections.abc import Mapping
-
 from ray.data import ActorPoolStrategy
 
 from nemo_curator.backends.utils import RayStageSpecKeys
 from nemo_curator.stages.base import ProcessingStage
-
-ACTOR_POOL_SIZING_KEYS = (
-    RayStageSpecKeys.MIN_WORKERS,
-    RayStageSpecKeys.MAX_WORKERS,
-    RayStageSpecKeys.INITIAL_WORKERS,
-)
-
-
-def get_configured_actor_pool_sizing_keys(ray_stage_spec: Mapping[str, object]) -> list[str]:
-    """Return actor-pool sizing keys configured in a ray stage spec."""
-    stage_spec_keys = {key.value if isinstance(key, RayStageSpecKeys) else key for key in ray_stage_spec}
-    return [key.value for key in ACTOR_POOL_SIZING_KEYS if key.value in stage_spec_keys]
 
 
 def get_actor_compute_strategy_for_stage(stage: ProcessingStage) -> ActorPoolStrategy:

--- a/nemo_curator/backends/utils.py
+++ b/nemo_curator/backends/utils.py
@@ -23,7 +23,7 @@ from loguru import logger
 
 from nemo_curator.backends.base import NodeInfo, WorkerMetadata
 from nemo_curator.stages.base import ProcessingStage
-from nemo_curator.utils.ray_utils import get_head_node_id, submit_on_each_node
+from nemo_curator.utils.ray_utils import get_alive_ray_nodes, get_head_node_id, submit_on_each_node
 
 if TYPE_CHECKING:
     import loguru
@@ -137,6 +137,20 @@ class RayStageSpecKeys(str, Enum):
     RAY_NUM_CPUS = "ray_num_cpus"
 
 
+def get_stage_num_workers_per_node(stage: ProcessingStage) -> int | float | None:
+    """Return a stage's validated per-node worker request."""
+    value = stage.num_workers_per_node()
+    if value is None:
+        return None
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        msg = f"num_workers_per_node() for stage {stage.name} must be a positive number."
+        raise TypeError(msg)
+    if value <= 0:
+        msg = f"num_workers_per_node() for stage {stage.name} must be > 0."
+        raise ValueError(msg)
+    return value
+
+
 def get_worker_metadata_and_node_id() -> tuple[NodeInfo, WorkerMetadata]:
     """Get the worker metadata and node id from the runtime context."""
     ray_context = ray.get_runtime_context()
@@ -212,13 +226,8 @@ def execute_setup_on_node(stages: list[ProcessingStage], ignore_head_node: bool 
     the sum of per-stage times — important when setup is heavy (model downloads, weight
     loads) and stages don't contend for the same resources.
     """
-    head_node_id = get_head_node_id() if ignore_head_node else None
-    for node in ray.nodes():
-        if not node.get("Alive"):
-            continue
+    for node in get_alive_ray_nodes(ignore_head_node=ignore_head_node):
         node_id = node["NodeID"]
-        if ignore_head_node and node_id == head_node_id:
-            continue
         logger.info(f"Executing setup on node {node_id} for {len(stages)} stages")
 
     refs: list = []

--- a/nemo_curator/backends/utils.py
+++ b/nemo_curator/backends/utils.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import math
 import os
 import time
 from copy import deepcopy
@@ -145,8 +146,8 @@ def get_stage_num_workers_per_node(stage: ProcessingStage) -> int | float | None
     if isinstance(value, bool) or not isinstance(value, (int, float)):
         msg = f"num_workers_per_node() for stage {stage.name} must be a positive number."
         raise TypeError(msg)
-    if value <= 0:
-        msg = f"num_workers_per_node() for stage {stage.name} must be > 0."
+    if value <= 0 or (isinstance(value, float) and not math.isfinite(value)):
+        msg = f"num_workers_per_node() for stage {stage.name} must be finite and > 0."
         raise ValueError(msg)
     return value
 

--- a/nemo_curator/backends/utils.py
+++ b/nemo_curator/backends/utils.py
@@ -138,18 +138,22 @@ class RayStageSpecKeys(str, Enum):
     RAY_NUM_CPUS = "ray_num_cpus"
 
 
-def get_stage_num_workers_per_node(stage: ProcessingStage) -> int | float | None:
-    """Return a stage's validated per-node worker request."""
-    value = stage.num_workers_per_node()
+def validate_num_workers_per_node(value: object, stage_name: str) -> int | float | None:
+    """Validate a per-node worker request."""
     if value is None:
         return None
     if isinstance(value, bool) or not isinstance(value, (int, float)):
-        msg = f"num_workers_per_node() for stage {stage.name} must be a positive number."
+        msg = f"num_workers_per_node for stage {stage_name} must be a positive number."
         raise TypeError(msg)
     if value <= 0 or (isinstance(value, float) and not math.isfinite(value)):
-        msg = f"num_workers_per_node() for stage {stage.name} must be finite and > 0."
+        msg = f"num_workers_per_node for stage {stage_name} must be finite and > 0."
         raise ValueError(msg)
     return value
+
+
+def get_stage_num_workers_per_node(stage: ProcessingStage) -> int | float | None:
+    """Return a stage's validated per-node worker request."""
+    return validate_num_workers_per_node(stage.num_workers_per_node(), stage.name)
 
 
 def get_worker_metadata_and_node_id() -> tuple[NodeInfo, WorkerMetadata]:

--- a/nemo_curator/backends/utils.py
+++ b/nemo_curator/backends/utils.py
@@ -156,6 +156,15 @@ def get_stage_num_workers_per_node(stage: ProcessingStage) -> int | float | None
     return validate_num_workers_per_node(stage.num_workers_per_node(), stage.name)
 
 
+def get_num_workers_for_nodes(num_workers_per_node: float, node_count: int, stage_name: str) -> int:
+    """Convert a per-node request to a finite cluster-wide worker count."""
+    total = num_workers_per_node * node_count
+    if isinstance(total, float) and not math.isfinite(total):
+        msg = f"num_workers_per_node for stage {stage_name} is too large for {node_count} nodes."
+        raise ValueError(msg)
+    return max(1, math.ceil(total))
+
+
 def get_worker_metadata_and_node_id() -> tuple[NodeInfo, WorkerMetadata]:
     """Get the worker metadata and node id from the runtime context."""
     ray_context = ray.get_runtime_context()

--- a/nemo_curator/backends/utils.py
+++ b/nemo_curator/backends/utils.py
@@ -15,6 +15,7 @@
 import math
 import os
 import time
+from collections.abc import Mapping
 from copy import deepcopy
 from enum import Enum
 from typing import TYPE_CHECKING
@@ -136,6 +137,19 @@ class RayStageSpecKeys(str, Enum):
     INITIAL_WORKERS = "initial_workers"
     RAY_REMOTE_ARGS = "ray_remote_args"
     RAY_NUM_CPUS = "ray_num_cpus"
+
+
+ACTOR_POOL_SIZING_KEYS = (
+    RayStageSpecKeys.MIN_WORKERS,
+    RayStageSpecKeys.MAX_WORKERS,
+    RayStageSpecKeys.INITIAL_WORKERS,
+)
+
+
+def get_configured_actor_pool_sizing_keys(ray_stage_spec: Mapping[str, object]) -> list[str]:
+    """Return actor-pool sizing keys configured in a Ray stage spec."""
+    stage_spec_keys = {key.value if isinstance(key, RayStageSpecKeys) else key for key in ray_stage_spec}
+    return [key.value for key in ACTOR_POOL_SIZING_KEYS if key.value in stage_spec_keys]
 
 
 def validate_num_workers_per_node(value: object, stage_name: str) -> int | float | None:

--- a/nemo_curator/backends/xenna/executor.py
+++ b/nemo_curator/backends/xenna/executor.py
@@ -20,7 +20,7 @@ from cosmos_xenna.utils.verbosity import VerbosityLevel
 from loguru import logger
 
 from nemo_curator.backends.base import BaseExecutor
-from nemo_curator.backends.utils import register_loguru_serializer
+from nemo_curator.backends.utils import get_stage_num_workers_per_node, register_loguru_serializer
 from nemo_curator.backends.xenna.adapter import create_named_xenna_stage_adapter
 from nemo_curator.stages.base import ProcessingStage
 from nemo_curator.tasks import EmptyTask, Task
@@ -83,11 +83,20 @@ class XennaExecutor(BaseExecutor):
                 raise ValueError(msg)
 
             num_workers = stage.num_workers()
-            num_workers_per_node = stage_config.get("num_workers_per_node")
+            num_workers_per_node = get_stage_num_workers_per_node(stage)
+            legacy_num_workers_per_node = stage_config.get("num_workers_per_node")
+            if num_workers_per_node is not None and legacy_num_workers_per_node is not None:
+                msg = (
+                    f"Stage {stage.name} sets both num_workers_per_node() and "
+                    "xenna_stage_spec()['num_workers_per_node']. Use only one worker sizing option."
+                )
+                raise ValueError(msg)
+            if num_workers_per_node is None:
+                num_workers_per_node = legacy_num_workers_per_node
             if num_workers is not None and num_workers_per_node is not None:
                 msg = (
-                    f"Stage {stage.name} sets both num_workers() and "
-                    "xenna_stage_spec()['num_workers_per_node']. Use only one worker sizing option."
+                    f"Stage {stage.name} sets both num_workers() and num_workers_per_node. "
+                    "Use only one worker sizing option."
                 )
                 raise ValueError(msg)
 

--- a/nemo_curator/backends/xenna/executor.py
+++ b/nemo_curator/backends/xenna/executor.py
@@ -20,7 +20,11 @@ from cosmos_xenna.utils.verbosity import VerbosityLevel
 from loguru import logger
 
 from nemo_curator.backends.base import BaseExecutor
-from nemo_curator.backends.utils import get_stage_num_workers_per_node, register_loguru_serializer
+from nemo_curator.backends.utils import (
+    get_stage_num_workers_per_node,
+    register_loguru_serializer,
+    validate_num_workers_per_node,
+)
 from nemo_curator.backends.xenna.adapter import create_named_xenna_stage_adapter
 from nemo_curator.stages.base import ProcessingStage
 from nemo_curator.tasks import EmptyTask, Task
@@ -84,7 +88,9 @@ class XennaExecutor(BaseExecutor):
 
             num_workers = stage.num_workers()
             num_workers_per_node = get_stage_num_workers_per_node(stage)
-            legacy_num_workers_per_node = stage_config.get("num_workers_per_node")
+            legacy_num_workers_per_node = validate_num_workers_per_node(
+                stage_config.get("num_workers_per_node"), stage.name
+            )
             if num_workers_per_node is not None and legacy_num_workers_per_node is not None:
                 msg = (
                     f"Stage {stage.name} sets both num_workers_per_node() and "

--- a/nemo_curator/stages/base.py
+++ b/nemo_curator/stages/base.py
@@ -74,6 +74,15 @@ def _num_workers_method(num_workers: int | None) -> Callable[[], int | None]:
     return get_num_workers
 
 
+def _num_workers_per_node_method(
+    num_workers_per_node: float | None,
+) -> Callable[[], float | None]:
+    def get_num_workers_per_node() -> float | None:
+        return num_workers_per_node
+
+    return get_num_workers_per_node
+
+
 class StageMeta(ABCMeta):
     """Metaclass that automatically registers concrete Stage subclasses.
     A class is considered *concrete* if it directly inherits from
@@ -96,6 +105,12 @@ class StageMeta(ABCMeta):
             _STAGE_REGISTRY[cls.__name__] = cls  # type: ignore[assignment]
 
         return cls
+
+    def __call__(cls, *args, **kwargs):
+        """Validate worker sizing after the stage is fully constructed."""
+        instance = super().__call__(*args, **kwargs)
+        instance._validate_worker_sizing()
+        return instance
 
 
 def get_stage_class(name: str) -> type[ProcessingStage]:
@@ -165,16 +180,17 @@ class ProcessingStage(ABC, Generic[X, Y], metaclass=StageMeta):
                 msg = f"{cls.__name__} must not override '{attr}'"
                 raise TypeError(msg)
 
-        num_workers = cls.__dict__.get("num_workers")
-        if (num_workers is not None and not callable(num_workers)) or (
-            num_workers is None and "num_workers" in cls.__dict__.get("__annotations__", {})
-        ):
-            msg = (
-                f"{cls.__name__} must not define 'num_workers' as a stage attribute. "
-                "Override num_workers() for backend worker sizing, or use a different field name "
-                "for stage-specific worker counts."
-            )
-            raise TypeError(msg)
+        for worker_attr in ("num_workers", "num_workers_per_node"):
+            value = cls.__dict__.get(worker_attr)
+            if (value is not None and not callable(value)) or (
+                value is None and worker_attr in cls.__dict__.get("__annotations__", {})
+            ):
+                msg = (
+                    f"{cls.__name__} must not define '{worker_attr}' as a stage attribute. "
+                    f"Override {worker_attr}() for backend worker sizing, or use a different field name "
+                    "for stage-specific worker counts."
+                )
+                raise TypeError(msg)
 
         for attr in ("name", "resources", "batch_size", "runtime_env"):
             if isinstance(cls.__dict__.get(attr), property):
@@ -188,6 +204,33 @@ class ProcessingStage(ABC, Generic[X, Y], metaclass=StageMeta):
     def num_workers(self) -> int | None:
         """Number of workers required. If None, then executor will determine the number of workers."""
         return None
+
+    def num_workers_per_node(self) -> float | None:
+        """Number of workers required per Ray node. If None, executor default sizing is used."""
+        return None
+
+    def _validate_worker_sizing(self) -> None:
+        """Reject ambiguous combinations of backend worker-sizing options."""
+        configured = [
+            name
+            for name, value in (
+                ("num_workers()", self.num_workers()),
+                ("num_workers_per_node()", self.num_workers_per_node()),
+            )
+            if value is not None
+        ]
+
+        from nemo_curator.backends.ray_data.utils import get_configured_actor_pool_sizing_keys
+
+        if get_configured_actor_pool_sizing_keys(self.ray_stage_spec()):
+            configured.append("actor-pool sizing keys (min/max/initial_workers)")
+
+        if len(configured) > 1:
+            msg = (
+                f"Stage {self.name} sets multiple worker-sizing options ({', '.join(configured)}); "
+                "use only one of num_workers, num_workers_per_node, or actor-pool sizing keys."
+            )
+            raise ValueError(msg)
 
     def validate_input(self, task: Task) -> bool:
         """Validate input task meets requirements.
@@ -235,10 +278,7 @@ class ProcessingStage(ABC, Generic[X, Y], metaclass=StageMeta):
         if isinstance(input_specs, tuple):
             return self._validate_input_spec(input_specs, "inputs()")
         if not isinstance(input_specs, dict):
-            msg = (
-                f"Stage {self.name} inputs() must return an input spec tuple "
-                "or dict of task type to input spec"
-            )
+            msg = f"Stage {self.name} inputs() must return an input spec tuple or dict of task type to input spec"
             raise TypeError(msg)
 
         # Search the task's MRO from most to least specific. For example, given
@@ -246,9 +286,7 @@ class ProcessingStage(ABC, Generic[X, Y], metaclass=StageMeta):
         # for CustomDocumentBatch first, then DocumentBatch, and finally Task.
         for candidate_type in type(task).mro():
             if candidate_type in input_specs:
-                return self._validate_input_spec(
-                    input_specs[candidate_type], f"inputs()[{candidate_type.__name__}]"
-                )
+                return self._validate_input_spec(input_specs[candidate_type], f"inputs()[{candidate_type.__name__}]")
 
         supported_task_types = ", ".join(supported_type.__name__ for supported_type in input_specs) or "<none>"
         msg = (
@@ -383,6 +421,7 @@ class ProcessingStage(ABC, Generic[X, Y], metaclass=StageMeta):
         ray_stage_spec: dict[str, Any] | None = None,
         xenna_stage_spec: dict[str, Any] | None = None,
         num_workers: int | None | _UnsetType = _UNSET,
+        num_workers_per_node: float | None | _UnsetType = _UNSET,
     ) -> ProcessingStage:
         """Apply configuration changes to this stage with overridden properties.
 
@@ -397,6 +436,8 @@ class ProcessingStage(ABC, Generic[X, Y], metaclass=StageMeta):
             xenna_stage_spec: Merge overrides into the Xenna stage spec. User-provided keys win.
                 Use num_workers instead of setting num_workers in xenna_stage_spec.
             num_workers: Override the num_workers() result. Passing None explicitly resets to executor default behavior.
+            num_workers_per_node: Override the num_workers_per_node() result. Passing None explicitly resets to
+                executor default behavior.
         """
         new_instance = copy.deepcopy(self)
 
@@ -432,6 +473,12 @@ class ProcessingStage(ABC, Generic[X, Y], metaclass=StageMeta):
 
         if num_workers is not _UNSET:
             new_instance.num_workers = _num_workers_method(cast("int | None", num_workers))
+        if num_workers_per_node is not _UNSET:
+            new_instance.num_workers_per_node = _num_workers_per_node_method(
+                cast("float | None", num_workers_per_node)
+            )
+
+        new_instance._validate_worker_sizing()
 
         return new_instance
 

--- a/nemo_curator/stages/base.py
+++ b/nemo_curator/stages/base.py
@@ -211,16 +211,19 @@ class ProcessingStage(ABC, Generic[X, Y], metaclass=StageMeta):
 
     def _validate_worker_sizing(self) -> None:
         """Reject ambiguous combinations of backend worker-sizing options."""
+        from nemo_curator.backends.utils import (
+            get_configured_actor_pool_sizing_keys,
+            get_stage_num_workers_per_node,
+        )
+
         configured = [
             name
             for name, value in (
                 ("num_workers()", self.num_workers()),
-                ("num_workers_per_node()", self.num_workers_per_node()),
+                ("num_workers_per_node()", get_stage_num_workers_per_node(self)),
             )
             if value is not None
         ]
-
-        from nemo_curator.backends.ray_data.utils import get_configured_actor_pool_sizing_keys
 
         if get_configured_actor_pool_sizing_keys(self.ray_stage_spec()):
             configured.append("actor-pool sizing keys (min/max/initial_workers)")

--- a/nemo_curator/stages/image/deduplication/removal.py
+++ b/nemo_curator/stages/image/deduplication/removal.py
@@ -14,7 +14,6 @@
 
 import os
 from dataclasses import dataclass, field
-from typing import Any
 
 import pyarrow as pa
 import pyarrow.dataset as ds
@@ -36,16 +35,14 @@ class ImageDuplicatesRemovalStage(ProcessingStage[ImageBatch, ImageBatch]):
         removal_parquets_dir: Directory containing Parquet files with image IDs to remove
         duplicate_id_field: Name of the column containing image IDs to remove
         verbose: Whether to log verbose output
-        num_workers_per_node: Number of workers per node for the stage. This is sometimes needed
-            to avoid OOM when concurrently running actors on one node loading the same removal
-            parquet files into memory.
+
+    To cap concurrent actors per node (for example, to avoid OOM when each actor loads
+    the same removal Parquet files), configure ``.with_(num_workers_per_node=...)``.
     """
 
     removal_parquets_dir: str
     duplicate_id_field: str = "id"
     verbose: bool = False
-    num_workers_per_node: int | None = None
-
     name: str = "image_dedup_filter"
 
     # Internal cache
@@ -96,9 +93,3 @@ class ImageDuplicatesRemovalStage(ProcessingStage[ImageBatch, ImageBatch]):
             _metadata=task._metadata,
             _stage_perf=task._stage_perf,
         )
-
-    def xenna_stage_spec(self) -> dict[str, Any]:
-        spec: dict[str, Any] = {}
-        if self.num_workers_per_node is not None:
-            spec["num_workers_per_node"] = self.num_workers_per_node
-        return spec

--- a/nemo_curator/stages/image/deduplication/removal.py
+++ b/nemo_curator/stages/image/deduplication/removal.py
@@ -36,8 +36,9 @@ class ImageDuplicatesRemovalStage(ProcessingStage[ImageBatch, ImageBatch]):
         duplicate_id_field: Name of the column containing image IDs to remove
         verbose: Whether to log verbose output
 
-    To cap concurrent actors per node (for example, to avoid OOM when each actor loads
-    the same removal Parquet files), configure ``.with_(num_workers_per_node=...)``.
+    To size the worker pool from the cluster's node count, configure
+    ``.with_(num_workers_per_node=...)``. Ray placement is best-effort, not a hard
+    per-node cap.
     """
 
     removal_parquets_dir: str

--- a/nemo_curator/stages/text/download/arxiv/download.py
+++ b/nemo_curator/stages/text/download/arxiv/download.py
@@ -30,6 +30,9 @@ class ArxivDownloader(DocumentDownloader):
             msg = "s5cmd is not installed. Please install it from https://github.com/peak/s5cmd"
             raise RuntimeError(msg)
 
+    def num_workers_per_node(self) -> int:
+        return 2
+
     def _get_output_filename(self, url: str) -> str:
         # Use tarfile name as output filename
         return url

--- a/nemo_curator/stages/text/download/base/download.py
+++ b/nemo_curator/stages/text/download/base/download.py
@@ -15,7 +15,6 @@
 import os
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import Any
 
 from loguru import logger
 
@@ -159,7 +158,5 @@ class DocumentDownloadStage(ProcessingStage[FileGroupTask, FileGroupTask]):
             _stage_perf=task._stage_perf,
         )
 
-    def xenna_stage_spec(self) -> dict[str, Any]:
-        return {
-            "num_workers_per_node": self.downloader.num_workers_per_node(),
-        }
+    def num_workers_per_node(self) -> float | None:
+        return self.downloader.num_workers_per_node()

--- a/nemo_curator/stages/text/download/common_crawl/download.py
+++ b/nemo_curator/stages/text/download/common_crawl/download.py
@@ -59,6 +59,9 @@ class CommonCrawlWARCDownloader(DocumentDownloader):
             msg = "s5cmd is not installed. Please install it from https://github.com/peak/s5cmd"
             raise RuntimeError(msg)
 
+    def num_workers_per_node(self) -> int:
+        return 2
+
     def _get_output_filename(self, url: str) -> str:
         """Generate output filename from URL."""
         return urlparse(url).path[1:].replace("/", "-")

--- a/nemo_curator/utils/ray_utils.py
+++ b/nemo_curator/utils/ray_utils.py
@@ -19,7 +19,6 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any
 
 import ray
-from loguru import logger
 from ray.util.scheduling_strategies import NodeAffinitySchedulingStrategy
 
 if TYPE_CHECKING:
@@ -52,6 +51,19 @@ def get_head_node_id() -> str | None:
     return None
 
 
+def get_alive_ray_nodes(ignore_head_node: bool = False) -> list[dict[str, Any]]:
+    """Return alive Ray nodes, optionally excluding the cluster head."""
+    head_node_id = get_head_node_id() if ignore_head_node else None
+    return [
+        node for node in ray.nodes() if node.get("Alive") and (not ignore_head_node or node["NodeID"] != head_node_id)
+    ]
+
+
+def get_alive_ray_node_count(ignore_head_node: bool = False) -> int:
+    """Return the number of alive Ray nodes available for per-node work."""
+    return len(get_alive_ray_nodes(ignore_head_node=ignore_head_node))
+
+
 def submit_on_each_node(
     remote_fn: RemoteFunction,
     *args,
@@ -67,15 +79,9 @@ def submit_on_each_node(
     for awaiting the returned refs (typically via ``ray.get``); use this when batching
     multiple fan-outs into a single await preserves parallelism.
     """
-    head_node_id = get_head_node_id() if ignore_head_node else None
     refs = []
-    for node in ray.nodes():
-        if not node.get("Alive"):
-            continue
+    for node in get_alive_ray_nodes(ignore_head_node=ignore_head_node):
         node_id = node["NodeID"]
-        if ignore_head_node and node_id == head_node_id:
-            logger.info(f"Skipping head node {node_id}")
-            continue
         refs.append(
             remote_fn.options(
                 num_cpus=num_cpus,

--- a/tests/backends/ray_actor_pool/test_executor.py
+++ b/tests/backends/ray_actor_pool/test_executor.py
@@ -156,6 +156,20 @@ class TestRayActorPoolExecutor:
         ):
             calculate_optimal_actors_for_stage_with_wait(stage, 4, (4.0, 4.0), timeout=0.5, interval=0.1)
 
+    def test_wait_for_stage_resources_propagates_invalid_worker_count(self) -> None:
+        stage = _stage_with_worker_sizing(
+            num_workers=None,
+            num_workers_per_node=1e308,
+            cpus=1.0,
+            batch_size=1,
+        )
+
+        with (
+            mock.patch("nemo_curator.backends.ray_actor_pool.utils.get_alive_ray_node_count", return_value=2),
+            pytest.raises(ValueError, match="too large"),
+        ):
+            calculate_optimal_actors_for_stage_with_wait(stage, 1, (4.0, 0.0))
+
     def test_actor_pool_resources_apply_reservations_and_update_baseline(self) -> None:
         with mock.patch(
             "nemo_curator.backends.ray_actor_pool.utils.get_available_cpu_gpu_resources",

--- a/tests/backends/ray_actor_pool/test_executor.py
+++ b/tests/backends/ray_actor_pool/test_executor.py
@@ -168,7 +168,7 @@ class TestRayActorPoolExecutor:
             mock.patch("nemo_curator.backends.ray_actor_pool.utils.get_alive_ray_node_count", return_value=2),
             pytest.raises(ValueError, match="too large"),
         ):
-            calculate_optimal_actors_for_stage_with_wait(stage, 1, (4.0, 0.0))
+            calculate_optimal_actors_for_stage_with_wait(stage, 1, (0.0, 0.0))
 
     def test_actor_pool_resources_apply_reservations_and_update_baseline(self) -> None:
         with mock.patch(

--- a/tests/backends/ray_actor_pool/test_executor.py
+++ b/tests/backends/ray_actor_pool/test_executor.py
@@ -51,7 +51,7 @@ class TestRayActorPoolExecutor:
     def test_calculate_optimal_actors_respects_explicit_num_workers(
         self, available_cpus: float, expected_actors: int, expected_warning: str | None
     ) -> None:
-        stage = _stage_with_num_workers(num_workers=4, cpus=1.0, batch_size=10)
+        stage = _stage_with_worker_sizing(num_workers=4, num_workers_per_node=None, cpus=1.0, batch_size=10)
 
         with (
             mock.patch(
@@ -69,7 +69,7 @@ class TestRayActorPoolExecutor:
             assert expected_warning in mock_warning.call_args.args[0]
 
     def test_wait_for_stage_resources_polls_cpu_and_gpu(self) -> None:
-        stage = _stage_with_num_workers(num_workers=4, cpus=1.0, batch_size=1)
+        stage = _stage_with_worker_sizing(num_workers=4, num_workers_per_node=None, cpus=1.0, batch_size=1)
         stage.resources.gpus = 1.0
 
         with (
@@ -84,7 +84,7 @@ class TestRayActorPoolExecutor:
         mock_sleep.assert_has_calls([mock.call(0.2), mock.call(0.2)])
 
     def test_wait_for_stage_resources_does_not_sleep_past_timeout(self) -> None:
-        stage = _stage_with_num_workers(num_workers=4, cpus=1.0, batch_size=1)
+        stage = _stage_with_worker_sizing(num_workers=4, num_workers_per_node=None, cpus=1.0, batch_size=1)
 
         with (
             mock.patch(
@@ -103,7 +103,7 @@ class TestRayActorPoolExecutor:
         mock_sleep.assert_called_once_with(5.0)
 
     def test_wait_for_stage_resources_raises_when_only_partial_pool_fits_at_timeout(self) -> None:
-        stage = _stage_with_num_workers(num_workers=4, cpus=1.0, batch_size=1)
+        stage = _stage_with_worker_sizing(num_workers=4, num_workers_per_node=None, cpus=1.0, batch_size=1)
         stage.resources.gpus = 1.0
 
         with (
@@ -122,7 +122,7 @@ class TestRayActorPoolExecutor:
             calculate_optimal_actors_for_stage_with_wait(stage, 4, (4.0, 4.0), timeout=0, interval=1)
 
     def test_wait_for_stage_resources_raises_when_no_actor_fits_at_timeout(self) -> None:
-        stage = _stage_with_num_workers(num_workers=4, cpus=1.0, batch_size=1)
+        stage = _stage_with_worker_sizing(num_workers=4, num_workers_per_node=None, cpus=1.0, batch_size=1)
         stage.resources.gpus = 1.0
 
         with (
@@ -191,11 +191,45 @@ class TestRayActorPoolExecutor:
             ),
         ]
 
+    @pytest.mark.parametrize(
+        ("available_cpus", "expected_actors", "expected_warning"),
+        [
+            (8.0, 6, None),
+            (4.0, 4, "requires 6 actors from num_workers_per_node()"),
+        ],
+    )
+    def test_calculate_optimal_actors_respects_num_workers_per_node(
+        self, available_cpus: float, expected_actors: int, expected_warning: str | None
+    ) -> None:
+        stage = _stage_with_worker_sizing(num_workers=None, num_workers_per_node=2, cpus=1.0, batch_size=10)
 
-def _stage_with_num_workers(*, num_workers: int, cpus: float, batch_size: int) -> mock.Mock:
+        with (
+            mock.patch(
+                "nemo_curator.backends.ray_actor_pool.utils.get_available_cpu_gpu_resources",
+                return_value=(available_cpus, 0.0),
+            ),
+            mock.patch(
+                "nemo_curator.backends.ray_actor_pool.utils.get_alive_ray_node_count", return_value=3
+            ) as mock_node_count,
+            mock.patch("nemo_curator.backends.ray_actor_pool.utils.logger.warning") as mock_warning,
+        ):
+            assert calculate_optimal_actors_for_stage(stage, num_tasks=1, ignore_head_node=True) == expected_actors
+
+        mock_node_count.assert_called_once_with(ignore_head_node=True)
+        if expected_warning is None:
+            mock_warning.assert_not_called()
+        else:
+            mock_warning.assert_called_once()
+            assert expected_warning in mock_warning.call_args.args[0]
+
+
+def _stage_with_worker_sizing(
+    *, num_workers: int | None, num_workers_per_node: float | None, cpus: float, batch_size: int
+) -> mock.Mock:
     stage = mock.Mock()
     stage.name = "stage"
     stage.resources = Resources(cpus=cpus, gpus=0.0)
     stage.batch_size = batch_size
     stage.num_workers.return_value = num_workers
+    stage.num_workers_per_node.return_value = num_workers_per_node
     return stage

--- a/tests/backends/ray_actor_pool/test_executor.py
+++ b/tests/backends/ray_actor_pool/test_executor.py
@@ -16,7 +16,7 @@ from unittest import mock
 
 import pytest
 
-from nemo_curator.backends.ray_actor_pool.executor import RayActorPoolExecutor, _parse_runtime_env
+from nemo_curator.backends.ray_actor_pool.executor import RayActorPoolExecutor, _get_actor_options, _parse_runtime_env
 from nemo_curator.backends.ray_actor_pool.utils import (
     calculate_optimal_actors_for_stage,
     calculate_optimal_actors_for_stage_with_wait,
@@ -39,6 +39,28 @@ class TestRayActorPoolExecutor:
         assert _parse_runtime_env(without_env_var) == {
             "env_vars": {"RAY_EXPERIMENTAL_NOSET_CUDA_VISIBLE_DEVICES": ""},
             "some_other_key": "some_other_value",
+        }
+
+    @pytest.mark.parametrize(
+        ("num_workers_per_node", "expected_strategy"),
+        [(None, None), (2, "SPREAD")],
+    )
+    def test_actor_options_spread_per_node_workers(
+        self, num_workers_per_node: float | None, expected_strategy: str | None
+    ) -> None:
+        stage = _stage_with_worker_sizing(
+            num_workers=None,
+            num_workers_per_node=num_workers_per_node,
+            cpus=2.0,
+            batch_size=1,
+        )
+
+        options = _get_actor_options(stage)
+
+        assert options == {
+            "num_cpus": 2.0,
+            "num_gpus": 0.0,
+            **({"scheduling_strategy": expected_strategy} if expected_strategy else {}),
         }
 
     @pytest.mark.parametrize(

--- a/tests/backends/ray_data/test_adapter.py
+++ b/tests/backends/ray_data/test_adapter.py
@@ -44,9 +44,15 @@ class ConfigurableActorStage(ProcessingStage[EmptyTask, EmptyTask]):
     resources = Resources(cpus=2.0)
     batch_size = 7
 
-    def __init__(self, ray_stage_spec: dict[str, object] | None = None, num_workers: int | None = None):
+    def __init__(
+        self,
+        ray_stage_spec: dict[str, object] | None = None,
+        num_workers: int | None = None,
+        num_workers_per_node: float | None = None,
+    ):
         self._ray_stage_spec = ray_stage_spec or {}
         self._num_workers = num_workers
+        self._num_workers_per_node = num_workers_per_node
 
     def ray_stage_spec(self) -> dict[str, object]:
         return {
@@ -56,6 +62,9 @@ class ConfigurableActorStage(ProcessingStage[EmptyTask, EmptyTask]):
 
     def num_workers(self) -> int | None:
         return self._num_workers
+
+    def num_workers_per_node(self) -> float | None:
+        return self._num_workers_per_node
 
     def process(self, task: EmptyTask) -> EmptyTask:
         return task
@@ -91,22 +100,80 @@ class TestRayDataStageAdapter:
             assert "concurrency" not in kwargs
 
     def test_task_stage_uses_task_pool_strategy_for_num_workers(self):
+        task_kwargs = _map_batches_kwargs(ConfigurableTaskStage(num_workers=3))
+
+        assert task_kwargs["compute"] == TaskPoolStrategy(size=3)
+
+    def test_task_stage_warns_on_actor_pool_sizing_keys(self):
         stage = ConfigurableTaskStage(
             ray_stage_spec={
                 RayStageSpecKeys.MIN_WORKERS: 2,
                 RayStageSpecKeys.MAX_WORKERS: 8,
                 RayStageSpecKeys.INITIAL_WORKERS: 4,
             },
-            num_workers=3,
         )
 
         with mock.patch("nemo_curator.backends.ray_data.adapter.logger.warning") as mock_warning:
             task_kwargs = _map_batches_kwargs(stage)
 
-        assert task_kwargs["compute"] == TaskPoolStrategy(size=3)
-        assert mock_warning.call_count == 1
-        warning_messages = [call.args[0] for call in mock_warning.call_args_list]
-        assert "Ignoring ray_stage_spec worker sizing keys" in warning_messages[0]
+        assert "compute" not in task_kwargs
+        mock_warning.assert_called_once()
+        assert "Ignoring ray_stage_spec worker sizing keys" in mock_warning.call_args.args[0]
+
+    @pytest.mark.parametrize(
+        ("stage", "expected"),
+        [
+            (ConfigurableTaskStage(num_workers_per_node=2), TaskPoolStrategy(size=6)),
+            (ConfigurableActorStage(num_workers_per_node=2), ActorPoolStrategy(size=6)),
+        ],
+    )
+    def test_num_workers_per_node_sizes_and_spreads_pool(self, stage: ProcessingStage, expected: object):
+        with mock.patch("nemo_curator.backends.ray_data.adapter.get_alive_ray_node_count", return_value=3):
+            kwargs = _map_batches_kwargs(stage)
+
+        assert kwargs["compute"] == expected
+        assert kwargs["scheduling_strategy"] == "SPREAD"
+
+    def test_num_workers_per_node_passes_ignore_head_node_to_node_count(self):
+        stage = ConfigurableTaskStage(num_workers_per_node=2)
+
+        with mock.patch(
+            "nemo_curator.backends.ray_data.adapter.get_alive_ray_node_count", return_value=2
+        ) as mock_count:
+            kwargs = _map_batches_kwargs(stage, ignore_head_node=True)
+
+        mock_count.assert_called_once_with(ignore_head_node=True)
+        assert kwargs["compute"] == TaskPoolStrategy(size=4)
+
+    def test_num_workers_per_node_preserves_scheduling_strategy_override(self):
+        stage = ConfigurableTaskStage(
+            ray_stage_spec={RayStageSpecKeys.RAY_REMOTE_ARGS: {"scheduling_strategy": "DEFAULT"}},
+            num_workers_per_node=2,
+        )
+
+        with mock.patch("nemo_curator.backends.ray_data.adapter.get_alive_ray_node_count", return_value=3):
+            kwargs = _map_batches_kwargs(stage)
+
+        assert kwargs["scheduling_strategy"] == "DEFAULT"
+
+    def test_num_workers_per_node_rejects_no_alive_nodes(self):
+        stage = ConfigurableTaskStage(num_workers_per_node=2)
+
+        with (
+            mock.patch("nemo_curator.backends.ray_data.adapter.get_alive_ray_node_count", return_value=0),
+            pytest.raises(ValueError, match="No alive Ray nodes"),
+        ):
+            _map_batches_kwargs(stage)
+
+    @pytest.mark.parametrize(
+        ("value", "error"),
+        [(0, ValueError), (-1, ValueError), (True, TypeError), ("2", TypeError)],
+    )
+    def test_num_workers_per_node_rejects_invalid_values(self, value: object, error: type[Exception]):
+        stage = ConfigurableTaskStage(num_workers_per_node=value)  # type: ignore[arg-type]
+
+        with pytest.raises(error, match="num_workers_per_node"):
+            _map_batches_kwargs(stage)
 
     def test_source_fanout_task_stage_uses_task_pool_strategy_for_single_worker_default(self):
         stage = ConfigurableTaskStage(
@@ -141,9 +208,9 @@ class TestRayDataStageAdapter:
         assert kwargs["num_cpus"] == stage.resources.cpus
 
 
-def _map_batches_kwargs(stage: ProcessingStage) -> dict[str, object]:
+def _map_batches_kwargs(stage: ProcessingStage, ignore_head_node: bool = False) -> dict[str, object]:
     dataset = RecordingDataset()
-    RayDataStageAdapter(stage).process_dataset(dataset)  # type: ignore[arg-type]
+    RayDataStageAdapter(stage, ignore_head_node=ignore_head_node).process_dataset(dataset)  # type: ignore[arg-type]
     assert dataset.map_batches_kwargs is not None
     assert dataset.batch_size == stage.batch_size
     return dataset.map_batches_kwargs

--- a/tests/backends/ray_data/test_adapter.py
+++ b/tests/backends/ray_data/test_adapter.py
@@ -167,7 +167,14 @@ class TestRayDataStageAdapter:
 
     @pytest.mark.parametrize(
         ("value", "error"),
-        [(0, ValueError), (-1, ValueError), (True, TypeError), ("2", TypeError)],
+        [
+            (0, ValueError),
+            (-1, ValueError),
+            (float("nan"), ValueError),
+            (float("inf"), ValueError),
+            (True, TypeError),
+            ("2", TypeError),
+        ],
     )
     def test_num_workers_per_node_rejects_invalid_values(self, value: object, error: type[Exception]):
         stage = ConfigurableTaskStage(num_workers_per_node=value)  # type: ignore[arg-type]

--- a/tests/backends/ray_data/test_adapter.py
+++ b/tests/backends/ray_data/test_adapter.py
@@ -165,23 +165,6 @@ class TestRayDataStageAdapter:
         ):
             _map_batches_kwargs(stage)
 
-    @pytest.mark.parametrize(
-        ("value", "error"),
-        [
-            (0, ValueError),
-            (-1, ValueError),
-            (float("nan"), ValueError),
-            (float("inf"), ValueError),
-            (True, TypeError),
-            ("2", TypeError),
-        ],
-    )
-    def test_num_workers_per_node_rejects_invalid_values(self, value: object, error: type[Exception]):
-        stage = ConfigurableTaskStage(num_workers_per_node=value)  # type: ignore[arg-type]
-
-        with pytest.raises(error, match="num_workers_per_node"):
-            _map_batches_kwargs(stage)
-
     def test_source_fanout_task_stage_uses_task_pool_strategy_for_single_worker_default(self):
         stage = ConfigurableTaskStage(
             ray_stage_spec={RayStageSpecKeys.IS_FANOUT_STAGE: True},

--- a/tests/backends/ray_data/test_utils.py
+++ b/tests/backends/ray_data/test_utils.py
@@ -64,12 +64,12 @@ class TestGetActorComputeStrategyForStage:
     """Test class for Ray Data compute strategy construction."""
 
     @pytest.mark.parametrize(
-        ("num_workers", "ray_stage_spec", "expected", "expected_warning"),
+        ("num_workers", "ray_stage_spec", "expected"),
         [
-            (4, {}, ActorPoolStrategy(size=4), None),
-            (0, {}, ActorPoolStrategy(min_size=1, max_size=None), None),
-            (-1, {}, ActorPoolStrategy(min_size=1, max_size=None), None),
-            (None, {}, ActorPoolStrategy(min_size=1, max_size=None), None),
+            (4, {}, ActorPoolStrategy(size=4)),
+            (0, {}, ActorPoolStrategy(min_size=1, max_size=None)),
+            (-1, {}, ActorPoolStrategy(min_size=1, max_size=None)),
+            (None, {}, ActorPoolStrategy(min_size=1, max_size=None)),
             (
                 None,
                 {
@@ -78,17 +78,6 @@ class TestGetActorComputeStrategyForStage:
                     RayStageSpecKeys.INITIAL_WORKERS: 4,
                 },
                 ActorPoolStrategy(min_size=2, max_size=8, initial_size=4),
-                None,
-            ),
-            (
-                3,
-                {
-                    RayStageSpecKeys.MIN_WORKERS: 1,
-                    RayStageSpecKeys.MAX_WORKERS: 8,
-                    RayStageSpecKeys.INITIAL_WORKERS: 2,
-                },
-                ActorPoolStrategy(size=3),
-                "uses num_workers=3",
             ),
         ],
     )
@@ -97,19 +86,11 @@ class TestGetActorComputeStrategyForStage:
         num_workers: int | None,
         ray_stage_spec: dict[str, object],
         expected: ActorPoolStrategy,
-        expected_warning: str | None,
     ):
         mock_stage = Mock(num_workers=lambda: num_workers, ray_stage_spec=lambda: ray_stage_spec)
         mock_stage.name = "stage"
 
-        with patch("nemo_curator.backends.ray_data.utils.logger.warning") as mock_warning:
-            assert get_actor_compute_strategy_for_stage(mock_stage) == expected
-
-        if expected_warning is None:
-            mock_warning.assert_not_called()
-        else:
-            mock_warning.assert_called_once()
-            assert expected_warning in mock_warning.call_args.args[0]
+        assert get_actor_compute_strategy_for_stage(mock_stage) == expected
 
     def test_actor_compute_strategy_rejects_invalid_sizing(self):
         mock_stage = Mock(

--- a/tests/backends/test_utils.py
+++ b/tests/backends/test_utils.py
@@ -27,6 +27,7 @@ from nemo_curator.backends.utils import (
     RayStageSpecKeys,
     check_total_gpu_capacity,
     execute_setup_on_node,
+    get_num_workers_for_nodes,
     merge_executor_configs,
 )
 from nemo_curator.stages.base import ProcessingStage
@@ -36,6 +37,11 @@ from nemo_curator.utils.ray_utils import get_head_node_id
 
 if TYPE_CHECKING:
     from nemo_curator.tasks import Task
+
+
+def test_get_num_workers_for_nodes_rejects_overflow() -> None:
+    with pytest.raises(ValueError, match="too large"):
+        get_num_workers_for_nodes(1e308, 2, "stage")
 
 
 class TestMergeExecutorConfig:

--- a/tests/backends/test_xenna_executor.py
+++ b/tests/backends/test_xenna_executor.py
@@ -28,13 +28,18 @@ class ConfigurableStage(ProcessingStage[EmptyTask, EmptyTask]):
         self,
         *,
         num_workers: int | None = None,
+        num_workers_per_node: float | None = None,
         xenna_stage_spec: dict[str, object] | None = None,
     ) -> None:
         self._num_workers = num_workers
+        self._num_workers_per_node = num_workers_per_node
         self._xenna_stage_spec = xenna_stage_spec or {}
 
     def num_workers(self) -> int | None:
         return self._num_workers
+
+    def num_workers_per_node(self) -> float | None:
+        return self._num_workers_per_node
 
     def xenna_stage_spec(self) -> dict[str, object]:
         return self._xenna_stage_spec
@@ -58,7 +63,7 @@ def test_xenna_executor_uses_stage_num_workers_when_xenna_spec_has_no_worker_siz
 def test_xenna_executor_accepts_num_workers_per_node_when_stage_num_workers_is_unset(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    stage = ConfigurableStage(xenna_stage_spec={"num_workers_per_node": 0.5})
+    stage = ConfigurableStage(num_workers_per_node=0.5)
 
     captured = _execute_and_capture_stage_spec(monkeypatch, stage)
 
@@ -66,17 +71,33 @@ def test_xenna_executor_accepts_num_workers_per_node_when_stage_num_workers_is_u
     assert captured["num_workers_per_node"] == 0.5
 
 
-def test_xenna_executor_rejects_num_workers_with_num_workers_per_node(monkeypatch: pytest.MonkeyPatch) -> None:
-    stage = ConfigurableStage(num_workers=3, xenna_stage_spec={"num_workers_per_node": 0.5})
+def test_xenna_executor_accepts_legacy_num_workers_per_node_spec(monkeypatch: pytest.MonkeyPatch) -> None:
+    stage = ConfigurableStage(xenna_stage_spec={"num_workers_per_node": 0.5})
 
+    captured = _execute_and_capture_stage_spec(monkeypatch, stage)
+
+    assert captured["num_workers_per_node"] == 0.5
+
+
+def test_xenna_executor_rejects_num_workers_with_num_workers_per_node() -> None:
     with pytest.raises(ValueError, match=r"num_workers\(\).*num_workers_per_node"):
-        _execute_and_capture_stage_spec(monkeypatch, stage)
+        ConfigurableStage(num_workers=3, num_workers_per_node=0.5)
 
 
 def test_xenna_executor_rejects_num_workers_in_xenna_stage_spec(monkeypatch: pytest.MonkeyPatch) -> None:
     stage = ConfigurableStage(xenna_stage_spec={"num_workers": 3})
 
     with pytest.raises(ValueError, match="Use num_workers\\(\\) instead"):
+        _execute_and_capture_stage_spec(monkeypatch, stage)
+
+
+def test_xenna_executor_rejects_generic_and_legacy_num_workers_per_node(monkeypatch: pytest.MonkeyPatch) -> None:
+    stage = ConfigurableStage(
+        num_workers_per_node=1,
+        xenna_stage_spec={"num_workers_per_node": 0.5},
+    )
+
+    with pytest.raises(ValueError, match=r"num_workers_per_node\(\).*xenna_stage_spec"):
         _execute_and_capture_stage_spec(monkeypatch, stage)
 
 

--- a/tests/backends/test_xenna_executor.py
+++ b/tests/backends/test_xenna_executor.py
@@ -79,6 +79,16 @@ def test_xenna_executor_accepts_legacy_num_workers_per_node_spec(monkeypatch: py
     assert captured["num_workers_per_node"] == 0.5
 
 
+@pytest.mark.parametrize("value", [float("nan"), float("inf")])
+def test_xenna_executor_rejects_non_finite_legacy_num_workers_per_node(
+    monkeypatch: pytest.MonkeyPatch, value: float
+) -> None:
+    stage = ConfigurableStage(xenna_stage_spec={"num_workers_per_node": value})
+
+    with pytest.raises(ValueError, match="must be finite and > 0"):
+        _execute_and_capture_stage_spec(monkeypatch, stage)
+
+
 def test_xenna_executor_rejects_num_workers_with_num_workers_per_node() -> None:
     with pytest.raises(ValueError, match=r"num_workers\(\).*num_workers_per_node"):
         ConfigurableStage(num_workers=3, num_workers_per_node=0.5)

--- a/tests/stages/common/test_base.py
+++ b/tests/stages/common/test_base.py
@@ -392,6 +392,32 @@ class TestProcessingStageWith:
         assert stage.num_workers() == 2
         assert stage_new.num_workers() is None
 
+    def test_num_workers_per_node_override_accepts_none_as_explicit_override(self):
+        stage = ConcreteProcessingStage()
+
+        stage_new = stage.with_(num_workers_per_node=2)
+        stage_reset = stage_new.with_(num_workers_per_node=None)
+
+        assert stage.num_workers_per_node() is None
+        assert stage_new.num_workers_per_node() == 2
+        assert stage_reset.num_workers_per_node() is None
+
+    @pytest.mark.parametrize("num_workers", [0, 2])
+    def test_worker_sizing_rejects_num_workers_with_num_workers_per_node(self, num_workers: int):
+        with pytest.raises(ValueError, match=r"num_workers\(\).*num_workers_per_node"):
+            ConcreteProcessingStage().with_(num_workers=num_workers, num_workers_per_node=2)
+
+    def test_worker_sizing_rejects_existing_num_workers_with_num_workers_per_node(self):
+        with pytest.raises(ValueError, match=r"num_workers\(\).*num_workers_per_node"):
+            BackendConfiguredStage().with_(num_workers_per_node=2)
+
+    def test_worker_sizing_rejects_actor_pool_keys_with_num_workers_per_node(self):
+        with pytest.raises(ValueError, match=r"num_workers_per_node.*actor-pool sizing"):
+            ConcreteProcessingStage().with_(
+                num_workers_per_node=2,
+                ray_stage_spec={"max_workers": 4},
+            )
+
 
 class TestProcessingStageInputSpecs:
     """Test legacy and task-type-specific input specs."""
@@ -585,6 +611,17 @@ class TestProcessingStageOverriddenProperties:
                 name = "MockStageNumWorkersAttribute"
                 resources = Resources(cpus=1.0)
                 num_workers: int = 1
+
+                def process(self, task: MockTask) -> MockTask:
+                    return task
+
+    def test_num_workers_per_node_attribute(self):
+        with pytest.raises(TypeError, match="must not define 'num_workers_per_node' as a stage attribute"):
+
+            class MockStageNumWorkersPerNodeAttribute(ProcessingStage[MockTask, MockTask]):
+                name = "MockStageNumWorkersPerNodeAttribute"
+                resources = Resources(cpus=1.0)
+                num_workers_per_node: float = 1
 
                 def process(self, task: MockTask) -> MockTask:
                     return task

--- a/tests/stages/common/test_base.py
+++ b/tests/stages/common/test_base.py
@@ -115,6 +115,18 @@ class BackendConfiguredStage(ConcreteProcessingStage):
         return 2
 
 
+class PerNodeConfiguredStage(ConcreteProcessingStage):
+    """Stage whose per-node worker count is configured at construction."""
+
+    name = "PerNodeConfiguredStage"
+
+    def __init__(self, num_workers_per_node: float | None):
+        self._num_workers_per_node = num_workers_per_node
+
+    def num_workers_per_node(self) -> float | None:
+        return self._num_workers_per_node
+
+
 @pytest.mark.parametrize("table_factory", [pa.table, pd.DataFrame], ids=["pyarrow", "pandas"])
 def test_validate_input_with_tabular_columns(
     table_factory: Callable[[dict[str, list[str]]], pa.Table | pd.DataFrame],
@@ -401,6 +413,21 @@ class TestProcessingStageWith:
         assert stage.num_workers_per_node() is None
         assert stage_new.num_workers_per_node() == 2
         assert stage_reset.num_workers_per_node() is None
+
+    @pytest.mark.parametrize(
+        ("value", "error"),
+        [
+            (0, ValueError),
+            (-1, ValueError),
+            (float("nan"), ValueError),
+            (float("inf"), ValueError),
+            (True, TypeError),
+            ("2", TypeError),
+        ],
+    )
+    def test_worker_sizing_rejects_invalid_num_workers_per_node(self, value: object, error: type[Exception]) -> None:
+        with pytest.raises(error, match="num_workers_per_node"):
+            PerNodeConfiguredStage(value)  # type: ignore[arg-type]
 
     @pytest.mark.parametrize("num_workers", [0, 2])
     def test_worker_sizing_rejects_num_workers_with_num_workers_per_node(self, num_workers: int):

--- a/tests/stages/text/download/base/test_download.py
+++ b/tests/stages/text/download/base/test_download.py
@@ -186,6 +186,20 @@ class TestBaseDocumentDownloader:
 class TestDocumentDownloadStage:
     """Test class for DocumentDownloadStage functionality."""
 
+    def test_num_workers_per_node_delegates_to_downloader(self, tmp_path: Path) -> None:
+        class PerNodeMockDownloader(MockDocumentDownloader):
+            def num_workers_per_node(self) -> int:
+                return 4
+
+        stage = DocumentDownloadStage(PerNodeMockDownloader(str(tmp_path)))
+
+        assert stage.num_workers_per_node() == 4
+
+    def test_num_workers_per_node_can_be_overridden(self, tmp_path: Path) -> None:
+        stage = DocumentDownloadStage(MockDocumentDownloader(str(tmp_path))).with_(num_workers_per_node=4)
+
+        assert stage.num_workers_per_node() == 4
+
     def test_stage_properties(self, tmp_path: Path) -> None:
         """Test that stage properties are correctly defined."""
         downloader = MockDocumentDownloader(str(tmp_path), verbose=False)

--- a/tests/utils/test_ray_utils.py
+++ b/tests/utils/test_ray_utils.py
@@ -69,6 +69,18 @@ class _FakeRemoteFunction:
 
 
 class TestRunOnEachNode:
+    def test_get_alive_ray_nodes_filters_dead_nodes(self) -> None:
+        nodes = ray_utils.get_alive_ray_nodes()
+
+        assert [node["NodeID"] for node in nodes] == [_HEAD_NODE_ID, _WORKER_NODE_ID]
+        assert ray_utils.get_alive_ray_node_count() == 2
+
+    def test_get_alive_ray_nodes_can_ignore_head_node(self, reset_head_node_cache: None) -> None:
+        nodes = ray_utils.get_alive_ray_nodes(ignore_head_node=True)
+
+        assert [node["NodeID"] for node in nodes] == [_WORKER_NODE_ID]
+        assert ray_utils.get_alive_ray_node_count(ignore_head_node=True) == 1
+
     def test_returns_one_result_per_alive_node(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Default call schedules ``remote_fn`` once per alive node and returns each landing node's id."""
         remote_fn = _FakeRemoteFunction()
@@ -78,9 +90,7 @@ class TestRunOnEachNode:
 
         assert results == remote_fn.submissions
         assert [r["args"] for r in results] == [("payload",), ("payload",)]
-        scheduled_ids = [
-            r["options"]["scheduling_strategy"].node_id for r in remote_fn.submissions
-        ]
+        scheduled_ids = [r["options"]["scheduling_strategy"].node_id for r in remote_fn.submissions]
         assert scheduled_ids == [_HEAD_NODE_ID, _WORKER_NODE_ID]
         assert all(not r["options"]["scheduling_strategy"].soft for r in remote_fn.submissions)
 

--- a/tutorials/audio/callhome_diar/run.py
+++ b/tutorials/audio/callhome_diar/run.py
@@ -34,7 +34,6 @@ import time
 from collections import Counter
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
 
 from loguru import logger
 
@@ -144,8 +143,8 @@ class CallHomeReaderStage(ProcessingStage[EmptyTask, AudioTask]):
     def outputs(self) -> tuple[list[str], list[str]]:
         return ["data"], [self.filepath_key]
 
-    def xenna_stage_spec(self) -> dict[str, Any]:
-        return {"num_workers_per_node": 1}
+    def num_workers_per_node(self) -> int:
+        return 1
 
     def process(self, task: EmptyTask) -> list[AudioTask]:  # noqa: ARG002
         cha_path = Path(self.cha_dir)


### PR DESCRIPTION
## Summary

- Add backend-neutral `ProcessingStage.num_workers_per_node()` and `with_(num_workers_per_node=...)` configuration.
- Translate per-node sizing across Ray Data, Ray Actor Pool, and Xenna while keeping the legacy Xenna stage-spec key compatible.
- Size Ray actor pools and task concurrency as `ceil(num_workers_per_node * alive_node_count)` and use `scheduling_strategy="SPREAD"` for best-effort distribution.
- Route document download stages through the common policy and default Arxiv, Common Crawl, and Wikipedia downloads to two workers per node.
- Centralize conflicting worker-sizing validation and update current Fern/backend guidance.

## Semantics and constraints

- `num_workers_per_node` is a sizing policy, not a hard placement guarantee. Ray actor stages create fixed cluster-wide pools; Ray Data task stages use cluster-wide concurrency caps. Both Ray backends use `SPREAD`, which may still place workers unevenly when resources or other constraints differ.
- `STRICT_SPREAD` is not a valid string scheduling strategy for Ray tasks or actors. Enforcing exact placement would require placement-group creation, gang resource reservation, lifecycle management, and separate handling for heterogeneous or autoscaling clusters; that is intentionally outside this API.
- Per-node values must be positive, finite integers or fractions. The common hook and legacy Xenna stage-spec key use the same validation. Ray Data and Ray Actor Pool round the cluster-wide request up with `ceil`; Xenna receives the per-node value directly.

## API changes

- `num_workers`, `num_workers_per_node`, and Ray Data actor-pool min/max/initial sizing are mutually exclusive.
- `ImageDuplicatesRemovalStage(num_workers_per_node=...)` is replaced by `ImageDuplicatesRemovalStage(...).with_(num_workers_per_node=...)`.
- Existing `xenna_stage_spec()["num_workers_per_node"]` configurations remain supported when the common worker hooks are unset.

## Validation

- 133 changed-area tests and all repository pre-commit hooks pass in `nvcr.io/nvidian/nemo-curator:nightly-2026-08-31` with Ray 2.57.0.
- In the same image, a Ray multi-node `Cluster` probe used a zero-CPU head, two 3-CPU worker nodes, and `ActorPoolStrategy(size=4)`. `map_batches(..., scheduling_strategy="SPREAD")` created two actors on each worker and none on the head.

Replaces #2198.
Fixes #2197.
