### PR TITLE
fix(docs): preserve semantic deduplication IDs

### DIFF
--- a/.github/workflows/config/.secrets.baseline
+++ b/.github/workflows/config/.secrets.baseline
@@ -91,6 +91,10 @@
       "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
     },
     {
+      "path": "detect_secrets.filters.common.is_baseline_file",
+      "filename": ".github/workflows/config/.secrets.baseline"
+    },
+    {
       "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
       "min_level": 2
     },
@@ -530,9 +534,9 @@
         "filename": "tutorials/text/deduplication/semantic/semantic_step_by_step.ipynb",
         "hashed_secret": "00ad2e1afc84d1b7c3c139b68f00edd67998232c",
         "is_verified": false,
-        "line_number": 671
+        "line_number": 672
       }
     ]
   },
-  "generated_at": "2026-08-07T18:14:16Z"
+  "generated_at": "2026-08-31T17:50:35Z"
 }

--- a/tutorials/text/deduplication/semantic/semantic_step_by_step.ipynb
+++ b/tutorials/text/deduplication/semantic/semantic_step_by_step.ipynb
@@ -222,6 +222,7 @@
     "            text_field=\"text\",\n",
     "            max_chars=None,\n",
     "            pretokenize=False,\n",
+    "            metadata_fields=[\"_curator_dedup_id\"],\n",
     "        ),\n",
     "        # We specify the fields out so that we also don't end up writing the `text` field, or the intermediate `input_ids` and `attention_mask` fields which are no longer needed.\n",
     "        ParquetWriter(path=embedding_output_path, fields=[\"_curator_dedup_id\", \"embeddings\"]),\n",


### PR DESCRIPTION
## Description

Preserve the generated `_curator_dedup_id` through the embedding stage in the semantic deduplication step-by-step tutorial.

PR #2317 made `VLLMEmbeddingModelStage` retain only explicitly requested metadata fields and updated the high-level semantic deduplication workflow accordingly. The standalone tutorial pipeline was not updated, so it dropped `_curator_dedup_id` before `ParquetWriter` selected that column, causing:

```text
KeyError: "['_curator_dedup_id'] not in index"
```

This change mirrors the high-level workflow by passing the ID through `metadata_fields`. It keeps the bounded embedding output behavior and restores the schema expected by the writer and downstream clustering stages.

## Usage

```python
VLLMEmbeddingModelStage(
    model_identifier="google/embeddinggemma-300m",
    metadata_fields=["_curator_dedup_id"],
    # ...
)
```

## Validation

- Executed the complete patched `semantic_step_by_step.ipynb` in `nvcr.io/nvidian/nemo-curator:nightly-2026-08-27` on four GPUs: `nbconvert` exited 0 with zero notebook errors.
- Ran the relevant `VLLMEmbeddingModelStage` initialization and metadata-contract tests in the nightly container: 2 passed.
- Ran pre-commit on the changed notebook in the nightly container: all hooks passed.

## Checklist

- [x] I am familiar with the [Contributing Guide](https://github.com/NVIDIA-NeMo/Curator/blob/main/CONTRIBUTING.md).
- [x] New or Existing tests cover these changes.
- [x] The documentation is up to date with these changes.
