### PR TITLE
perf(semantic): bulk read parquet footer metadata

### DIFF
--- a/nemo_curator/stages/deduplication/semantic/kmeans.py
+++ b/nemo_curator/stages/deduplication/semantic/kmeans.py
@@ -27,7 +27,7 @@ from nemo_curator.stages.text.embedders.utils import create_list_series_from_1d_
 from nemo_curator.tasks import EmptyTask, FileGroupTask
 from nemo_curator.utils.file_utils import check_disallowed_kwargs, get_default_file_extensions
 
-from .utils import break_parquet_partition_into_groups, get_array_from_df
+from .utils import break_parquet_partition_into_groups, get_array_from_df, read_parquet_file_row_counts
 
 if TYPE_CHECKING:
     import cudf
@@ -148,13 +148,16 @@ class KMeansReadFitWriteStage(ProcessingStage[FileGroupTask, EmptyTask], Dedupli
 
         # Collect all files from all tasks
         all_files = [file for task in tasks for file in task.data]
+        row_counts = None
 
         # Break files into subgroups to avoid cudf row limits
         if self.filetype == "parquet":
+            row_counts = read_parquet_file_row_counts(all_files, storage_options=self.input_storage_options)
             groups = break_parquet_partition_into_groups(
                 all_files,
                 embedding_dim=self.embedding_dim,
                 storage_options=self.input_storage_options,
+                row_counts=row_counts,
             )
         elif self.filetype == "jsonl":
             # For JSONL files, just group all files together since we can't easily estimate size
@@ -164,7 +167,7 @@ class KMeansReadFitWriteStage(ProcessingStage[FileGroupTask, EmptyTask], Dedupli
             raise ValueError(msg)
 
         if self.fit_data_fraction is not None:
-            return self._process_batch_two_pass(tasks, groups)
+            return self._process_batch_two_pass(tasks, groups, row_counts)
         return self._process_batch_single_pass(tasks, groups)
 
     def _read_group(self, group: list[str], columns: list[str]) -> "cudf.DataFrame":
@@ -264,7 +267,9 @@ class KMeansReadFitWriteStage(ProcessingStage[FileGroupTask, EmptyTask], Dedupli
 
         return results
 
-    def _process_batch_two_pass(self, tasks: list[FileGroupTask], groups: list[list[str]]) -> list["EmptyTask"]:
+    def _process_batch_two_pass(
+        self, tasks: list[FileGroupTask], groups: list[list[str]], row_counts: dict[str, int] | None = None
+    ) -> list["EmptyTask"]:
         """Memory-efficient two-pass approach for large datasets.
 
         Pass 1 (_fit_pass): samples fit_data_fraction of the actor's files (across
@@ -279,7 +284,7 @@ class KMeansReadFitWriteStage(ProcessingStage[FileGroupTask, EmptyTask], Dedupli
         Peak GPU memory ≈ max(fit_data_fraction x actor_rows, one_group_size) x embedding_dim x 4 bytes,
         instead of total_data x embedding_dim x 4 bytes.
         """
-        pass1_read_time = self._fit_pass(groups)
+        pass1_read_time = self._fit_pass(groups, row_counts)
         results, pass2_read_time, total_rows = self._predict_write_pass(tasks, groups)
         self._log_metrics(
             {
@@ -289,7 +294,7 @@ class KMeansReadFitWriteStage(ProcessingStage[FileGroupTask, EmptyTask], Dedupli
         )
         return results
 
-    def _fit_pass(self, groups: list[list[str]]) -> float:
+    def _fit_pass(self, groups: list[list[str]], row_counts: dict[str, int] | None = None) -> float:
         """Pass 1: sample files at the actor level, read embeddings, fit KMeans,
         and (on actor 0) save centroids.
 
@@ -325,6 +330,7 @@ class KMeansReadFitWriteStage(ProcessingStage[FileGroupTask, EmptyTask], Dedupli
                 fit_files,
                 embedding_dim=self.embedding_dim,
                 storage_options=self.input_storage_options,
+                row_counts=row_counts,
             )
         else:  # jsonl
             fit_groups = [fit_files]

--- a/nemo_curator/stages/deduplication/semantic/utils.py
+++ b/nemo_curator/stages/deduplication/semantic/utils.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from concurrent.futures import ThreadPoolExecutor
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -20,9 +21,12 @@ if TYPE_CHECKING:
 
 from typing import Any
 
+import pyarrow.parquet as pq
+from fsspec.parquet import open_parquet_file
 from loguru import logger
 
 PARQUET_FOOTER_BATCH_SIZE = 512
+PARQUET_FOOTER_READ_WORKERS = 8
 
 
 def get_array_from_df(df: "cudf.DataFrame", embedding_col: str) -> "cp.ndarray":
@@ -33,23 +37,30 @@ def get_array_from_df(df: "cudf.DataFrame", embedding_col: str) -> "cp.ndarray":
 
 
 def read_parquet_file_row_counts(files: list[str], storage_options: dict[str, Any] | None = None) -> dict[str, int]:
-    """Read ordered per-file row counts with one pylibcudf footer call."""
+    """Read ordered per-file row counts from Parquet footer metadata."""
     if not files:
         return {}
 
+    if storage_options:
+
+        def read_num_rows(file: str) -> int:
+            with open_parquet_file(file, storage_options=storage_options) as parquet_file:
+                return pq.read_metadata(parquet_file).num_rows
+
+        try:
+            with ThreadPoolExecutor(max_workers=min(PARQUET_FOOTER_READ_WORKERS, len(files))) as executor:
+                return dict(zip(files, executor.map(read_num_rows, files), strict=True))
+        except Exception as error:
+            msg = f"Failed to read Parquet footer metadata, starting with {files[0]!r}"
+            raise RuntimeError(msg) from error
+
     import pylibcudf as plc
-    from cudf.utils import ioutils
 
     row_counts = {}
     for offset in range(0, len(files), PARQUET_FOOTER_BATCH_SIZE):
         batch = files[offset : offset + PARQUET_FOOTER_BATCH_SIZE]
         try:
-            sources = ioutils.get_reader_filepath_or_buffer(
-                batch,
-                storage_options=storage_options,
-                prefetch_options={"method": "parquet", "columns": []},
-            )
-            footers = plc.io.parquet_metadata.read_parquet_footers(plc.io.SourceInfo(sources))
+            footers = plc.io.parquet_metadata.read_parquet_footers(plc.io.SourceInfo(batch))
         except Exception as error:
             msg = f"Failed to read Parquet footer metadata for batch starting with {batch[0]!r}"
             raise RuntimeError(msg) from error

--- a/nemo_curator/stages/deduplication/semantic/utils.py
+++ b/nemo_curator/stages/deduplication/semantic/utils.py
@@ -22,6 +22,8 @@ from typing import Any
 
 from loguru import logger
 
+PARQUET_FOOTER_BATCH_SIZE = 512
+
 
 def get_array_from_df(df: "cudf.DataFrame", embedding_col: str) -> "cp.ndarray":
     """
@@ -38,17 +40,25 @@ def read_parquet_file_row_counts(files: list[str], storage_options: dict[str, An
     import pylibcudf as plc
     from cudf.utils import ioutils
 
-    try:
-        sources = ioutils.get_reader_filepath_or_buffer(files, storage_options=storage_options)
-        footers = plc.io.parquet_metadata.read_parquet_footers(plc.io.SourceInfo(sources))
-    except Exception as error:
-        msg = f"Failed to read Parquet footer metadata for {len(files)} file(s), starting with {files[0]!r}"
-        raise RuntimeError(msg) from error
+    row_counts = {}
+    for offset in range(0, len(files), PARQUET_FOOTER_BATCH_SIZE):
+        batch = files[offset : offset + PARQUET_FOOTER_BATCH_SIZE]
+        try:
+            sources = ioutils.get_reader_filepath_or_buffer(
+                batch,
+                storage_options=storage_options,
+                prefetch_options={"method": "parquet", "columns": []},
+            )
+            footers = plc.io.parquet_metadata.read_parquet_footers(plc.io.SourceInfo(sources))
+        except Exception as error:
+            msg = f"Failed to read Parquet footer metadata for batch starting with {batch[0]!r}"
+            raise RuntimeError(msg) from error
 
-    if len(footers) != len(files):
-        msg = f"Expected {len(files)} Parquet footers, got {len(footers)}"
-        raise RuntimeError(msg)
-    return {file: int(footer.num_rows) for file, footer in zip(files, footers, strict=True)}
+        if len(footers) != len(batch):
+            msg = f"Expected {len(batch)} Parquet footers, got {len(footers)}"
+            raise RuntimeError(msg)
+        row_counts.update((file, int(footer.num_rows)) for file, footer in zip(batch, footers, strict=True))
+    return row_counts
 
 
 def break_parquet_partition_into_groups(  # noqa: C901

--- a/nemo_curator/stages/deduplication/semantic/utils.py
+++ b/nemo_curator/stages/deduplication/semantic/utils.py
@@ -24,8 +24,6 @@ import pyarrow.parquet as pq
 from fsspec.parquet import open_parquet_files
 from loguru import logger
 
-PARQUET_FOOTER_BATCH_SIZE = 512
-
 
 def get_array_from_df(df: "cudf.DataFrame", embedding_col: str) -> "cp.ndarray":
     """
@@ -39,37 +37,26 @@ def read_parquet_file_row_counts(files: list[str], storage_options: dict[str, An
     if not files:
         return {}
 
-    if storage_options:
-        row_counts = {}
-        for offset in range(0, len(files), PARQUET_FOOTER_BATCH_SIZE):
-            batch = files[offset : offset + PARQUET_FOOTER_BATCH_SIZE]
-            try:
-                parquet_files = open_parquet_files(batch, storage_options=storage_options, row_groups=[])
-                row_counts.update(
-                    (file, pq.read_metadata(parquet_file).num_rows)
-                    for file, parquet_file in zip(batch, parquet_files, strict=True)
-                )
-            except Exception as error:
-                msg = f"Failed to read Parquet footer metadata for batch starting with {batch[0]!r}"
-                raise RuntimeError(msg) from error
-        return row_counts
+    try:
+        if storage_options:
+            parquet_files = open_parquet_files(files, storage_options=storage_options, row_groups=[])
+            row_counts = [pq.read_metadata(parquet_file).num_rows for parquet_file in parquet_files]
+        else:
+            import pylibcudf as plc
 
-    import pylibcudf as plc
-
-    row_counts = {}
-    for offset in range(0, len(files), PARQUET_FOOTER_BATCH_SIZE):
-        batch = files[offset : offset + PARQUET_FOOTER_BATCH_SIZE]
-        try:
-            footers = plc.io.parquet_metadata.read_parquet_footers(plc.io.SourceInfo(batch))
-        except Exception as error:
-            msg = f"Failed to read Parquet footer metadata for batch starting with {batch[0]!r}"
-            raise RuntimeError(msg) from error
-
-        if len(footers) != len(batch):
-            msg = f"Expected {len(batch)} Parquet footers, got {len(footers)}"
-            raise RuntimeError(msg)
-        row_counts.update((file, int(footer.num_rows)) for file, footer in zip(batch, footers, strict=True))
-    return row_counts
+            metadata = plc.io.parquet_metadata.read_parquet_metadata(plc.io.SourceInfo(files))
+            row_groups_per_file = metadata.num_rowgroups_per_file()
+            row_group_metadata = metadata.rowgroup_metadata()
+            row_counts = []
+            offset = 0
+            for num_row_groups in row_groups_per_file:
+                end = offset + num_row_groups
+                row_counts.append(sum(group["num_rows"] for group in row_group_metadata[offset:end]))
+                offset = end
+        return dict(zip(files, row_counts, strict=True))
+    except Exception as error:
+        msg = f"Failed to read Parquet footer metadata for {files[0]!r}"
+        raise RuntimeError(msg) from error
 
 
 def break_parquet_partition_into_groups(  # noqa: C901

--- a/nemo_curator/stages/deduplication/semantic/utils.py
+++ b/nemo_curator/stages/deduplication/semantic/utils.py
@@ -37,6 +37,8 @@ def read_parquet_file_row_counts(files: list[str], storage_options: dict[str, An
     if not files:
         return {}
 
+    # TODO(https://github.com/NVIDIA/cudf/issues/23899): Use the cuDF metadata path for all inputs once it
+    # supports storage_options without opening every file simultaneously.
     try:
         if storage_options:
             parquet_files = open_parquet_files(files, storage_options=storage_options, row_groups=[])
@@ -55,7 +57,7 @@ def read_parquet_file_row_counts(files: list[str], storage_options: dict[str, An
                 offset = end
         return dict(zip(files, row_counts, strict=True))
     except Exception as error:
-        msg = f"Failed to read Parquet footer metadata for {files[0]!r}"
+        msg = f"Failed to read Parquet footer metadata for one of {len(files)} files"
         raise RuntimeError(msg) from error
 
 

--- a/nemo_curator/stages/deduplication/semantic/utils.py
+++ b/nemo_curator/stages/deduplication/semantic/utils.py
@@ -20,8 +20,6 @@ if TYPE_CHECKING:
 
 from typing import Any
 
-import pyarrow.parquet as pq
-from fsspec.parquet import open_parquet_file
 from loguru import logger
 
 
@@ -32,29 +30,75 @@ def get_array_from_df(df: "cudf.DataFrame", embedding_col: str) -> "cp.ndarray":
     return df[embedding_col].list.leaves.values.reshape(len(df), -1)
 
 
-def break_parquet_partition_into_groups(
-    files: list[str], embedding_dim: int | None = None, storage_options: dict[str, Any] | None = None
+def read_parquet_file_row_counts(files: list[str], storage_options: dict[str, Any] | None = None) -> dict[str, int]:
+    """Read ordered per-file row counts with one pylibcudf footer call."""
+    if not files:
+        return {}
+
+    import pylibcudf as plc
+    from cudf.utils import ioutils
+
+    try:
+        sources = ioutils.get_reader_filepath_or_buffer(files, storage_options=storage_options)
+        footers = plc.io.parquet_metadata.read_parquet_footers(plc.io.SourceInfo(sources))
+    except Exception as error:
+        msg = f"Failed to read Parquet footer metadata for {len(files)} file(s), starting with {files[0]!r}"
+        raise RuntimeError(msg) from error
+
+    if len(footers) != len(files):
+        msg = f"Expected {len(files)} Parquet footers, got {len(footers)}"
+        raise RuntimeError(msg)
+    return {file: int(footer.num_rows) for file, footer in zip(files, footers, strict=True)}
+
+
+def break_parquet_partition_into_groups(  # noqa: C901
+    files: list[str],
+    embedding_dim: int | None = None,
+    storage_options: dict[str, Any] | None = None,
+    *,
+    row_counts: dict[str, int] | None = None,
 ) -> list[list[str]]:
     """Break parquet files into groups to avoid cudf 2bn row limit."""
+    if not files:
+        return []
     if embedding_dim is None:
         # Default aggressive assumption of 1024 dimensional embedding
         embedding_dim = 1024
+    if embedding_dim <= 0:
+        msg = f"embedding_dim must be positive, got {embedding_dim}"
+        raise ValueError(msg)
 
     cudf_max_num_rows = 2_000_000_000  # cudf only allows 2bn rows
-    cudf_max_num_elements = cudf_max_num_rows / embedding_dim  # cudf considers each element in an array to be a row
+    max_rows_per_group = cudf_max_num_rows // embedding_dim
+    if max_rows_per_group == 0:
+        msg = f"embedding_dim {embedding_dim} exceeds the cuDF list-child element limit"
+        raise ValueError(msg)
 
-    # Load the first file and get the number of rows to estimate
-    with open_parquet_file(files[0], storage_options=storage_options) as f:
-        # Multiply by 1.5 to adjust for skew
-        avg_num_rows = pq.read_metadata(f).num_rows * 1.5
+    if row_counts is None:
+        row_counts = read_parquet_file_row_counts(files, storage_options=storage_options)
+    subgroups: list[list[str]] = []
+    subgroup: list[str] = []
+    subgroup_rows = 0
+    for file in files:
+        if file not in row_counts:
+            msg = f"Missing Parquet row count for {file!r}"
+            raise ValueError(msg)
+        file_rows = row_counts[file]
+        if file_rows < 0:
+            msg = f"Parquet row count for {file!r} must be non-negative, got {file_rows}"
+            raise ValueError(msg)
+        if file_rows > max_rows_per_group:
+            msg = f"Parquet file {file!r} has {file_rows} rows, exceeding the per-group limit of {max_rows_per_group}"
+            raise ValueError(msg)
+        if subgroup and subgroup_rows + file_rows > max_rows_per_group:
+            subgroups.append(subgroup)
+            subgroup = []
+            subgroup_rows = 0
+        subgroup.append(file)
+        subgroup_rows += file_rows
+    if subgroup:
+        subgroups.append(subgroup)
 
-    max_files_per_subgroup = int(cudf_max_num_elements / avg_num_rows)
-    max_files_per_subgroup = max(1, max_files_per_subgroup)  # Ensure at least 1 file per subgroup
-
-    # Break files into subgroups
-    subgroups = [files[i : i + max_files_per_subgroup] for i in range(0, len(files), max_files_per_subgroup)]
     if len(subgroups) > 1:
-        logger.debug(
-            f"Broke {len(files)} files into {len(subgroups)} subgroups with max {max_files_per_subgroup} files per subgroup"
-        )
+        logger.debug(f"Broke {len(files)} files into {len(subgroups)} row-bounded subgroups")
     return subgroups

--- a/nemo_curator/stages/deduplication/semantic/utils.py
+++ b/nemo_curator/stages/deduplication/semantic/utils.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from concurrent.futures import ThreadPoolExecutor
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -22,11 +21,10 @@ if TYPE_CHECKING:
 from typing import Any
 
 import pyarrow.parquet as pq
-from fsspec.parquet import open_parquet_file
+from fsspec.parquet import open_parquet_files
 from loguru import logger
 
 PARQUET_FOOTER_BATCH_SIZE = 512
-PARQUET_FOOTER_READ_WORKERS = 8
 
 
 def get_array_from_df(df: "cudf.DataFrame", embedding_col: str) -> "cp.ndarray":
@@ -42,17 +40,19 @@ def read_parquet_file_row_counts(files: list[str], storage_options: dict[str, An
         return {}
 
     if storage_options:
-
-        def read_num_rows(file: str) -> int:
-            with open_parquet_file(file, storage_options=storage_options) as parquet_file:
-                return pq.read_metadata(parquet_file).num_rows
-
-        try:
-            with ThreadPoolExecutor(max_workers=min(PARQUET_FOOTER_READ_WORKERS, len(files))) as executor:
-                return dict(zip(files, executor.map(read_num_rows, files), strict=True))
-        except Exception as error:
-            msg = f"Failed to read Parquet footer metadata, starting with {files[0]!r}"
-            raise RuntimeError(msg) from error
+        row_counts = {}
+        for offset in range(0, len(files), PARQUET_FOOTER_BATCH_SIZE):
+            batch = files[offset : offset + PARQUET_FOOTER_BATCH_SIZE]
+            try:
+                parquet_files = open_parquet_files(batch, storage_options=storage_options, row_groups=[])
+                row_counts.update(
+                    (file, pq.read_metadata(parquet_file).num_rows)
+                    for file, parquet_file in zip(batch, parquet_files, strict=True)
+                )
+            except Exception as error:
+                msg = f"Failed to read Parquet footer metadata for batch starting with {batch[0]!r}"
+                raise RuntimeError(msg) from error
+        return row_counts
 
     import pylibcudf as plc
 

--- a/tests/stages/deduplication/semantic/test_kmeans.py
+++ b/tests/stages/deduplication/semantic/test_kmeans.py
@@ -480,6 +480,10 @@ class TestKMeansReadFitWriteStage:
 
         with (
             patch(
+                "nemo_curator.stages.deduplication.semantic.kmeans.read_parquet_file_row_counts",
+                return_value=dict.fromkeys(all_files, len(df)),
+            ) as mock_row_counts,
+            patch(
                 "nemo_curator.stages.deduplication.semantic.kmeans.break_parquet_partition_into_groups"
             ) as mock_break,
             patch.object(stage, "read_parquet", return_value=df) as mock_read_parquet,
@@ -491,8 +495,15 @@ class TestKMeansReadFitWriteStage:
             results = stage.process_batch(all_tasks)
 
             if expect_break:
-                mock_break.assert_called_once_with(all_files, embedding_dim=32, storage_options=None)
+                mock_row_counts.assert_called_once_with(all_files, storage_options=None)
+                mock_break.assert_called_once_with(
+                    all_files,
+                    embedding_dim=32,
+                    storage_options=None,
+                    row_counts=dict.fromkeys(all_files, len(df)),
+                )
             else:
+                mock_row_counts.assert_not_called()
                 mock_break.assert_not_called()
 
             if filetype == "parquet":

--- a/tests/stages/deduplication/semantic/test_utils.py
+++ b/tests/stages/deduplication/semantic/test_utils.py
@@ -16,7 +16,7 @@
 
 import io
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 import fsspec
 import pandas as pd
@@ -30,112 +30,212 @@ def test_get_array_from_df() -> None:
 
     from nemo_curator.stages.deduplication.semantic.utils import get_array_from_df
 
-    df = cudf.DataFrame({"embedding": [[3, 4, 5], [1, 2, 2], [1, 0, 0]]})
-    expected_array = cp.array([[3, 4, 5], [1, 2, 2], [1, 0, 0]])
-    cp.testing.assert_allclose(get_array_from_df(df, "embedding"), expected_array, rtol=1e-5, atol=1e-5)
+    """Test that get_array_from_df works correctly."""
+    df = cudf.DataFrame(
+        {
+            "embedding": [[3, 4, 5], [1, 2, 2], [1, 0, 0]],
+        }
+    )
+    expected_array = cp.array(
+        [
+            [3, 4, 5],
+            [1, 2, 2],
+            [1, 0, 0],
+        ]
+    )
+    result = get_array_from_df(df, "embedding")
+    cp.testing.assert_allclose(result, expected_array, rtol=1e-5, atol=1e-5)
 
 
-@pytest.mark.gpu  # TODO: Remove this once semantic imports work without GPU dependencies.
+@pytest.mark.gpu  # TODO : Remove this once we figure out how to import semantic on CPU
 class TestBreakParquetPartitionIntoGroups:
-    def test_bulk_row_counts_preserve_file_order_and_empty_files(self, tmp_path: Path) -> None:
+    @patch("nemo_curator.stages.deduplication.semantic.utils.read_parquet_file_row_counts")
+    def test_calculation_logic(self, mock_read_row_counts: Mock) -> None:
+        from nemo_curator.stages.deduplication.semantic.utils import break_parquet_partition_into_groups
+
+        """Test the calculation logic of break_parquet_partition_into_groups without actual files."""
+        test_files = [f"mock_file_{i}.parquet" for i in range(1000)]
+        # Mock the bulk parquet metadata read to return a specific number of rows per file
+        mock_read_row_counts.return_value = dict.fromkeys(test_files, 10_000)
+
+        # Test with embedding_dim=1000
+        # Expected calculation:
+        # - cudf_max_num_rows = 2_000_000_000
+        # - cudf_max_num_elements = 2_000_000_000 / 1000 = 2_000_000
+        # - each file has exactly 10_000 rows according to its footer
+        # - max_files_per_subgroup = int(2_000_000 / 10_000) = 200
+        # Since we have 1000 files and max_files_per_subgroup=200
+
+        groups = break_parquet_partition_into_groups(test_files, embedding_dim=1000)
+
+        # Verify metadata was read once in bulk
+        mock_read_row_counts.assert_called_once_with(test_files, storage_options=None)
+
+        assert len(groups) == 5, "1000 files each with 10k rows with embedding_dim=1000 should fit in 5 groups"
+        for group in groups:
+            assert len(group) == 200, "Each group should contain 200 files"
+
+    def test_small_files_no_break(self, tmp_path: Path) -> None:
+        """Test that break_parquet_partition_into_groups correctly splits files to avoid cuDF 2bn row limit."""
+        from nemo_curator.stages.deduplication.semantic.utils import break_parquet_partition_into_groups
+
+        # Create test parquet files
+        test_files = []
+        for i in range(5):
+            file_path = tmp_path / f"test_file_{i}.parquet"
+            # Create a small test dataframe and save as parquet
+            df = pd.DataFrame(
+                {
+                    "id": list(range(i * 10, (i + 1) * 10)),
+                    "embedding": [[1.0, 2.0, 3.0]] * 10,
+                }
+            )
+            df.to_parquet(file_path)
+            test_files.append(str(file_path))
+
+        # Test with default embedding dimension (1024)
+        groups = break_parquet_partition_into_groups(test_files, embedding_dim=1024)
+
+        # Verify that we get groups (should be all files in one group for small test data)
+        assert len(groups) == 1, "Should create one group"
+        # Verify all files are included
+        all_files_in_group = list(groups[0])
+        assert set(all_files_in_group) == set(test_files), "All input files should be included in groups"
+
+    def test_large_files_break(self, tmp_path: Path) -> None:
+        """Test break_parquet_partition_into_groups with large embedding dimension that forces multiple groups."""
+        from nemo_curator.stages.deduplication.semantic.utils import break_parquet_partition_into_groups
+
+        # Create test parquet files
+        test_files = []
+        num_rows, num_files = 1000, 10
+
+        # Create 10 files, each with 1000 rows and 2000-dimensional embeddings
+        # Each file contains: 1000 rows * 2000 dimensions = 2,000,000 elements
+        for i in range(num_files):
+            file_path = tmp_path / f"large_test_file_{i}.parquet"
+            df = pd.DataFrame(
+                {
+                    "id": list(range(i * num_rows, (i + 1) * num_rows)),
+                    "embedding": [[1.0] * 2000] * num_rows,  # 2000-dim embeddings
+                }
+            )
+            df.to_parquet(file_path)
+            test_files.append(str(file_path))
+
+        # Test with embedding_dim=400,000 to force file splitting
+        # This parameter tells the function how many dimensions each embedding has
+        # The function uses this to calculate the effective row limit for cuDF
+
+        # Calculation breakdown:
+        # 1. cuDF max rows: 2,000,000,000 (2 billion)
+        # 2. Effective max elements per group: 2,000,000,000 / 400,000 = 5,000
+        # 3. Each file has exactly 1000 rows according to its footer
+        # 4. Max files per group: int(5,000 / 1,000) = 5
+        # 5. With 10 files and max 5 files per group: 2 groups
+
+        # Expected groups:
+        # - Group 0: files 0 through 4 (5 files)
+        # - Group 1: files 5 through 9 (5 files)
+
+        groups = break_parquet_partition_into_groups(test_files, embedding_dim=400_000)
+
+        # Verify we get exactly 2 groups as calculated above
+        assert len(groups) == 2, "Should create 2 groups based on embedding_dim=400,000 calculation"
+        for i, group in enumerate(groups):
+            assert len(group) == 5, f"Group {i} should contain 5 files"
+            assert set(group) == set(test_files[i * 5 : (i + 1) * 5]), (
+                f"Group {i} should contain files {i * 5} to {(i + 1) * 5}"
+            )
+
+        # If we run with the default value of embedding_dim=1024, we should get one group
+        groups = break_parquet_partition_into_groups(test_files)
+        assert len(groups) == 1, "Should create one group"
+        assert set(groups[0]) == set(test_files), "All input files should be included in groups"
+
+
+@pytest.mark.gpu
+class TestReadParquetFileRowCounts:
+    def test_multiple_files_preserve_order_and_empty_file(self, tmp_path: Path) -> None:
+        """Return exact row counts in input order, including a valid zero-row file."""
         from nemo_curator.stages.deduplication.semantic.utils import read_parquet_file_row_counts
 
-        files = []
-        for index, rows in enumerate((7, 0, 3)):
-            path = tmp_path / f"rows_{index}.parquet"
-            pd.DataFrame({"value": range(rows)}).to_parquet(path)
-            files.append(str(path))
+        test_files = []
+        expected_rows = [7, 0, 3]
+        for i, num_rows in enumerate(expected_rows):
+            file_path = tmp_path / f"test_file_{i}.parquet"
+            pd.DataFrame({"value": range(num_rows)}).to_parquet(file_path)
+            test_files.append(str(file_path))
 
-        assert read_parquet_file_row_counts(files) == dict(zip(files, (7, 0, 3), strict=True))
+        assert read_parquet_file_row_counts(test_files) == dict(zip(test_files, expected_rows, strict=True))
 
-    def test_bulk_row_counts_honor_remote_storage_options(self) -> None:
+    def test_remote_files_honor_storage_options(self) -> None:
+        """Pass storage options through cuDF's filesystem resolution for remote inputs."""
         from nemo_curator.stages.deduplication.semantic.utils import read_parquet_file_row_counts
 
-        buffer = io.BytesIO()
-        pd.DataFrame({"value": range(4)}).to_parquet(buffer)
+        parquet_buffer = io.BytesIO()
+        pd.DataFrame({"value": range(4)}).to_parquet(parquet_buffer)
         filesystem = fsspec.filesystem("memory", auto_mkdir=True)
-        filesystem.pipe("metadata-test/data.parquet", buffer.getvalue())
+        filesystem.pipe("metadata-test/data.parquet", parquet_buffer.getvalue())
 
         assert read_parquet_file_row_counts(
             ["memory://metadata-test/data.parquet"], storage_options={"auto_mkdir": True}
         ) == {"memory://metadata-test/data.parquet": 4}
 
-    def test_bulk_row_counts_use_one_pylibcudf_call(self, tmp_path: Path) -> None:
+    def test_multiple_files_use_one_bulk_footer_call(self, tmp_path: Path) -> None:
+        """A small file set is passed to pylibcudf in one bulk metadata call."""
         import pylibcudf as plc
 
         from nemo_curator.stages.deduplication.semantic.utils import read_parquet_file_row_counts
 
-        files = []
-        for index in range(3):
-            path = tmp_path / f"part_{index}.parquet"
-            pd.DataFrame({"value": [index]}).to_parquet(path)
-            files.append(str(path))
+        test_files = []
+        for i in range(3):
+            file_path = tmp_path / f"test_file_{i}.parquet"
+            pd.DataFrame({"value": [i]}).to_parquet(file_path)
+            test_files.append(str(file_path))
 
         original = plc.io.parquet_metadata.read_parquet_footers
         with patch.object(plc.io.parquet_metadata, "read_parquet_footers", wraps=original) as read_footers:
-            assert read_parquet_file_row_counts(files) == dict.fromkeys(files, 1)
+            assert read_parquet_file_row_counts(test_files) == dict.fromkeys(test_files, 1)
         read_footers.assert_called_once()
 
-    def test_bulk_row_counts_reject_corrupt_footer(self, tmp_path: Path) -> None:
+    def test_large_file_set_uses_bounded_bulk_calls(self) -> None:
+        """Bound each pylibcudf call below typical process file-descriptor limits."""
+        import pylibcudf as plc
+        from cudf.utils import ioutils
+
         from nemo_curator.stages.deduplication.semantic.utils import read_parquet_file_row_counts
 
-        valid = tmp_path / "valid.parquet"
-        corrupt = tmp_path / "corrupt.parquet"
-        pd.DataFrame({"value": [1]}).to_parquet(valid)
-        corrupt.write_bytes(b"not parquet")
+        test_files = [f"test_file_{i}.parquet" for i in range(513)]
+        with (
+            patch.object(
+                ioutils,
+                "get_reader_filepath_or_buffer",
+                side_effect=[[b"footer"] * 512, [b"footer"]],
+            ),
+            patch.object(
+                plc.io.parquet_metadata,
+                "read_parquet_footers",
+                side_effect=[[Mock(num_rows=1)] * 512, [Mock(num_rows=1)]],
+            ) as read_footers,
+        ):
+            assert read_parquet_file_row_counts(test_files) == dict.fromkeys(test_files, 1)
+        assert read_footers.call_count == 2
+
+    def test_corrupt_footer_raises_bounded_error(self, tmp_path: Path) -> None:
+        """Do not guess row counts when any footer in a bounded batch is unreadable."""
+        from nemo_curator.stages.deduplication.semantic.utils import read_parquet_file_row_counts
+
+        valid_file = tmp_path / "valid.parquet"
+        corrupt_file = tmp_path / "corrupt.parquet"
+        pd.DataFrame({"value": [1]}).to_parquet(valid_file)
+        corrupt_file.write_bytes(b"not parquet")
 
         with pytest.raises(RuntimeError, match="Failed to read Parquet footer metadata"):
-            read_parquet_file_row_counts([str(valid), str(corrupt)])
+            read_parquet_file_row_counts([str(valid_file), str(corrupt_file)])
 
     def test_empty_file_list_skips_metadata_read(self) -> None:
-        from nemo_curator.stages.deduplication.semantic.utils import (
-            break_parquet_partition_into_groups,
-            read_parquet_file_row_counts,
-        )
+        """An empty input has no footer work and returns an empty ordered mapping."""
+        from nemo_curator.stages.deduplication.semantic.utils import read_parquet_file_row_counts
 
         assert read_parquet_file_row_counts([]) == {}
-        assert break_parquet_partition_into_groups([]) == []
-
-    def test_exact_row_counts_bound_groups_and_are_reusable(self) -> None:
-        from nemo_curator.stages.deduplication.semantic import utils as semantic_utils
-
-        files = ["a.parquet", "b.parquet", "c.parquet"]
-        row_counts = {"a.parquet": 40, "b.parquet": 70, "c.parquet": 30}
-        with patch.object(
-            semantic_utils,
-            "read_parquet_file_row_counts",
-            side_effect=AssertionError("metadata should not be reread"),
-        ):
-            groups = semantic_utils.break_parquet_partition_into_groups(
-                files, embedding_dim=20_000_000, row_counts=row_counts
-            )
-
-        assert groups == [["a.parquet"], ["b.parquet", "c.parquet"]]
-
-    def test_small_files_no_break(self, tmp_path: Path) -> None:
-        from nemo_curator.stages.deduplication.semantic.utils import break_parquet_partition_into_groups
-
-        files = []
-        for index in range(5):
-            path = tmp_path / f"small_{index}.parquet"
-            pd.DataFrame({"id": range(10), "embedding": [[1.0, 2.0, 3.0]] * 10}).to_parquet(path)
-            files.append(str(path))
-
-        assert break_parquet_partition_into_groups(files, embedding_dim=1024) == [files]
-
-    def test_large_files_break_at_exact_limit(self) -> None:
-        from nemo_curator.stages.deduplication.semantic.utils import break_parquet_partition_into_groups
-
-        files = [f"part_{index}.parquet" for index in range(10)]
-        row_counts = dict.fromkeys(files, 1_000)
-        groups = break_parquet_partition_into_groups(files, embedding_dim=400_000, row_counts=row_counts)
-
-        assert groups == [files[:5], files[5:]]
-
-    def test_file_larger_than_limit_is_rejected(self) -> None:
-        from nemo_curator.stages.deduplication.semantic.utils import break_parquet_partition_into_groups
-
-        with pytest.raises(ValueError, match="exceeding the per-group limit"):
-            break_parquet_partition_into_groups(
-                ["large.parquet"], embedding_dim=20_000_000, row_counts={"large.parquet": 101}
-            )

--- a/tests/stages/deduplication/semantic/test_utils.py
+++ b/tests/stages/deduplication/semantic/test_utils.py
@@ -14,9 +14,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import io
 from pathlib import Path
-from unittest.mock import Mock, patch
+from unittest.mock import patch
 
+import fsspec
 import pandas as pd
 import pytest
 
@@ -28,138 +30,112 @@ def test_get_array_from_df() -> None:
 
     from nemo_curator.stages.deduplication.semantic.utils import get_array_from_df
 
-    """Test that get_array_from_df works correctly."""
-    df = cudf.DataFrame(
-        {
-            "embedding": [[3, 4, 5], [1, 2, 2], [1, 0, 0]],
-        }
-    )
-    expected_array = cp.array(
-        [
-            [3, 4, 5],
-            [1, 2, 2],
-            [1, 0, 0],
-        ]
-    )
-    result = get_array_from_df(df, "embedding")
-    cp.testing.assert_allclose(result, expected_array, rtol=1e-5, atol=1e-5)
+    df = cudf.DataFrame({"embedding": [[3, 4, 5], [1, 2, 2], [1, 0, 0]]})
+    expected_array = cp.array([[3, 4, 5], [1, 2, 2], [1, 0, 0]])
+    cp.testing.assert_allclose(get_array_from_df(df, "embedding"), expected_array, rtol=1e-5, atol=1e-5)
 
 
-@pytest.mark.gpu  # TODO : Remove this once we figure out how to import semantic on CPU
+@pytest.mark.gpu  # TODO: Remove this once semantic imports work without GPU dependencies.
 class TestBreakParquetPartitionIntoGroups:
-    @patch("pyarrow.parquet.read_metadata", return_value=Mock(num_rows=10_000))
-    @patch("nemo_curator.stages.deduplication.semantic.utils.open_parquet_file")
-    def test_calculation_logic(self, mock_open_parquet: Mock, mock_read_metadata: Mock) -> None:
-        from nemo_curator.stages.deduplication.semantic.utils import break_parquet_partition_into_groups
+    def test_bulk_row_counts_preserve_file_order_and_empty_files(self, tmp_path: Path) -> None:
+        from nemo_curator.stages.deduplication.semantic.utils import read_parquet_file_row_counts
 
-        """Test the calculation logic of break_parquet_partition_into_groups without actual files."""
-        # Mock the parquet metadata to return a specific number of rows
+        files = []
+        for index, rows in enumerate((7, 0, 3)):
+            path = tmp_path / f"rows_{index}.parquet"
+            pd.DataFrame({"value": range(rows)}).to_parquet(path)
+            files.append(str(path))
 
-        test_files = [f"mock_file_{i}.parquet" for i in range(1000)]
-        # Test with embedding_dim=1000
-        # Expected calculation:
-        # - cudf_max_num_rows = 2_000_000_000
-        # - cudf_max_num_elements = 2_000_000_000 / 1000 = 2_000_000
-        # - avg_num_rows = 10_000 * 1.5 = 15_000
-        # - max_files_per_subgroup = int(2_000_000 / 15_000) = 133
-        # Since we have 1000 files and max_files_per_subgroup=133
+        assert read_parquet_file_row_counts(files) == dict(zip(files, (7, 0, 3), strict=True))
 
-        groups = break_parquet_partition_into_groups(test_files, embedding_dim=1000)
+    def test_bulk_row_counts_honor_remote_storage_options(self) -> None:
+        from nemo_curator.stages.deduplication.semantic.utils import read_parquet_file_row_counts
 
-        # Verify the mock was called
-        mock_open_parquet.assert_called_once()
-        mock_read_metadata.assert_called_once()
+        buffer = io.BytesIO()
+        pd.DataFrame({"value": range(4)}).to_parquet(buffer)
+        filesystem = fsspec.filesystem("memory", auto_mkdir=True)
+        filesystem.pipe("metadata-test/data.parquet", buffer.getvalue())
 
-        # With our calculation, all 10 files should fit in one group
-        assert len(groups) == 8, "1000 files each with 10k rows with embedding_dim=1000 should fit in 8 groups"
-        for i, group in enumerate(groups):
-            if i != len(groups) - 1:
-                assert len(group) == 133, f"Group {i} should contain 133 files"
-            else:
-                assert len(group) == 69, "Last group should contain fewer files"
+        assert read_parquet_file_row_counts(
+            ["memory://metadata-test/data.parquet"], storage_options={"auto_mkdir": True}
+        ) == {"memory://metadata-test/data.parquet": 4}
+
+    def test_bulk_row_counts_use_one_pylibcudf_call(self, tmp_path: Path) -> None:
+        import pylibcudf as plc
+
+        from nemo_curator.stages.deduplication.semantic.utils import read_parquet_file_row_counts
+
+        files = []
+        for index in range(3):
+            path = tmp_path / f"part_{index}.parquet"
+            pd.DataFrame({"value": [index]}).to_parquet(path)
+            files.append(str(path))
+
+        original = plc.io.parquet_metadata.read_parquet_footers
+        with patch.object(plc.io.parquet_metadata, "read_parquet_footers", wraps=original) as read_footers:
+            assert read_parquet_file_row_counts(files) == dict.fromkeys(files, 1)
+        read_footers.assert_called_once()
+
+    def test_bulk_row_counts_reject_corrupt_footer(self, tmp_path: Path) -> None:
+        from nemo_curator.stages.deduplication.semantic.utils import read_parquet_file_row_counts
+
+        valid = tmp_path / "valid.parquet"
+        corrupt = tmp_path / "corrupt.parquet"
+        pd.DataFrame({"value": [1]}).to_parquet(valid)
+        corrupt.write_bytes(b"not parquet")
+
+        with pytest.raises(RuntimeError, match="Failed to read Parquet footer metadata"):
+            read_parquet_file_row_counts([str(valid), str(corrupt)])
+
+    def test_empty_file_list_skips_metadata_read(self) -> None:
+        from nemo_curator.stages.deduplication.semantic.utils import (
+            break_parquet_partition_into_groups,
+            read_parquet_file_row_counts,
+        )
+
+        assert read_parquet_file_row_counts([]) == {}
+        assert break_parquet_partition_into_groups([]) == []
+
+    def test_exact_row_counts_bound_groups_and_are_reusable(self) -> None:
+        from nemo_curator.stages.deduplication.semantic import utils as semantic_utils
+
+        files = ["a.parquet", "b.parquet", "c.parquet"]
+        row_counts = {"a.parquet": 40, "b.parquet": 70, "c.parquet": 30}
+        with patch.object(
+            semantic_utils,
+            "read_parquet_file_row_counts",
+            side_effect=AssertionError("metadata should not be reread"),
+        ):
+            groups = semantic_utils.break_parquet_partition_into_groups(
+                files, embedding_dim=20_000_000, row_counts=row_counts
+            )
+
+        assert groups == [["a.parquet"], ["b.parquet", "c.parquet"]]
 
     def test_small_files_no_break(self, tmp_path: Path) -> None:
-        """Test that break_parquet_partition_into_groups correctly splits files to avoid cuDF 2bn row limit."""
         from nemo_curator.stages.deduplication.semantic.utils import break_parquet_partition_into_groups
 
-        # Create test parquet files
-        test_files = []
-        for i in range(5):
-            file_path = tmp_path / f"test_file_{i}.parquet"
-            # Create a small test dataframe and save as parquet
-            df = pd.DataFrame(
-                {
-                    "id": list(range(i * 10, (i + 1) * 10)),
-                    "embedding": [[1.0, 2.0, 3.0]] * 10,
-                }
-            )
-            df.to_parquet(file_path)
-            test_files.append(str(file_path))
+        files = []
+        for index in range(5):
+            path = tmp_path / f"small_{index}.parquet"
+            pd.DataFrame({"id": range(10), "embedding": [[1.0, 2.0, 3.0]] * 10}).to_parquet(path)
+            files.append(str(path))
 
-        # Test with default embedding dimension (1024)
-        groups = break_parquet_partition_into_groups(test_files, embedding_dim=1024)
+        assert break_parquet_partition_into_groups(files, embedding_dim=1024) == [files]
 
-        # Verify that we get groups (should be all files in one group for small test data)
-        assert len(groups) == 1, "Should create one group"
-        # Verify all files are included
-        all_files_in_group = list(groups[0])
-        assert set(all_files_in_group) == set(test_files), "All input files should be included in groups"
-
-    def test_large_files_break(self, tmp_path: Path) -> None:
-        """Test break_parquet_partition_into_groups with large embedding dimension that forces multiple groups."""
+    def test_large_files_break_at_exact_limit(self) -> None:
         from nemo_curator.stages.deduplication.semantic.utils import break_parquet_partition_into_groups
 
-        # Create test parquet files
-        test_files = []
-        num_rows, num_files = 1000, 10
+        files = [f"part_{index}.parquet" for index in range(10)]
+        row_counts = dict.fromkeys(files, 1_000)
+        groups = break_parquet_partition_into_groups(files, embedding_dim=400_000, row_counts=row_counts)
 
-        # Create 10 files, each with 1000 rows and 2000-dimensional embeddings
-        # Each file contains: 1000 rows * 2000 dimensions = 2,000,000 elements
-        for i in range(num_files):
-            file_path = tmp_path / f"large_test_file_{i}.parquet"
-            df = pd.DataFrame(
-                {
-                    "id": list(range(i * num_rows, (i + 1) * num_rows)),
-                    "embedding": [[1.0] * 2000] * num_rows,  # 2000-dim embeddings
-                }
+        assert groups == [files[:5], files[5:]]
+
+    def test_file_larger_than_limit_is_rejected(self) -> None:
+        from nemo_curator.stages.deduplication.semantic.utils import break_parquet_partition_into_groups
+
+        with pytest.raises(ValueError, match="exceeding the per-group limit"):
+            break_parquet_partition_into_groups(
+                ["large.parquet"], embedding_dim=20_000_000, row_counts={"large.parquet": 101}
             )
-            df.to_parquet(file_path)
-            test_files.append(str(file_path))
-
-        # Test with embedding_dim=400,000 to force file splitting
-        # This parameter tells the function how many dimensions each embedding has
-        # The function uses this to calculate the effective row limit for cuDF
-
-        # Calculation breakdown:
-        # 1. cuDF max rows: 2,000,000,000 (2 billion)
-        # 2. Effective max elements per group: 2,000,000,000 / 400,000 = 5,000
-        # 3. Each file has 1000 rows, so with 1.5x safety factor: 1000 * 1.5 = 1,500 rows per file
-        # 4. Max files per group: int(5,000 / 1,500) = int(3.33) = 3
-        # 5. With 10 files and max 3 files per group: ceil(10 / 3) = 4 groups
-
-        # Expected groups:
-        # - Group 0: files 0, 1, 2 (3 files)
-        # - Group 1: files 3, 4, 5 (3 files)
-        # - Group 2: files 6, 7, 8 (3 files)
-        # - Group 3: file 9 (1 file)
-
-        groups = break_parquet_partition_into_groups(test_files, embedding_dim=400_000)
-
-        # Verify we get exactly 4 groups as calculated above
-        assert len(groups) == 4, "Should create 4 groups based on embedding_dim=400,000 calculation"
-        for i, group in enumerate(groups):
-            if i != len(groups) - 1:
-                assert len(group) == 3, f"Group {i} should contain 3 files"
-                assert set(group) == set(test_files[i * 3 : (i + 1) * 3]), (
-                    f"Group {i} should contain files {i * 3} to {(i + 1) * 3}"
-                )
-            else:
-                assert len(group) == 1, f"Group {i} should contain 1 file"
-                assert set(group) == set(test_files[i * 3 : (i + 1) * 3]), (
-                    f"Group {i} should contain files {i * 3} to {(i + 1) * 3}"
-                )
-
-        # If we run with the default value of embedding_dim=1024, we should get one group
-        groups = break_parquet_partition_into_groups(test_files)
-        assert len(groups) == 1, "Should create one group"
-        assert set(groups[0]) == set(test_files), "All input files should be included in groups"

--- a/tests/stages/deduplication/semantic/test_utils.py
+++ b/tests/stages/deduplication/semantic/test_utils.py
@@ -170,17 +170,21 @@ class TestReadParquetFileRowCounts:
         assert read_parquet_file_row_counts(test_files) == dict(zip(test_files, expected_rows, strict=True))
 
     def test_remote_files_honor_storage_options(self) -> None:
-        """Pass storage options through fsspec for remote inputs."""
-        from nemo_curator.stages.deduplication.semantic.utils import read_parquet_file_row_counts
+        """Pass storage options through fsspec's metadata-only Parquet reads."""
+        from nemo_curator.stages.deduplication.semantic import utils as semantic_utils
 
         parquet_buffer = io.BytesIO()
         pd.DataFrame({"value": range(4)}).to_parquet(parquet_buffer)
         filesystem = fsspec.filesystem("memory", auto_mkdir=True)
         filesystem.pipe("metadata-test/data.parquet", parquet_buffer.getvalue())
 
-        assert read_parquet_file_row_counts(
-            ["memory://metadata-test/data.parquet"], storage_options={"auto_mkdir": True}
-        ) == {"memory://metadata-test/data.parquet": 4}
+        test_files = ["memory://metadata-test/data.parquet"]
+        storage_options = {"auto_mkdir": True}
+        with patch.object(semantic_utils, "open_parquet_files", wraps=semantic_utils.open_parquet_files) as open_files:
+            assert semantic_utils.read_parquet_file_row_counts(test_files, storage_options=storage_options) == {
+                test_files[0]: 4
+            }
+        open_files.assert_called_once_with(test_files, storage_options=storage_options, row_groups=[])
 
     def test_multiple_files_use_one_bulk_footer_call(self, tmp_path: Path) -> None:
         """A small file set is passed to pylibcudf in one bulk metadata call."""

--- a/tests/stages/deduplication/semantic/test_utils.py
+++ b/tests/stages/deduplication/semantic/test_utils.py
@@ -170,7 +170,7 @@ class TestReadParquetFileRowCounts:
         assert read_parquet_file_row_counts(test_files) == dict(zip(test_files, expected_rows, strict=True))
 
     def test_remote_files_honor_storage_options(self) -> None:
-        """Pass storage options through cuDF's filesystem resolution for remote inputs."""
+        """Pass storage options through fsspec for remote inputs."""
         from nemo_curator.stages.deduplication.semantic.utils import read_parquet_file_row_counts
 
         parquet_buffer = io.BytesIO()
@@ -202,17 +202,12 @@ class TestReadParquetFileRowCounts:
     def test_large_file_set_uses_bounded_bulk_calls(self) -> None:
         """Bound each pylibcudf call below typical process file-descriptor limits."""
         import pylibcudf as plc
-        from cudf.utils import ioutils
 
         from nemo_curator.stages.deduplication.semantic.utils import read_parquet_file_row_counts
 
         test_files = [f"test_file_{i}.parquet" for i in range(513)]
         with (
-            patch.object(
-                ioutils,
-                "get_reader_filepath_or_buffer",
-                side_effect=[[b"footer"] * 512, [b"footer"]],
-            ),
+            patch.object(plc.io, "SourceInfo", side_effect=lambda sources: sources),
             patch.object(
                 plc.io.parquet_metadata,
                 "read_parquet_footers",

--- a/tests/stages/deduplication/semantic/test_utils.py
+++ b/tests/stages/deduplication/semantic/test_utils.py
@@ -198,13 +198,13 @@ class TestReadParquetFileRowCounts:
             pd.DataFrame({"value": [i]}).to_parquet(file_path)
             test_files.append(str(file_path))
 
-        original = plc.io.parquet_metadata.read_parquet_footers
-        with patch.object(plc.io.parquet_metadata, "read_parquet_footers", wraps=original) as read_footers:
+        original = plc.io.parquet_metadata.read_parquet_metadata
+        with patch.object(plc.io.parquet_metadata, "read_parquet_metadata", wraps=original) as read_metadata:
             assert read_parquet_file_row_counts(test_files) == dict.fromkeys(test_files, 1)
-        read_footers.assert_called_once()
+        read_metadata.assert_called_once()
 
-    def test_large_file_set_uses_bounded_bulk_calls(self) -> None:
-        """Bound each pylibcudf call below typical process file-descriptor limits."""
+    def test_large_file_set_uses_one_bulk_metadata_call(self) -> None:
+        """Pass the entire file set to pylibcudf in one bulk metadata call."""
         import pylibcudf as plc
 
         from nemo_curator.stages.deduplication.semantic.utils import read_parquet_file_row_counts
@@ -212,17 +212,15 @@ class TestReadParquetFileRowCounts:
         test_files = [f"test_file_{i}.parquet" for i in range(513)]
         with (
             patch.object(plc.io, "SourceInfo", side_effect=lambda sources: sources),
-            patch.object(
-                plc.io.parquet_metadata,
-                "read_parquet_footers",
-                side_effect=[[Mock(num_rows=1)] * 512, [Mock(num_rows=1)]],
-            ) as read_footers,
+            patch.object(plc.io.parquet_metadata, "read_parquet_metadata") as read_metadata,
         ):
+            read_metadata.return_value.num_rowgroups_per_file.return_value = [1] * len(test_files)
+            read_metadata.return_value.rowgroup_metadata.return_value = [{"num_rows": 1}] * len(test_files)
             assert read_parquet_file_row_counts(test_files) == dict.fromkeys(test_files, 1)
-        assert read_footers.call_count == 2
+        read_metadata.assert_called_once_with(test_files)
 
     def test_corrupt_footer_raises_bounded_error(self, tmp_path: Path) -> None:
-        """Do not guess row counts when any footer in a bounded batch is unreadable."""
+        """Do not guess row counts when any footer is unreadable."""
         from nemo_curator.stages.deduplication.semantic.utils import read_parquet_file_row_counts
 
         valid_file = tmp_path / "valid.parquet"

--- a/tests/stages/deduplication/semantic/test_utils.py
+++ b/tests/stages/deduplication/semantic/test_utils.py
@@ -228,7 +228,7 @@ class TestReadParquetFileRowCounts:
         pd.DataFrame({"value": [1]}).to_parquet(valid_file)
         corrupt_file.write_bytes(b"not parquet")
 
-        with pytest.raises(RuntimeError, match="Failed to read Parquet footer metadata"):
+        with pytest.raises(RuntimeError, match="Failed to read Parquet footer metadata for one of 2 files"):
             read_parquet_file_row_counts([str(valid_file), str(corrupt_file)])
 
     def test_empty_file_list_skips_metadata_read(self) -> None:


### PR DESCRIPTION
## TL;DR

It uses `plc.io.parquet_metadata.read_parquet_metadata` to read metadata for multiple Parquet files in one call. We do not make extensive use of the resulting row counts in this PR; we simply use the exact counts to break files into subgroups instead of relying on an estimate.

A follow-up PR will reuse this information to reduce memory overhead by roughly 2×.

## Details

- bulk-read ordered Parquet row counts with the RAPIDS 26.08 `pylibcudf.io.parquet_metadata.read_parquet_metadata` helper
- honor remote `storage_options` through fsspec metadata-only footer reads and fail explicitly on unreadable/corrupt metadata
- reuse the row-count manifest for grouping while preserving the existing grouping API

Linear: [NMCUR-243](https://linear.app/nvidia/issue/NMCUR-243/improve-parquet-metadata-read-inside-kmeanspairwise-to-use-pylibcudf)

Related cuDF issue: https://github.com/NVIDIA/cudf/issues/23899

## Testing

- `10 passed` — `tests/stages/deduplication/semantic/test_utils.py`
- `54 passed, 1 skipped` — KMeans and Pairwise unit/integration tests
- pre-commit hooks passed
- 38,377-file `/raid/curator-team/datasets/nemotron-cc` metadata benchmark: one pylibcudf call, 1.674 s, 26,209,337 rows

All tests and the benchmark ran in `nvcr.io/nvidian/nemo-curator:nightly-2026-08-31` on GPUs 3-6; the benchmark used `nofile=131072`.
