### PR TITLE
perf(semantic-dedup): overlap parquet writes

### DIFF
--- a/benchmarking/benchmarks.yaml
+++ b/benchmarking/benchmarks.yaml
@@ -628,10 +628,14 @@ entries:
           - kmeans_fit_time_s
           - kmeans_predict_time_s
           - kmeans_write_time_s
+          - kmeans_output_pipeline_time_s
+          - kmeans_write_work_time
+          - kmeans_write_lane_count
+          - kmeans_read_backpressure_count
           - kmeans_actual_fit_percent
           - kmeans_fit_data_fraction
           - kmeans_fit_file_fraction
-          # Percent of KMeans/workflow wall time.
+          # Share of measured KMeans component work; output components can overlap.
           - kmeans_read_percent_time
           - kmeans_write_percent_time
           - kmeans_fit_predict_percent_time
@@ -674,10 +678,14 @@ entries:
           - kmeans_fit_time_s
           - kmeans_predict_time_s
           - kmeans_write_time_s
+          - kmeans_output_pipeline_time_s
+          - kmeans_write_work_time
+          - kmeans_write_lane_count
+          - kmeans_read_backpressure_count
           - kmeans_actual_fit_percent
           - kmeans_fit_data_fraction
           - kmeans_fit_file_fraction
-          # Percent of KMeans/workflow wall time.
+          # Share of measured KMeans component work; output components can overlap.
           - kmeans_read_percent_time
           - kmeans_write_percent_time
           - kmeans_fit_predict_percent_time

--- a/benchmarking/scripts/semdedup_identification_benchmark.py
+++ b/benchmarking/scripts/semdedup_identification_benchmark.py
@@ -116,6 +116,9 @@ def run_semdedup_identification_benchmark(  # noqa: PLR0913, PLR0915
     kmeans_write_lane_count = task_metrics.get("kmeans_KMeansStage_custom.kmeans_write_lane_count_mean")
     kmeans_write_wall_time = task_metrics.get("kmeans_KMeansStage_custom.kmeans_write_wall_time_mean")
     kmeans_write_work_time = task_metrics.get("kmeans_KMeansStage_custom.kmeans_write_work_time_mean")
+    kmeans_write_batch_rows = task_metrics.get("kmeans_KMeansStage_custom.kmeans_write_batch_rows_mean")
+    kmeans_write_batch_bytes = task_metrics.get("kmeans_KMeansStage_custom.kmeans_write_batch_bytes_mean")
+    kmeans_read_backpressure_count = task_metrics.get("kmeans_KMeansStage_custom.kmeans_read_backpressure_count_sum")
     kmeans_actual_fit_percent = (
         round(100 * kmeans_fit_rows / num_documents_processed, 2) if num_documents_processed else None
     )
@@ -146,17 +149,17 @@ def run_semdedup_identification_benchmark(  # noqa: PLR0913, PLR0915
     pairwise_percent_time = None
     kmeans_footer_scan_time = task_metrics.get("kmeans_KMeansStage_custom.kmeans_footer_scan_time_mean", 0)
     kmeans_read_time = task_metrics.get("kmeans_KMeansStage_custom.kmeans_read_time_mean", 0)
-    kmeans_write_pipeline_time = task_metrics.get("kmeans_KMeansStage_custom.kmeans_write_pipeline_time_mean")
+    kmeans_output_pipeline_time = task_metrics.get("kmeans_KMeansStage_custom.kmeans_output_pipeline_time_mean")
     kmeans_write_time = (
-        kmeans_write_pipeline_time
-        if kmeans_write_pipeline_time is not None
+        kmeans_write_wall_time
+        if kmeans_write_wall_time is not None
         else task_metrics.get("kmeans_KMeansStage_custom.kmeans_write_time_mean", 0)
     )
     kmeans_fit_time = task_metrics.get("kmeans_KMeansStage_custom.kmeans_fit_time_mean", 0)
     kmeans_predict_time = task_metrics.get("kmeans_KMeansStage_custom.kmeans_predict_time_mean", 0)
     kmeans_fit_predict_time = (
-        kmeans_fit_time
-        if kmeans_write_pipeline_time is not None
+        kmeans_fit_time + kmeans_predict_time
+        if kmeans_output_pipeline_time is not None
         else task_metrics.get("kmeans_KMeansStage_custom.kmeans_fit_predict_time_mean", kmeans_fit_time)
     )
     if workflow_total_time:
@@ -188,6 +191,7 @@ def run_semdedup_identification_benchmark(  # noqa: PLR0913, PLR0915
             "kmeans_fit_time_s": kmeans_fit_time,
             "kmeans_predict_time_s": kmeans_predict_time,
             "kmeans_write_time_s": kmeans_write_time,
+            "kmeans_output_pipeline_time_s": kmeans_output_pipeline_time,
             "kmeans_fit_rows": kmeans_fit_rows,
             "kmeans_fit_files": kmeans_fit_files,
             "kmeans_input_files": kmeans_input_files,
@@ -197,6 +201,9 @@ def run_semdedup_identification_benchmark(  # noqa: PLR0913, PLR0915
             "kmeans_write_lane_count": kmeans_write_lane_count,
             "kmeans_write_wall_time": kmeans_write_wall_time,
             "kmeans_write_work_time": kmeans_write_work_time,
+            "kmeans_write_max_batch_rows": kmeans_write_batch_rows,
+            "kmeans_write_max_batch_bytes": kmeans_write_batch_bytes,
+            "kmeans_read_backpressure_count": kmeans_read_backpressure_count,
             # within kmeans time
             "kmeans_read_percent_time": kmeans_read_percent_time,
             "kmeans_write_percent_time": kmeans_write_percent_time,

--- a/benchmarking/scripts/semdedup_identification_benchmark.py
+++ b/benchmarking/scripts/semdedup_identification_benchmark.py
@@ -33,7 +33,7 @@ from nemo_curator.tasks.utils import TaskPerfUtils
 from nemo_curator.utils.file_utils import get_default_file_extensions
 
 
-def run_semdedup_identification_benchmark(  # noqa: PLR0913
+def run_semdedup_identification_benchmark(  # noqa: PLR0913, PLR0915
     input_path: str,
     cache_path: str,
     output_path: str,
@@ -113,6 +113,9 @@ def run_semdedup_identification_benchmark(  # noqa: PLR0913
     kmeans_input_files = int(task_metrics.get("kmeans_KMeansStage_custom.kmeans_input_files_sum", 0))
     kmeans_fit_data_fraction = task_metrics.get("kmeans_KMeansStage_custom.kmeans_fit_data_fraction_mean")
     kmeans_fit_file_fraction = task_metrics.get("kmeans_KMeansStage_custom.kmeans_fit_file_fraction_mean")
+    kmeans_write_lane_count = task_metrics.get("kmeans_KMeansStage_custom.kmeans_write_lane_count_mean")
+    kmeans_write_wall_time = task_metrics.get("kmeans_KMeansStage_custom.kmeans_write_wall_time_mean")
+    kmeans_write_work_time = task_metrics.get("kmeans_KMeansStage_custom.kmeans_write_work_time_mean")
     kmeans_actual_fit_percent = (
         round(100 * kmeans_fit_rows / num_documents_processed, 2) if num_documents_processed else None
     )
@@ -126,6 +129,8 @@ def run_semdedup_identification_benchmark(  # noqa: PLR0913
         logger.info(
             f"Mean actor fit fractions: rows={kmeans_fit_data_fraction:.4f}, files={kmeans_fit_file_fraction:.4f}"
         )
+    if kmeans_write_lane_count is not None:
+        logger.info(f"KMeans writer lanes per actor: {kmeans_write_lane_count:g}")
 
     # Extract metrics from workflow result
     workflow_total_time = workflow_run_result.metadata.get("total_time")
@@ -141,12 +146,18 @@ def run_semdedup_identification_benchmark(  # noqa: PLR0913
     pairwise_percent_time = None
     kmeans_footer_scan_time = task_metrics.get("kmeans_KMeansStage_custom.kmeans_footer_scan_time_mean", 0)
     kmeans_read_time = task_metrics.get("kmeans_KMeansStage_custom.kmeans_read_time_mean", 0)
-    kmeans_write_time = task_metrics.get("kmeans_KMeansStage_custom.kmeans_write_time_mean", 0)
+    kmeans_write_pipeline_time = task_metrics.get("kmeans_KMeansStage_custom.kmeans_write_pipeline_time_mean")
+    kmeans_write_time = (
+        kmeans_write_pipeline_time
+        if kmeans_write_pipeline_time is not None
+        else task_metrics.get("kmeans_KMeansStage_custom.kmeans_write_time_mean", 0)
+    )
     kmeans_fit_time = task_metrics.get("kmeans_KMeansStage_custom.kmeans_fit_time_mean", 0)
     kmeans_predict_time = task_metrics.get("kmeans_KMeansStage_custom.kmeans_predict_time_mean", 0)
-    kmeans_fit_predict_time = task_metrics.get(
-        "kmeans_KMeansStage_custom.kmeans_fit_predict_time_mean",
-        kmeans_fit_time + kmeans_predict_time,
+    kmeans_fit_predict_time = (
+        kmeans_fit_time
+        if kmeans_write_pipeline_time is not None
+        else task_metrics.get("kmeans_KMeansStage_custom.kmeans_fit_predict_time_mean", kmeans_fit_time)
     )
     if workflow_total_time:
         # this is different than kmeans_time because kmeans_time also includes setting up actors
@@ -183,10 +194,15 @@ def run_semdedup_identification_benchmark(  # noqa: PLR0913
             "kmeans_actual_fit_percent": kmeans_actual_fit_percent,
             "kmeans_fit_data_fraction": kmeans_fit_data_fraction,
             "kmeans_fit_file_fraction": kmeans_fit_file_fraction,
+            "kmeans_write_lane_count": kmeans_write_lane_count,
+            "kmeans_write_wall_time": kmeans_write_wall_time,
+            "kmeans_write_work_time": kmeans_write_work_time,
             # within kmeans time
             "kmeans_read_percent_time": kmeans_read_percent_time,
             "kmeans_write_percent_time": kmeans_write_percent_time,
             "kmeans_fit_predict_percent_time": kmeans_fit_predict_percent_time,
+            "kmeans_predict_write_percent_time": kmeans_write_percent_time,
+            "kmeans_fit_percent_time": kmeans_fit_predict_percent_time,
             # between workflows
             "kmeans_percent_time": kmeans_percent_time,
             "pairwise_percent_time": pairwise_percent_time,

--- a/fern/versions/main/pages/curate-text/process-data/deduplication/semdedup.mdx
+++ b/fern/versions/main/pages/curate-text/process-data/deduplication/semdedup.mdx
@@ -181,7 +181,7 @@ but their I/O differs:
 
 - **Parquet:** Exact footer counts group reads below cuDF's column-size limit and size the fit array.
   The sampled rows remain in memory for prediction, so only the files excluded from fitting are read
-  after the fit.
+  after the fit. Prediction overlaps with incremental Parquet writes.
 - **JSONL:** The first pass reads the sampled files and fits K-means. The second pass reads all files,
   including the sampled files, to predict and write every row.
 

--- a/nemo_curator/stages/deduplication/semantic/kmeans.py
+++ b/nemo_curator/stages/deduplication/semantic/kmeans.py
@@ -19,6 +19,7 @@ from typing import TYPE_CHECKING, Any, Literal
 
 import cupy as cp
 import numpy as np
+from cudf.io.parquet import ParquetDatasetWriter
 
 from nemo_curator.backends.base import WorkerMetadata
 from nemo_curator.stages.base import CompositeStage, ProcessingStage
@@ -30,11 +31,13 @@ from nemo_curator.tasks import EmptyTask, FileGroupTask
 from nemo_curator.utils.file_utils import check_disallowed_kwargs, get_default_file_extensions
 
 from .utils import (
+    CUDF_COLUMN_SIZE_LIMIT,
     ParquetFileInfo,
     break_parquet_partition_into_groups,
     get_array_from_df,
     read_parquet_file_info,
 )
+from .write_utils import ConcurrentParquetWriters, RollingParquetWriter
 
 if TYPE_CHECKING:
     import cudf
@@ -140,7 +143,7 @@ class KMeansReadFitWriteStage(ProcessingStage[FileGroupTask, EmptyTask], Dedupli
         raise NotImplementedError(msg)
 
     def process_batch(self, tasks: list[FileGroupTask]) -> list[EmptyTask]:
-        """Fit cooperatively, then predict and write each bounded frame."""
+        """Fit cooperatively, then overlap sequential prediction with writes."""
 
         if not tasks:
             return []
@@ -216,46 +219,44 @@ class KMeansReadFitWriteStage(ProcessingStage[FileGroupTask, EmptyTask], Dedupli
         cp.get_default_memory_pool().free_all_blocks()
 
         predict_time = 0.0
-        write_time = 0.0
+        writers = self._create_concurrent_writers(tasks, embedding_width)
+        write_pipeline_start = time.perf_counter()
         predicted_rows = 0
-        output_index = 0
-        for metadata, start, stop in sampled_chunks:
-            write_start = time.perf_counter()
-            self._write_output_frame(
-                f"{tasks[0].task_id}_{output_index}.parquet",
-                metadata,
-                fit_embeddings[start:stop],
-                fit_labels[start:stop],
-                centroids,
-            )
-            write_time += time.perf_counter() - write_start
-            predicted_rows += len(metadata)
-            output_index += 1
-
-        sampled_chunks.clear()
-        del fit_embeddings, fit_labels
-        gc.collect()
-        cp.get_default_memory_pool().free_all_blocks()
-
-        if prediction_only_info:
-            read_start = time.perf_counter()
-            for df in self._iter_parquet_frames(prediction_only_info, columns):
-                read_time += time.perf_counter() - read_start
-                embeddings = get_array_from_df(df, self.embedding_field).astype(cp.float32, copy=False)
-                self._normalize_embeddings_in_place(embeddings)
-                predict_start = time.perf_counter()
-                labels = cp.asarray(self.kmeans.predict(embeddings, convert_dtype=False)).astype(cp.int32, copy=False)
-                predict_time += time.perf_counter() - predict_start
-                del df[self.embedding_field]
-                write_start = time.perf_counter()
-                self._write_output_frame(
-                    f"{tasks[0].task_id}_{output_index}.parquet", df, embeddings, labels, centroids
+        try:
+            for metadata, start, stop in sampled_chunks:
+                self._submit_output_batches(
+                    writers,
+                    metadata,
+                    fit_embeddings[start:stop],
+                    fit_labels[start:stop],
+                    centroids,
                 )
-                write_time += time.perf_counter() - write_start
-                predicted_rows += len(df)
-                output_index += 1
+                predicted_rows += len(metadata)
+            writers.flush()
+
+            sampled_chunks.clear()
+            del fit_embeddings, fit_labels
+            gc.collect()
+            cp.get_default_memory_pool().free_all_blocks()
+
+            if prediction_only_info:
                 read_start = time.perf_counter()
-            read_time += time.perf_counter() - read_start
+                for df in self._iter_parquet_frames(prediction_only_info, columns):
+                    read_time += time.perf_counter() - read_start
+                    embeddings = get_array_from_df(df, self.embedding_field).astype(cp.float32, copy=False)
+                    self._normalize_embeddings_in_place(embeddings)
+                    predict_start = time.perf_counter()
+                    labels = cp.asarray(self.kmeans.predict(embeddings, convert_dtype=False)).astype(
+                        cp.int32, copy=False
+                    )
+                    predict_time += time.perf_counter() - predict_start
+                    del df[self.embedding_field]
+                    self._submit_output_batches(writers, df, embeddings, labels, centroids)
+                    predicted_rows += len(df)
+                    read_start = time.perf_counter()
+                read_time += time.perf_counter() - read_start
+        finally:
+            writers.close()
 
         if predicted_rows != total_rows:
             msg = f"Parquet footers reported {total_rows} rows but prediction processed {predicted_rows}"
@@ -264,7 +265,12 @@ class KMeansReadFitWriteStage(ProcessingStage[FileGroupTask, EmptyTask], Dedupli
             {
                 "kmeans_read_time": read_time,
                 "kmeans_predict_time": predict_time,
-                "kmeans_write_time": write_time,
+                "kmeans_write_pipeline_time": time.perf_counter() - write_pipeline_start,
+                "kmeans_write_work_time": writers.write_work_time,
+                "kmeans_write_wall_time": writers.write_wall_time,
+                "kmeans_write_lane_count": writers.lane_count,
+                "kmeans_write_batch_rows": writers.batch_rows,
+                "kmeans_write_batch_bytes": writers.batch_bytes,
                 "num_rows": total_rows,
             }
         )
@@ -318,9 +324,44 @@ class KMeansReadFitWriteStage(ProcessingStage[FileGroupTask, EmptyTask], Dedupli
         for group in break_parquet_partition_into_groups(file_info):
             yield self._read_group(group, columns)
 
-    def _write_output_frame(
+    def _create_concurrent_writers(self, tasks: list[FileGroupTask], embedding_width: int) -> ConcurrentParquetWriters:
+        max_rows_per_partition = (CUDF_COLUMN_SIZE_LIMIT - 1) // embedding_width
+        if max_rows_per_partition < 1:
+            msg = f"Embedding width {embedding_width} exceeds cuDF's column-size limit"
+            raise ValueError(msg)
+        return ConcurrentParquetWriters(
+            lambda lane_index: RollingParquetWriter(
+                create_writer=lambda generation: self._create_dataset_writer(tasks, lane_index, generation),
+                n_partitions=self.n_clusters,
+                max_rows_per_partition=max_rows_per_partition,
+                partition_column="centroid",
+            )
+        )
+
+    def _create_dataset_writer(
         self,
-        output_filename: str,
+        tasks: list[FileGroupTask],
+        lane_index: int,
+        generation: int,
+    ) -> ParquetDatasetWriter:
+        supported_kwargs = {"compression", "statistics"}
+        unsupported = set(self.write_kwargs).difference(supported_kwargs)
+        if unsupported:
+            msg = f"Incremental KMeans output does not support write kwargs {sorted(unsupported)}"
+            raise ValueError(msg)
+        return ParquetDatasetWriter(
+            self.output_path,
+            partition_cols=["centroid"],
+            index=False,
+            max_file_size=None,
+            file_name_prefix=f"{tasks[0].task_id}_lane{lane_index}_{generation}.parquet",
+            storage_options=self.output_storage_options,
+            **self.write_kwargs,
+        )
+
+    def _submit_output_batches(
+        self,
+        writers: ConcurrentParquetWriters,
         metadata: "cudf.DataFrame",
         embeddings: "cp.ndarray",
         labels: "cp.ndarray",
@@ -331,16 +372,7 @@ class KMeansReadFitWriteStage(ProcessingStage[FileGroupTask, EmptyTask], Dedupli
         frame = metadata.copy(deep=False)
         frame[self.embedding_field] = create_list_series_from_1d_or_2d_ar(embeddings, index=frame.index)
         frame["centroid"] = labels
-        frame = self._assign_distances(frame, self.embedding_field, centroids)
-        self.write_parquet(
-            frame,
-            self.output_path,
-            partition_file_name=output_filename,
-            partition_cols=["centroid"],
-            index=False,
-            storage_options=self.output_storage_options,
-            **self.write_kwargs,
-        )
+        writers.submit(self._assign_distances(frame, self.embedding_field, centroids))
 
     def _save_centroids(self, centroids: "cp.ndarray") -> None:
         if self.cache_path is not None and getattr(self, "_actor_index", 0) == 0:

--- a/nemo_curator/stages/deduplication/semantic/kmeans.py
+++ b/nemo_curator/stages/deduplication/semantic/kmeans.py
@@ -222,6 +222,7 @@ class KMeansReadFitWriteStage(ProcessingStage[FileGroupTask, EmptyTask], Dedupli
         writers = self._create_concurrent_writers(tasks, embedding_width)
         write_pipeline_start = time.perf_counter()
         predicted_rows = 0
+        read_backpressure_count = 0
         try:
             for metadata, start, stop in sampled_chunks:
                 self._submit_output_batches(
@@ -241,7 +242,9 @@ class KMeansReadFitWriteStage(ProcessingStage[FileGroupTask, EmptyTask], Dedupli
 
             if prediction_only_info:
                 read_start = time.perf_counter()
-                for df in self._iter_parquet_frames(prediction_only_info, columns):
+                for group in break_parquet_partition_into_groups(prediction_only_info):
+                    df, was_backpressured = self._read_prediction_group(group, columns, writers)
+                    read_backpressure_count += was_backpressured
                     read_time += time.perf_counter() - read_start
                     embeddings = get_array_from_df(df, self.embedding_field).astype(cp.float32, copy=False)
                     self._normalize_embeddings_in_place(embeddings)
@@ -265,12 +268,13 @@ class KMeansReadFitWriteStage(ProcessingStage[FileGroupTask, EmptyTask], Dedupli
             {
                 "kmeans_read_time": read_time,
                 "kmeans_predict_time": predict_time,
-                "kmeans_write_pipeline_time": time.perf_counter() - write_pipeline_start,
+                "kmeans_output_pipeline_time": time.perf_counter() - write_pipeline_start,
                 "kmeans_write_work_time": writers.write_work_time,
                 "kmeans_write_wall_time": writers.write_wall_time,
                 "kmeans_write_lane_count": writers.lane_count,
                 "kmeans_write_batch_rows": writers.batch_rows,
                 "kmeans_write_batch_bytes": writers.batch_bytes,
+                "kmeans_read_backpressure_count": read_backpressure_count,
                 "num_rows": total_rows,
             }
         )
@@ -337,6 +341,23 @@ class KMeansReadFitWriteStage(ProcessingStage[FileGroupTask, EmptyTask], Dedupli
                 partition_column="centroid",
             )
         )
+
+    def _read_prediction_group(
+        self,
+        group: list[str],
+        columns: list[str],
+        writers: ConcurrentParquetWriters,
+    ) -> tuple["cudf.DataFrame", bool]:
+        try:
+            return self._read_group(group, columns), False
+        except MemoryError:
+            # A partitioned write temporarily holds a grouped copy of its input. If that leaves
+            # too little room for the next read, finish the write and retry the same group once.
+            logger.warning("Waiting for the in-flight Parquet write before retrying a prediction read")
+            writers.flush()
+            gc.collect()
+            cp.get_default_memory_pool().free_all_blocks()
+            return self._read_group(group, columns), True
 
     def _create_dataset_writer(
         self,

--- a/nemo_curator/stages/deduplication/semantic/kmeans.py
+++ b/nemo_curator/stages/deduplication/semantic/kmeans.py
@@ -37,7 +37,13 @@ from .utils import (
     get_array_from_df,
     read_parquet_file_info,
 )
-from .write_utils import ConcurrentParquetWriters, LocalPartitionedParquetWriter, RollingParquetWriter, local_path
+from .write_utils import (
+    ConcurrentParquetWriters,
+    LocalPartitionedParquetWriter,
+    RollingParquetWriter,
+    WriteMemoryBudget,
+    local_path,
+)
 
 if TYPE_CHECKING:
     import cudf
@@ -341,6 +347,7 @@ class KMeansReadFitWriteStage(ProcessingStage[FileGroupTask, EmptyTask], Dedupli
             # benchmarks; a fourth only increased memory pressure. Each lane
             # sizes batches from live free memory, leaving fit sizing unchanged.
             write_lanes = LocalPartitionedParquetWriter.WRITE_LANES
+            memory_budget = WriteMemoryBudget(write_lanes)
             supported_kwargs = {"compression", "statistics"}
             unsupported = set(self.write_kwargs).difference(supported_kwargs)
             if unsupported:
@@ -353,6 +360,7 @@ class KMeansReadFitWriteStage(ProcessingStage[FileGroupTask, EmptyTask], Dedupli
                     n_partitions=self.n_clusters,
                     max_rows_per_partition=max_rows_per_partition,
                     write_kwargs=self.write_kwargs,
+                    memory_budget=memory_budget,
                 ),
                 max_lanes=write_lanes,
             )

--- a/nemo_curator/stages/deduplication/semantic/kmeans.py
+++ b/nemo_curator/stages/deduplication/semantic/kmeans.py
@@ -337,6 +337,10 @@ class KMeansReadFitWriteStage(ProcessingStage[FileGroupTask, EmptyTask], Dedupli
             raise ValueError(msg)
         output_path = local_path(self.output_path, self.output_storage_options)
         if output_path is not None:
+            # Three lanes saturated the target distributed filesystem in
+            # benchmarks; a fourth only increased memory pressure. Each lane
+            # sizes batches from live free memory, leaving fit sizing unchanged.
+            write_lanes = LocalPartitionedParquetWriter.WRITE_LANES
             supported_kwargs = {"compression", "statistics"}
             unsupported = set(self.write_kwargs).difference(supported_kwargs)
             if unsupported:
@@ -349,7 +353,8 @@ class KMeansReadFitWriteStage(ProcessingStage[FileGroupTask, EmptyTask], Dedupli
                     n_partitions=self.n_clusters,
                     max_rows_per_partition=max_rows_per_partition,
                     write_kwargs=self.write_kwargs,
-                )
+                ),
+                max_lanes=write_lanes,
             )
         return ConcurrentParquetWriters(
             lambda lane_index: RollingParquetWriter(

--- a/nemo_curator/stages/deduplication/semantic/kmeans.py
+++ b/nemo_curator/stages/deduplication/semantic/kmeans.py
@@ -239,9 +239,13 @@ class KMeansReadFitWriteStage(ProcessingStage[FileGroupTask, EmptyTask], Dedupli
                     centroids,
                 )
                 predicted_rows += len(metadata)
+            # In-flight writer frames keep their own shallow references. Drop
+            # the original metadata as soon as it has been handed off so
+            # completed writes release it while the remaining lanes drain.
+            sampled_chunks.clear()
+            del metadata, sampled_chunks
             writers.flush()
 
-            sampled_chunks.clear()
             del fit_embeddings, fit_labels
             gc.collect()
             cp.get_default_memory_pool().free_all_blocks()

--- a/nemo_curator/stages/deduplication/semantic/kmeans.py
+++ b/nemo_curator/stages/deduplication/semantic/kmeans.py
@@ -351,6 +351,8 @@ class KMeansReadFitWriteStage(ProcessingStage[FileGroupTask, EmptyTask], Dedupli
         try:
             return self._read_group(group, columns), False
         except MemoryError:
+            # TODO(https://github.com/NVIDIA/cudf/issues/23502): Remove this backpressure once
+            # partitioned writes no longer materialize an additional device-sized table.
             # A partitioned write temporarily holds a grouped copy of its input. If that leaves
             # too little room for the next read, finish the write and retry the same group once.
             logger.warning("Waiting for the in-flight Parquet write before retrying a prediction read")

--- a/nemo_curator/stages/deduplication/semantic/kmeans.py
+++ b/nemo_curator/stages/deduplication/semantic/kmeans.py
@@ -37,7 +37,7 @@ from .utils import (
     get_array_from_df,
     read_parquet_file_info,
 )
-from .write_utils import ConcurrentParquetWriters, RollingParquetWriter
+from .write_utils import ConcurrentParquetWriters, LocalPartitionedParquetWriter, RollingParquetWriter, local_path
 
 if TYPE_CHECKING:
     import cudf
@@ -274,6 +274,8 @@ class KMeansReadFitWriteStage(ProcessingStage[FileGroupTask, EmptyTask], Dedupli
                 "kmeans_write_lane_count": writers.lane_count,
                 "kmeans_write_batch_rows": writers.batch_rows,
                 "kmeans_write_batch_bytes": writers.batch_bytes,
+                "kmeans_write_batch_count": writers.batch_count,
+                "kmeans_write_group_count": writers.group_count,
                 "kmeans_read_backpressure_count": read_backpressure_count,
                 "num_rows": total_rows,
             }
@@ -333,6 +335,22 @@ class KMeansReadFitWriteStage(ProcessingStage[FileGroupTask, EmptyTask], Dedupli
         if max_rows_per_partition < 1:
             msg = f"Embedding width {embedding_width} exceeds cuDF's column-size limit"
             raise ValueError(msg)
+        output_path = local_path(self.output_path, self.output_storage_options)
+        if output_path is not None:
+            supported_kwargs = {"compression", "statistics"}
+            unsupported = set(self.write_kwargs).difference(supported_kwargs)
+            if unsupported:
+                msg = f"Incremental KMeans output does not support write kwargs {sorted(unsupported)}"
+                raise ValueError(msg)
+            return ConcurrentParquetWriters(
+                lambda lane_index: LocalPartitionedParquetWriter(
+                    output_path=output_path,
+                    file_name_prefix=f"{tasks[0].task_id}_lane{lane_index}",
+                    n_partitions=self.n_clusters,
+                    max_rows_per_partition=max_rows_per_partition,
+                    write_kwargs=self.write_kwargs,
+                )
+            )
         return ConcurrentParquetWriters(
             lambda lane_index: RollingParquetWriter(
                 create_writer=lambda generation: self._create_dataset_writer(tasks, lane_index, generation),

--- a/nemo_curator/stages/deduplication/semantic/write_utils.py
+++ b/nemo_curator/stages/deduplication/semantic/write_utils.py
@@ -16,8 +16,10 @@ import itertools
 import math
 import os
 import time
-from collections.abc import Callable
+from collections.abc import Callable, Iterator
 from concurrent.futures import Future, ThreadPoolExecutor
+from contextlib import contextmanager
+from threading import Lock
 from typing import TYPE_CHECKING, Protocol
 
 import cupy as cp
@@ -135,19 +137,21 @@ class LocalPartitionedParquetWriter:
     # TODO(https://github.com/NVIDIA/cudf/issues/23502): Use cuDF's partitioned
     # writer once it can bound the grouped copy and encoder buffers itself.
 
-    def __init__(
+    def __init__(  # noqa: PLR0913
         self,
         output_path: str,
         file_name_prefix: str,
         n_partitions: int,
         max_rows_per_partition: int,
         write_kwargs: dict,
+        memory_budget: "WriteMemoryBudget",
     ) -> None:
         self._output_path = output_path
         self._file_name_prefix = file_name_prefix
         self._n_partitions = n_partitions
         self._max_rows_per_partition = max_rows_per_partition
         self._write_kwargs = write_kwargs
+        self._memory_budget = memory_budget
         self._ranges: list[tuple[int, int]] = []
         self._writers: list[ParquetWriter | None] = []
         self._generations: list[int] = []
@@ -155,14 +159,6 @@ class LocalPartitionedParquetWriter:
         self.batch_count = 0
         self.batch_rows = 0
         self.batch_bytes = 0
-
-    def _rows_per_batch(self, frame_rows: int, frame_bytes: int) -> int:
-        free_bytes = cp.cuda.runtime.memGetInfo()[0]
-        # The source frame is already resident and therefore excluded from
-        # free_bytes. Divide the remaining memory between writer lanes; each
-        # lane then bounds its gathered table and two encoder buffers.
-        available = max(1, free_bytes // self.WRITE_LANES)
-        return max(1, min(frame_rows, frame_rows * available // max(1, 3 * frame_bytes)))
 
     def _initialize_ranges(self, counts: np.ndarray, rows_per_batch: int) -> None:
         requested = min(self._n_partitions, math.ceil(counts.sum() / rows_per_batch))
@@ -190,44 +186,45 @@ class LocalPartitionedParquetWriter:
         labels = frame[self._PARTITION_COLUMN].values
         counts = cp.asnumpy(cp.bincount(labels, minlength=self._n_partitions))
         frame_bytes = int(frame.memory_usage(deep=True).sum())
-        rows_per_batch = self._rows_per_batch(len(frame), frame_bytes)
-        if not self._ranges:
-            self._initialize_ranges(counts, rows_per_batch)
+        with self._memory_budget.claim(len(frame), frame_bytes) as rows_per_batch:
+            if not self._ranges:
+                self._initialize_ranges(counts, rows_per_batch)
 
-        order = labels.argsort()
-        offsets = np.concatenate(([0], np.cumsum(counts)))
-        for range_index, (first, last) in enumerate(self._ranges):
-            range_counts = counts[first:last]
-            if range_counts.max(initial=0) == 0:
-                continue
-            if np.any(
-                (self._rows[first:last] > 0) & (self._rows[first:last] + range_counts > self._max_rows_per_partition)
-            ):
-                if self._writers[range_index] is not None:
-                    self._writers[range_index].close()
-                self._writers[range_index] = None
-                self._generations[range_index] += 1
-                self._rows[first:last] = 0
+            order = labels.argsort()
+            offsets = np.concatenate(([0], np.cumsum(counts)))
+            for range_index, (first, last) in enumerate(self._ranges):
+                range_counts = counts[first:last]
+                if range_counts.max(initial=0) == 0:
+                    continue
+                if np.any(
+                    (self._rows[first:last] > 0)
+                    & (self._rows[first:last] + range_counts > self._max_rows_per_partition)
+                ):
+                    if self._writers[range_index] is not None:
+                        self._writers[range_index].close()
+                    self._writers[range_index] = None
+                    self._generations[range_index] += 1
+                    self._rows[first:last] = 0
 
-            writer = self._writers[range_index]
-            if writer is None:
-                writer = self._writers[range_index] = self._create_writer(range_index)
-            range_start, range_stop = int(offsets[first]), int(offsets[last])
-            for start in range(range_start, range_stop, rows_per_batch):
-                stop = min(start + rows_per_batch, range_stop)
-                batch = frame.take(order[start:stop]).drop(columns=self._PARTITION_COLUMN)
-                partition_info = [
-                    (
-                        max(int(offsets[partition]), start) - start,
-                        max(0, min(int(offsets[partition + 1]), stop) - max(int(offsets[partition]), start)),
-                    )
-                    for partition in range(first, last)
-                ]
-                writer.write_table(batch, partition_info)
-                self.batch_count += 1
-                self.batch_rows = max(self.batch_rows, len(batch))
-                self.batch_bytes = max(self.batch_bytes, frame_bytes * len(batch) // len(frame))
-            self._rows[first:last] += range_counts
+                writer = self._writers[range_index]
+                if writer is None:
+                    writer = self._writers[range_index] = self._create_writer(range_index)
+                range_start, range_stop = int(offsets[first]), int(offsets[last])
+                for start in range(range_start, range_stop, rows_per_batch):
+                    stop = min(start + rows_per_batch, range_stop)
+                    batch = frame.take(order[start:stop]).drop(columns=self._PARTITION_COLUMN)
+                    partition_info = [
+                        (
+                            max(int(offsets[partition]), start) - start,
+                            max(0, min(int(offsets[partition + 1]), stop) - max(int(offsets[partition]), start)),
+                        )
+                        for partition in range(first, last)
+                    ]
+                    writer.write_table(batch, partition_info)
+                    self.batch_count += 1
+                    self.batch_rows = max(self.batch_rows, len(batch))
+                    self.batch_bytes = max(self.batch_bytes, frame_bytes * len(batch) // len(frame))
+                self._rows[first:last] += range_counts
 
     def close(self) -> None:
         for writer in self._writers:
@@ -237,6 +234,50 @@ class LocalPartitionedParquetWriter:
     @property
     def group_count(self) -> int:
         return len(self._ranges)
+
+
+class WriteMemoryBudget:
+    """Coordinate transient device memory across concurrent Parquet writers."""
+
+    # TODO(https://github.com/NVIDIA/cudf/issues/23502): Replace this upper
+    # bound when cuDF exposes or internally bounds partitioned-write memory.
+    _BYTES_PER_INPUT_BYTE = 5
+
+    def __init__(self, max_lanes: int) -> None:
+        free_bytes, total_bytes = cp.cuda.runtime.memGetInfo()
+        # Writing should not need a larger device allocation than the data it
+        # is draining. When fit already occupies most of the GPU, free memory
+        # naturally becomes the tighter bound.
+        self._capacity = min(free_bytes, total_bytes - free_bytes)
+        self._max_lanes = max_lanes
+        self._reserved = 0
+        self._active = 0
+        self._lock = Lock()
+
+    @contextmanager
+    def claim(self, frame_rows: int, frame_bytes: int) -> Iterator[int]:
+        with self._lock:
+            free_bytes = cp.cuda.runtime.memGetInfo()[0]
+            remaining = min(self._capacity - self._reserved, free_bytes - self._reserved)
+            lanes_left = self._max_lanes - self._active
+            available = max(1, remaining // max(1, lanes_left))
+            # The input size comes from the complete runtime schema, including
+            # variable-width metadata. The multiplier also covers the grouped
+            # table, encoder buffers, and state retained by persistent writers.
+            multiplier = self._BYTES_PER_INPUT_BYTE
+            rows = max(1, min(frame_rows, frame_rows * available // max(1, multiplier * frame_bytes)))
+            reservation = max(1, multiplier * frame_bytes * rows // frame_rows)
+            if reservation > remaining:
+                msg = f"Insufficient GPU memory for one Parquet row: need {reservation} bytes, have {remaining}"
+                raise MemoryError(msg)
+            self._reserved += reservation
+            self._active += 1
+        try:
+            yield rows
+        finally:
+            with self._lock:
+                self._reserved -= reservation
+                self._active -= 1
 
 
 class _WriterLane:

--- a/nemo_curator/stages/deduplication/semantic/write_utils.py
+++ b/nemo_curator/stages/deduplication/semantic/write_utils.py
@@ -166,8 +166,8 @@ class ConcurrentParquetWriters:
         if not len(frame):
             return
         self.flush()
-        self._batch_rows = len(frame)
-        self._batch_bytes = self._frame_bytes(frame)
+        self._batch_rows = max(self._batch_rows, len(frame))
+        self._batch_bytes = max(self._batch_bytes, self._frame_bytes(frame))
         (self._lanes[0] if self._lanes else self._new_lane()).submit(frame)
 
     def flush(self) -> None:

--- a/nemo_curator/stages/deduplication/semantic/write_utils.py
+++ b/nemo_curator/stages/deduplication/semantic/write_utils.py
@@ -12,17 +12,40 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import itertools
+import math
+import os
 import time
 from collections.abc import Callable
 from concurrent.futures import Future, ThreadPoolExecutor
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Protocol
 
 import cupy as cp
 import numpy as np
-from cudf.io.parquet import ParquetDatasetWriter
+from cudf.io.parquet import ParquetDatasetWriter, ParquetWriter
+from fsspec.core import url_to_fs
+from fsspec.implementations.local import LocalFileSystem
 
 if TYPE_CHECKING:
     import cudf
+
+
+class PartitionedParquetWriter(Protocol):
+    batch_count: int
+    batch_rows: int
+    batch_bytes: int
+
+    @property
+    def group_count(self) -> int: ...
+
+    def write_table(self, frame: "cudf.DataFrame") -> None: ...
+
+    def close(self) -> None: ...
+
+
+def local_path(path: str, storage_options: dict | None) -> str | None:
+    fs, resolved = url_to_fs(path, **(storage_options or {}))
+    return resolved if isinstance(fs, LocalFileSystem) else None
 
 
 def interval_wall_time(intervals: list[tuple[float, float]]) -> float:
@@ -59,6 +82,9 @@ class RollingParquetWriter:
         self._generation = np.zeros(n_partitions, dtype=np.int64)
         self._rows = np.zeros(n_partitions, dtype=np.int64)
         self._target = max_rows_per_partition
+        self.batch_count = 0
+        self.batch_rows = 0
+        self.batch_bytes = 0
 
     def _writer(self, generation: int) -> ParquetDatasetWriter:
         if generation not in self._writers:
@@ -73,6 +99,10 @@ class RollingParquetWriter:
             for start in range(0, len(frame), rows):
                 self.write_table(frame.iloc[start : start + rows])
             return
+
+        self.batch_count += 1
+        self.batch_rows = max(self.batch_rows, len(frame))
+        self.batch_bytes = max(self.batch_bytes, int(frame.memory_usage(deep=True).sum()))
 
         present = counts > 0
         roll = present & (self._rows > 0) & (self._rows + counts > self._target)
@@ -91,13 +121,130 @@ class RollingParquetWriter:
         for writer in self._writers.values():
             writer.close()
 
+    @property
+    def group_count(self) -> int:
+        return len(self._writers)
+
+
+class LocalPartitionedParquetWriter:
+    """Write bounded centroid ranges without cuDF's full-frame partition copy."""
+
+    _PARTITION_COLUMN = "centroid"
+
+    # TODO(https://github.com/NVIDIA/cudf/issues/23502): Use cuDF's partitioned
+    # writer once it can bound the grouped copy and encoder buffers itself.
+
+    def __init__(
+        self,
+        output_path: str,
+        file_name_prefix: str,
+        n_partitions: int,
+        max_rows_per_partition: int,
+        write_kwargs: dict,
+    ) -> None:
+        self._output_path = output_path
+        self._file_name_prefix = file_name_prefix
+        self._n_partitions = n_partitions
+        self._max_rows_per_partition = max_rows_per_partition
+        self._write_kwargs = write_kwargs
+        self._ranges: list[tuple[int, int]] = []
+        self._writers: list[ParquetWriter | None] = []
+        self._generations: list[int] = []
+        self._rows = np.zeros(n_partitions, dtype=np.int64)
+        self.batch_count = 0
+        self.batch_rows = 0
+        self.batch_bytes = 0
+
+    @staticmethod
+    def _rows_per_batch(frame_rows: int, frame_bytes: int) -> int:
+        free_bytes = cp.cuda.runtime.memGetInfo()[0]
+        # A direct partition write holds the gathered batch plus cuDF's
+        # uncompressed and maximum-compressed encoder buffers. Reserving one
+        # input-sized buffer leaves room for the next prediction read.
+        available = max(1, free_bytes - frame_bytes)
+        return max(1, min(frame_rows, frame_rows * available // max(1, 3 * frame_bytes)))
+
+    def _initialize_ranges(self, counts: np.ndarray, rows_per_batch: int) -> None:
+        requested = min(self._n_partitions, math.ceil(counts.sum() / rows_per_batch))
+        cumulative = np.cumsum(counts)
+        boundaries = [0]
+        for target in np.linspace(0, counts.sum(), requested + 1, dtype=np.int64)[1:-1]:
+            boundaries.append(int(np.searchsorted(cumulative, target, side="right")))
+        boundaries.append(self._n_partitions)
+        boundaries = list(dict.fromkeys(boundaries))
+        self._ranges = list(itertools.pairwise(boundaries))
+        self._writers = [None] * len(self._ranges)
+        self._generations = [0] * len(self._ranges)
+
+    def _create_writer(self, range_index: int) -> ParquetWriter:
+        first, last = self._ranges[range_index]
+        generation = self._generations[range_index]
+        paths = []
+        for partition in range(first, last):
+            directory = os.path.join(self._output_path, f"{self._PARTITION_COLUMN}={partition}")
+            os.makedirs(directory, exist_ok=True)
+            paths.append(os.path.join(directory, f"{self._file_name_prefix}_{generation}.parquet"))
+        return ParquetWriter(paths, index=False, **self._write_kwargs)
+
+    def write_table(self, frame: "cudf.DataFrame") -> None:
+        labels = frame[self._PARTITION_COLUMN].values
+        counts = cp.asnumpy(cp.bincount(labels, minlength=self._n_partitions))
+        frame_bytes = int(frame.memory_usage(deep=True).sum())
+        rows_per_batch = self._rows_per_batch(len(frame), frame_bytes)
+        if not self._ranges:
+            self._initialize_ranges(counts, rows_per_batch)
+
+        order = labels.argsort()
+        offsets = np.concatenate(([0], np.cumsum(counts)))
+        for range_index, (first, last) in enumerate(self._ranges):
+            range_counts = counts[first:last]
+            if range_counts.max(initial=0) == 0:
+                continue
+            if np.any(
+                (self._rows[first:last] > 0) & (self._rows[first:last] + range_counts > self._max_rows_per_partition)
+            ):
+                if self._writers[range_index] is not None:
+                    self._writers[range_index].close()
+                self._writers[range_index] = None
+                self._generations[range_index] += 1
+                self._rows[first:last] = 0
+
+            writer = self._writers[range_index]
+            if writer is None:
+                writer = self._writers[range_index] = self._create_writer(range_index)
+            range_start, range_stop = int(offsets[first]), int(offsets[last])
+            for start in range(range_start, range_stop, rows_per_batch):
+                stop = min(start + rows_per_batch, range_stop)
+                batch = frame.take(order[start:stop]).drop(columns=self._PARTITION_COLUMN)
+                partition_info = [
+                    (
+                        max(int(offsets[partition]), start) - start,
+                        max(0, min(int(offsets[partition + 1]), stop) - max(int(offsets[partition]), start)),
+                    )
+                    for partition in range(first, last)
+                ]
+                writer.write_table(batch, partition_info)
+                self.batch_count += 1
+                self.batch_rows = max(self.batch_rows, len(batch))
+                self.batch_bytes = max(self.batch_bytes, frame_bytes * len(batch) // len(frame))
+            self._rows[first:last] += range_counts
+
+    def close(self) -> None:
+        for writer in self._writers:
+            if writer is not None:
+                writer.close()
+
+    @property
+    def group_count(self) -> int:
+        return len(self._ranges)
+
 
 class _WriterLane:
-    def __init__(self, create_writer: Callable[[], RollingParquetWriter], lane_index: int) -> None:
+    def __init__(self, create_writer: Callable[[], PartitionedParquetWriter], lane_index: int) -> None:
         self._create_writer = create_writer
         self._executor = ThreadPoolExecutor(max_workers=1, thread_name_prefix=f"parquet-writer-{lane_index}")
         self._future: Future[None] | None = None
-        self._writer: RollingParquetWriter | None = None
+        self._writer: PartitionedParquetWriter | None = None
         self.intervals: list[tuple[float, float]] = []
 
     def _write(self, frame: "cudf.DataFrame") -> None:
@@ -142,16 +289,10 @@ class ConcurrentParquetWriters:
 
     def __init__(
         self,
-        create_writer: Callable[[int], RollingParquetWriter],
+        create_writer: Callable[[int], PartitionedParquetWriter],
     ) -> None:
         self._create_writer = create_writer
         self._lanes: list[_WriterLane] = []
-        self._batch_rows = 0
-        self._batch_bytes = 0
-
-    @staticmethod
-    def _frame_bytes(frame: "cudf.DataFrame") -> int:
-        return int(frame.memory_usage(deep=True).sum())
 
     def _new_lane(self) -> _WriterLane:
         lane_index = len(self._lanes)
@@ -166,8 +307,6 @@ class ConcurrentParquetWriters:
         if not len(frame):
             return
         self.flush()
-        self._batch_rows = max(self._batch_rows, len(frame))
-        self._batch_bytes = max(self._batch_bytes, self._frame_bytes(frame))
         (self._lanes[0] if self._lanes else self._new_lane()).submit(frame)
 
     def flush(self) -> None:
@@ -198,8 +337,16 @@ class ConcurrentParquetWriters:
 
     @property
     def batch_rows(self) -> int:
-        return self._batch_rows
+        return max((lane._writer.batch_rows for lane in self._lanes if lane._writer is not None), default=0)
 
     @property
     def batch_bytes(self) -> int:
-        return self._batch_bytes
+        return max((lane._writer.batch_bytes for lane in self._lanes if lane._writer is not None), default=0)
+
+    @property
+    def batch_count(self) -> int:
+        return sum(lane._writer.batch_count for lane in self._lanes if lane._writer is not None)
+
+    @property
+    def group_count(self) -> int:
+        return sum(lane._writer.group_count for lane in self._lanes if lane._writer is not None)

--- a/nemo_curator/stages/deduplication/semantic/write_utils.py
+++ b/nemo_curator/stages/deduplication/semantic/write_utils.py
@@ -1,0 +1,205 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import time
+from collections.abc import Callable
+from concurrent.futures import Future, ThreadPoolExecutor
+from typing import TYPE_CHECKING
+
+import cupy as cp
+import numpy as np
+from cudf.io.parquet import ParquetDatasetWriter
+
+if TYPE_CHECKING:
+    import cudf
+
+
+def interval_wall_time(intervals: list[tuple[float, float]]) -> float:
+    intervals = sorted(intervals)
+    if not intervals:
+        return 0.0
+    wall_time = 0.0
+    start, stop = intervals[0]
+    for next_start, next_stop in intervals[1:]:
+        if next_start > stop:
+            wall_time += stop - start
+            start, stop = next_start, next_stop
+        else:
+            stop = max(stop, next_stop)
+    return wall_time + stop - start
+
+
+class RollingParquetWriter:
+    """Keep each partition's list child below cuDF's column-size limit."""
+
+    # TODO(https://github.com/NVIDIA/cudf/issues/23378): Remove logical rollover
+    # once the fix is available in our cuDF pin.
+
+    def __init__(
+        self,
+        create_writer: Callable[[int], ParquetDatasetWriter],
+        n_partitions: int,
+        max_rows_per_partition: int,
+        partition_column: str,
+    ) -> None:
+        self._create_writer = create_writer
+        self._partition_column = partition_column
+        self._writers: dict[int, ParquetDatasetWriter] = {}
+        self._generation = np.zeros(n_partitions, dtype=np.int64)
+        self._rows = np.zeros(n_partitions, dtype=np.int64)
+        self._target = max_rows_per_partition
+
+    def _writer(self, generation: int) -> ParquetDatasetWriter:
+        if generation not in self._writers:
+            self._writers[generation] = self._create_writer(generation)
+        return self._writers[generation]
+
+    def write_table(self, frame: "cudf.DataFrame") -> None:
+        counts = cp.asnumpy(cp.bincount(frame[self._partition_column].values, minlength=len(self._generation)))
+        if counts.max(initial=0) > self._target:
+            slices = int(np.ceil(counts.max() / self._target))
+            rows = int(np.ceil(len(frame) / slices))
+            for start in range(0, len(frame), rows):
+                self.write_table(frame.iloc[start : start + rows])
+            return
+
+        present = counts > 0
+        roll = present & (self._rows > 0) & (self._rows + counts > self._target)
+        self._generation[roll] += 1
+        self._rows[roll] = 0
+        generations = np.unique(self._generation[present])
+        if len(generations) == 1:
+            self._writer(int(generations[0])).write_table(frame)
+        else:
+            row_generations = cp.asarray(self._generation)[frame[self._partition_column].values]
+            for generation in generations:
+                self._writer(int(generation)).write_table(frame[row_generations == generation])
+        self._rows += counts
+
+    def close(self) -> None:
+        for writer in self._writers.values():
+            writer.close()
+
+
+class _WriterLane:
+    def __init__(self, create_writer: Callable[[], RollingParquetWriter], lane_index: int) -> None:
+        self._create_writer = create_writer
+        self._executor = ThreadPoolExecutor(max_workers=1, thread_name_prefix=f"parquet-writer-{lane_index}")
+        self._future: Future[None] | None = None
+        self._writer: RollingParquetWriter | None = None
+        self.intervals: list[tuple[float, float]] = []
+
+    def _write(self, frame: "cudf.DataFrame") -> None:
+        started = time.perf_counter()
+        try:
+            if self._writer is None:
+                self._writer = self._create_writer()
+            self._writer.write_table(frame)
+        finally:
+            self.intervals.append((started, time.perf_counter()))
+
+    def submit(self, frame: "cudf.DataFrame") -> None:
+        if self._future is not None:
+            msg = "Cannot submit to a busy Parquet writer lane"
+            raise RuntimeError(msg)
+        self._future = self._executor.submit(self._write, frame)
+
+    def wait(self) -> None:
+        if self._future is not None:
+            try:
+                self._future.result()
+            finally:
+                self._future = None
+
+    def close(self) -> None:
+        error: Exception | None = None
+        try:
+            self.wait()
+        except Exception as exc:  # noqa: BLE001
+            error = exc
+        try:
+            if self._writer is not None:
+                self._executor.submit(self._writer.close).result()
+        finally:
+            self._executor.shutdown()
+        if error is not None:
+            raise error
+
+
+class ConcurrentParquetWriters:
+    """Overlap one whole-frame Parquet write with preparation of the next frame."""
+
+    def __init__(
+        self,
+        create_writer: Callable[[int], RollingParquetWriter],
+    ) -> None:
+        self._create_writer = create_writer
+        self._lanes: list[_WriterLane] = []
+        self._batch_rows = 0
+        self._batch_bytes = 0
+
+    @staticmethod
+    def _frame_bytes(frame: "cudf.DataFrame") -> int:
+        return int(frame.memory_usage(deep=True).sum())
+
+    def _new_lane(self) -> _WriterLane:
+        lane_index = len(self._lanes)
+        lane = _WriterLane(
+            lambda lane_index=lane_index: self._create_writer(lane_index),
+            lane_index,
+        )
+        self._lanes.append(lane)
+        return lane
+
+    def submit(self, frame: "cudf.DataFrame") -> None:
+        if not len(frame):
+            return
+        self.flush()
+        self._batch_rows = len(frame)
+        self._batch_bytes = self._frame_bytes(frame)
+        (self._lanes[0] if self._lanes else self._new_lane()).submit(frame)
+
+    def flush(self) -> None:
+        for lane in self._lanes:
+            lane.wait()
+
+    def close(self) -> None:
+        first_error: Exception | None = None
+        for lane in self._lanes:
+            try:
+                lane.close()
+            except Exception as exc:  # noqa: BLE001
+                first_error = first_error or exc
+        if first_error is not None:
+            raise first_error
+
+    @property
+    def write_work_time(self) -> float:
+        return sum(stop - start for lane in self._lanes for start, stop in lane.intervals)
+
+    @property
+    def write_wall_time(self) -> float:
+        return interval_wall_time([interval for lane in self._lanes for interval in lane.intervals])
+
+    @property
+    def lane_count(self) -> int:
+        return len(self._lanes)
+
+    @property
+    def batch_rows(self) -> int:
+        return self._batch_rows
+
+    @property
+    def batch_bytes(self) -> int:
+        return self._batch_bytes

--- a/nemo_curator/stages/deduplication/semantic/write_utils.py
+++ b/nemo_curator/stages/deduplication/semantic/write_utils.py
@@ -130,6 +130,7 @@ class LocalPartitionedParquetWriter:
     """Write bounded centroid ranges without cuDF's full-frame partition copy."""
 
     _PARTITION_COLUMN = "centroid"
+    WRITE_LANES = 3
 
     # TODO(https://github.com/NVIDIA/cudf/issues/23502): Use cuDF's partitioned
     # writer once it can bound the grouped copy and encoder buffers itself.
@@ -155,13 +156,12 @@ class LocalPartitionedParquetWriter:
         self.batch_rows = 0
         self.batch_bytes = 0
 
-    @staticmethod
-    def _rows_per_batch(frame_rows: int, frame_bytes: int) -> int:
+    def _rows_per_batch(self, frame_rows: int, frame_bytes: int) -> int:
         free_bytes = cp.cuda.runtime.memGetInfo()[0]
-        # A direct partition write holds the gathered batch plus cuDF's
-        # uncompressed and maximum-compressed encoder buffers. Reserving one
-        # input-sized buffer leaves room for the next prediction read.
-        available = max(1, free_bytes - frame_bytes)
+        # The source frame is already resident and therefore excluded from
+        # free_bytes. Divide the remaining memory between writer lanes; each
+        # lane then bounds its gathered table and two encoder buffers.
+        available = max(1, free_bytes // self.WRITE_LANES)
         return max(1, min(frame_rows, frame_rows * available // max(1, 3 * frame_bytes)))
 
     def _initialize_ranges(self, counts: np.ndarray, rows_per_batch: int) -> None:
@@ -262,6 +262,14 @@ class _WriterLane:
             raise RuntimeError(msg)
         self._future = self._executor.submit(self._write, frame)
 
+    def is_available(self) -> bool:
+        if self._future is None:
+            return True
+        if not self._future.done():
+            return False
+        self.wait()
+        return True
+
     def wait(self) -> None:
         if self._future is not None:
             try:
@@ -285,13 +293,15 @@ class _WriterLane:
 
 
 class ConcurrentParquetWriters:
-    """Overlap one whole-frame Parquet write with preparation of the next frame."""
+    """Keep a small number of persistent Parquet writers busy concurrently."""
 
     def __init__(
         self,
         create_writer: Callable[[int], PartitionedParquetWriter],
+        max_lanes: int = 1,
     ) -> None:
         self._create_writer = create_writer
+        self._max_lanes = max_lanes
         self._lanes: list[_WriterLane] = []
 
     def _new_lane(self) -> _WriterLane:
@@ -306,8 +316,20 @@ class ConcurrentParquetWriters:
     def submit(self, frame: "cudf.DataFrame") -> None:
         if not len(frame):
             return
-        self.flush()
-        (self._lanes[0] if self._lanes else self._new_lane()).submit(frame)
+
+        for lane in self._lanes:
+            if lane.is_available():
+                lane.submit(frame)
+                return
+
+        if len(self._lanes) < self._max_lanes:
+            self._new_lane().submit(frame)
+            return
+
+        # Reusing the oldest lane bounds the number of resident input frames.
+        lane = self._lanes[0]
+        lane.wait()
+        lane.submit(frame)
 
     def flush(self) -> None:
         for lane in self._lanes:

--- a/tests/stages/deduplication/semantic/test_kmeans.py
+++ b/tests/stages/deduplication/semantic/test_kmeans.py
@@ -452,6 +452,20 @@ class TestKMeansReadFitWriteStage:
         with pytest.raises(ValueError, match="Only jsonl and parquet are supported"):
             stage.process_batch([FileGroupTask(dataset_name="test", data=["input.csv"])])
 
+    def test_prediction_read_waits_for_writer_after_oom(self, make_stage: "KMeansReadFitWriteStage") -> None:
+        """A read that collides with an in-flight write is retried after that write releases memory."""
+        stage = make_stage()
+        frame = cudf.DataFrame({"id": [1]})
+        stage._read_group = Mock(side_effect=[MemoryError, frame])
+        writers = Mock()
+
+        result, was_backpressured = stage._read_prediction_group(["input.parquet"], ["id"], writers)
+
+        assert result is frame
+        assert was_backpressured
+        assert stage._read_group.call_count == 2
+        writers.flush.assert_called_once_with()
+
     def test_assign_distances(self):
         """Test _assign_distances method computes L2 and cosine distances correctly."""
         df = cudf.DataFrame(

--- a/tests/stages/deduplication/semantic/test_kmeans.py
+++ b/tests/stages/deduplication/semantic/test_kmeans.py
@@ -303,7 +303,7 @@ class TestKMeansStageIntegration:
         """Output files are written with deterministic, input-derived names and
         partitioned by centroid.
 
-        Each frame uses ``{input_task_id}_{frame_index}.parquet`` where
+        Writer lanes use ``{input_task_id}_lane{lane}_{generation}.parquet`` where
         the input task id is the FilePartitioning id (``0_<file_hash>``).
         We assert the names match that deterministic pattern (never a random
         ``r<uuid>`` fallback) and that the centroid partitioning is correct.
@@ -323,12 +323,15 @@ class TestKMeansStageIntegration:
 
         # Bounded reads may produce multiple frames per actor, but every name must retain input ancestry.
         assert actual_filenames
-        deterministic_name = re.compile(r"^0_[0-9a-f]+_\d+\.parquet$")
+        deterministic_name = re.compile(r"^0_[0-9a-f]+_lane(?P<lane>\d+)_(?P<generation>\d+)\.parquet$")
         for name in actual_filenames:
-            assert deterministic_name.match(name), (
+            match = deterministic_name.match(name)
+            assert match, (
                 f"Output filename {name!r} is not deterministic/input-derived "
                 f"(an 'r<uuid>' name would mean ancestry was lost)"
             )
+            assert int(match.group("lane")) >= 0
+            assert int(match.group("generation")) >= 0
 
         # Exactly N_CLUSTERS centroid partitions.
         assert len(centroid_dirs) == N_CLUSTERS, (

--- a/tests/stages/deduplication/semantic/test_write_utils.py
+++ b/tests/stages/deduplication/semantic/test_write_utils.py
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 from pathlib import Path
-from threading import Event, Lock
+from threading import Barrier, Event, Lock
 
 import pytest
 
@@ -94,18 +94,20 @@ def test_rolling_writer_limits_rows_per_partition() -> None:
 
 
 @pytest.mark.gpu
-def test_concurrent_writer_hands_frame_to_background_thread() -> None:
+def test_concurrent_writer_uses_persistent_lanes_for_overlapping_writes() -> None:
     import cudf
 
     from nemo_curator.stages.deduplication.semantic.write_utils import ConcurrentParquetWriters
 
     lock = Lock()
     release = Event()
+    started = Barrier(3)
     writers = []
 
     def create_writer(lane_index: int) -> _RecordingWriter:
         class BlockingWriter(_RecordingWriter):
             def write_table(self, frame: object) -> None:
+                started.wait(timeout=5)
                 release.wait(timeout=5)
                 super().write_table(frame)
 
@@ -114,15 +116,21 @@ def test_concurrent_writer_hands_frame_to_background_thread() -> None:
             writers.append((lane_index, writer))
         return writer
 
-    concurrent = ConcurrentParquetWriters(create_writer)
-    concurrent.submit(cudf.DataFrame({"value": [0, 1, 2, 3]}))
+    concurrent = ConcurrentParquetWriters(create_writer, max_lanes=2)
+    frame = cudf.DataFrame({"value": [0, 1, 2, 3]})
+    concurrent.submit(frame)
+    concurrent.submit(frame + 4)
+    started.wait(timeout=5)
+
+    # Neither write can finish yet, so reaching two writers proves the second
+    # submission did not quietly serialize behind the first one.
+    assert [lane for lane, _ in writers] == [0, 1]
     release.set()
     concurrent.close()
 
-    assert [lane for lane, _ in writers] == [0]
     assert 0 < concurrent.write_wall_time <= concurrent.write_work_time
     values = [frame["value"].iloc[0] for _, writer in writers for frame in writer.frames]
-    assert values == [0]
+    assert values == [0, 4]
     assert all(writer.closed for _, writer in writers)
 
 
@@ -159,7 +167,7 @@ def test_local_partitioned_writer_preserves_rows_across_bounded_writes(
     # Keep the batches deliberately tiny here. This exercises the same persistent
     # multi-sink Parquet writer used by KMeans while making both centroid ranges
     # cross a write boundary in a small test.
-    monkeypatch.setattr(LocalPartitionedParquetWriter, "_rows_per_batch", staticmethod(lambda *_: 2))
+    monkeypatch.setattr(LocalPartitionedParquetWriter, "_rows_per_batch", lambda *_: 2)
     writer = LocalPartitionedParquetWriter(
         output_path=str(tmp_path),
         file_name_prefix="part",

--- a/tests/stages/deduplication/semantic/test_write_utils.py
+++ b/tests/stages/deduplication/semantic/test_write_utils.py
@@ -1,0 +1,145 @@
+# modality: text
+
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from threading import Event, Lock
+
+import pytest
+
+
+class _RecordingWriter:
+    def __init__(self) -> None:
+        self.frames = []
+        self.closed = False
+
+    def write_table(self, frame: object) -> None:
+        self.frames.append(frame)
+
+    def close(self) -> None:
+        self.closed = True
+
+
+@pytest.mark.gpu
+def test_rolling_writer_uses_native_incremental_writer_without_rollover() -> None:
+    import cudf
+
+    from nemo_curator.stages.deduplication.semantic.write_utils import RollingParquetWriter
+
+    created = []
+
+    def create_writer(generation: int) -> _RecordingWriter:
+        writer = _RecordingWriter()
+        created.append((generation, writer))
+        return writer
+
+    writer = RollingParquetWriter(
+        create_writer,
+        n_partitions=2,
+        max_rows_per_partition=10,
+        partition_column="centroid",
+    )
+    frame = cudf.DataFrame({"centroid": [0, 1], "value": [1, 2]})
+
+    writer.write_table(frame)
+    writer.close()
+
+    assert len(created) == 1
+    assert created[0][0] == 0
+    assert created[0][1].frames == [frame]
+    assert created[0][1].closed
+
+
+@pytest.mark.gpu
+def test_rolling_writer_limits_rows_per_partition() -> None:
+    import cudf
+
+    from nemo_curator.stages.deduplication.semantic.write_utils import RollingParquetWriter
+
+    created = []
+
+    def create_writer(generation: int) -> _RecordingWriter:
+        writer = _RecordingWriter()
+        created.append((generation, writer))
+        return writer
+
+    writer = RollingParquetWriter(
+        create_writer,
+        n_partitions=2,
+        max_rows_per_partition=2,
+        partition_column="centroid",
+    )
+    writer.write_table(cudf.DataFrame({"centroid": [0, 0, 1], "value": [1, 2, 3]}))
+    writer.write_table(cudf.DataFrame({"centroid": [0, 1], "value": [4, 5]}))
+    writer.close()
+
+    assert [generation for generation, _ in created] == [0, 1]
+    for _, created_writer in created:
+        partition_counts = cudf.concat(created_writer.frames).groupby("centroid").size()
+        assert partition_counts.max() <= 2
+
+
+@pytest.mark.gpu
+def test_concurrent_writer_hands_frame_to_background_thread() -> None:
+    import cudf
+
+    from nemo_curator.stages.deduplication.semantic.write_utils import ConcurrentParquetWriters
+
+    lock = Lock()
+    release = Event()
+    writers = []
+
+    def create_writer(lane_index: int) -> _RecordingWriter:
+        class BlockingWriter(_RecordingWriter):
+            def write_table(self, frame: object) -> None:
+                release.wait(timeout=5)
+                super().write_table(frame)
+
+        writer = BlockingWriter()
+        with lock:
+            writers.append((lane_index, writer))
+        return writer
+
+    concurrent = ConcurrentParquetWriters(create_writer)
+    concurrent.submit(cudf.DataFrame({"value": [0, 1, 2, 3]}))
+    release.set()
+    concurrent.close()
+
+    assert [lane for lane, _ in writers] == [0]
+    assert 0 < concurrent.write_wall_time <= concurrent.write_work_time
+    values = [frame["value"].iloc[0] for _, writer in writers for frame in writer.frames]
+    assert values == [0]
+    assert all(writer.closed for _, writer in writers)
+
+
+@pytest.mark.gpu
+def test_concurrent_writer_preserves_variable_width_metadata() -> None:
+    import cudf
+
+    from nemo_curator.stages.deduplication.semantic.write_utils import ConcurrentParquetWriters
+
+    writers = []
+
+    def create_writer(_: int) -> _RecordingWriter:
+        writer = _RecordingWriter()
+        writers.append(writer)
+        return writer
+
+    frame = cudf.DataFrame({"value": range(8), "metadata": ["x" * size for size in range(8)]})
+    concurrent = ConcurrentParquetWriters(create_writer)
+    concurrent.submit(frame)
+    concurrent.close()
+
+    written = cudf.concat([part for writer in writers for part in writer.frames]).sort_values("value")
+    assert written.to_pandas().reset_index(drop=True).equals(frame.to_pandas())

--- a/tests/stages/deduplication/semantic/test_write_utils.py
+++ b/tests/stages/deduplication/semantic/test_write_utils.py
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from contextlib import nullcontext
 from pathlib import Path
 from threading import Barrier, Event, Lock
 
@@ -157,23 +158,45 @@ def test_concurrent_writer_preserves_variable_width_metadata() -> None:
 
 
 @pytest.mark.gpu
+def test_write_memory_budget_coordinates_concurrent_lanes(monkeypatch: pytest.MonkeyPatch) -> None:
+    import cupy as cp
+
+    from nemo_curator.stages.deduplication.semantic.write_utils import WriteMemoryBudget
+
+    monkeypatch.setattr(cp.cuda.runtime, "memGetInfo", lambda: (700, 1_000))
+    budget = WriteMemoryBudget(max_lanes=3)
+
+    # Each overlapping claim receives one share of the same 300-byte budget.
+    # This guards against every lane independently treating all free memory as
+    # its own, which only becomes visible as an OOM at production scale.
+    with (
+        budget.claim(frame_rows=100, frame_bytes=100) as first,
+        budget.claim(frame_rows=100, frame_bytes=100) as second,
+        budget.claim(frame_rows=100, frame_bytes=100) as third,
+    ):
+        assert (first, second, third) == (20, 20, 20)
+
+
+@pytest.mark.gpu
 def test_local_partitioned_writer_preserves_rows_across_bounded_writes(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     import cudf
 
-    from nemo_curator.stages.deduplication.semantic.write_utils import LocalPartitionedParquetWriter
+    from nemo_curator.stages.deduplication.semantic.write_utils import LocalPartitionedParquetWriter, WriteMemoryBudget
 
     # Keep the batches deliberately tiny here. This exercises the same persistent
     # multi-sink Parquet writer used by KMeans while making both centroid ranges
     # cross a write boundary in a small test.
-    monkeypatch.setattr(LocalPartitionedParquetWriter, "_rows_per_batch", lambda *_: 2)
+    memory_budget = WriteMemoryBudget(1)
+    monkeypatch.setattr(memory_budget, "claim", lambda *_: nullcontext(2))
     writer = LocalPartitionedParquetWriter(
         output_path=str(tmp_path),
         file_name_prefix="part",
         n_partitions=2,
         max_rows_per_partition=3,
         write_kwargs={},
+        memory_budget=memory_budget,
     )
     first = cudf.DataFrame(
         {

--- a/tests/stages/deduplication/semantic/test_write_utils.py
+++ b/tests/stages/deduplication/semantic/test_write_utils.py
@@ -81,11 +81,13 @@ def test_rolling_writer_limits_rows_per_partition() -> None:
         max_rows_per_partition=2,
         partition_column="centroid",
     )
-    writer.write_table(cudf.DataFrame({"centroid": [0, 0, 1], "value": [1, 2, 3]}))
-    writer.write_table(cudf.DataFrame({"centroid": [0, 1], "value": [4, 5]}))
+    # The first call is itself too large for centroid 0; the second call also
+    # checks that each centroid continues in the right generation afterward.
+    writer.write_table(cudf.DataFrame({"centroid": [0, 0, 0, 0, 0, 1], "value": range(6)}))
+    writer.write_table(cudf.DataFrame({"centroid": [0, 1], "value": [6, 7]}))
     writer.close()
 
-    assert [generation for generation, _ in created] == [0, 1]
+    assert [generation for generation, _ in created] == [0, 1, 2]
     for _, created_writer in created:
         partition_counts = cudf.concat(created_writer.frames).groupby("centroid").size()
         assert partition_counts.max() <= 2

--- a/tests/stages/deduplication/semantic/test_write_utils.py
+++ b/tests/stages/deduplication/semantic/test_write_utils.py
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from pathlib import Path
 from threading import Event, Lock
 
 import pytest
@@ -143,3 +144,44 @@ def test_concurrent_writer_preserves_variable_width_metadata() -> None:
 
     written = cudf.concat([part for writer in writers for part in writer.frames]).sort_values("value")
     assert written.to_pandas().reset_index(drop=True).equals(frame.to_pandas())
+
+
+@pytest.mark.gpu
+def test_local_partitioned_writer_preserves_rows_across_bounded_writes(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import cudf
+
+    from nemo_curator.stages.deduplication.semantic.write_utils import LocalPartitionedParquetWriter
+
+    # Keep the batches deliberately tiny here. This exercises the same persistent
+    # multi-sink Parquet writer used by KMeans while making both centroid ranges
+    # cross a write boundary in a small test.
+    monkeypatch.setattr(LocalPartitionedParquetWriter, "_rows_per_batch", staticmethod(lambda *_: 2))
+    writer = LocalPartitionedParquetWriter(
+        output_path=str(tmp_path),
+        file_name_prefix="part",
+        n_partitions=2,
+        max_rows_per_partition=3,
+        write_kwargs={},
+    )
+    first = cudf.DataFrame(
+        {
+            "centroid": [1, 0, 1, 0, 1, 0],
+            "value": [0, 1, 2, 3, 4, 5],
+            "metadata": ["", "x", "yy", "zzz", "w" * 4, "v" * 5],
+        }
+    )
+    second = first.copy()
+    second["value"] += len(first)
+    expected = cudf.concat([first, second], ignore_index=True)
+
+    writer.write_table(first)
+    writer.write_table(second)
+    writer.close()
+
+    actual = cudf.read_parquet(str(tmp_path)).sort_values("value").reset_index(drop=True)
+    actual["centroid"] = actual["centroid"].astype(expected["centroid"].dtype)
+    assert actual.to_pandas().equals(expected[actual.columns].to_pandas())
+    assert writer.batch_count > 1
+    assert writer.group_count == 2


### PR DESCRIPTION
## Summary

This PR explored replacing synchronous partitioned Parquet output with bounded concurrent writer lanes. The implementation:

- overlapped KMeans prediction and Parquet output
- sized write batches from live GPU memory and the complete runtime schema
- used persistent writers to accumulate output across prediction batches
- added backpressure and benchmark telemetry

It builds on the bounded reader changes merged in #2367.

## Outcome

This approach substantially reduced output file count, but the final benchmark did not show enough speed or memory improvement to justify approximately 800 lines of custom I/O and memory-scheduling code.

| Workload | Metric | Sep 4 main nightly | PR | Change |
|---|---:|---:|---:|---:|
| 20% data, 100% fit | End-to-end | 198.22 s | 201.00 s | 1.4% slower |
| | KMeans | 123.98 s | 127.97 s | 3.2% slower |
| | Write wall time | 23.09 s | 23.14 s | unchanged |
| | Pairwise input files | 3,200 | 2,400 | 25% fewer |
| 100% data, 20% fit | End-to-end | 1122.78 s | 1080.07 s | 3.8% faster |
| | KMeans | 382.16 s | 346.86 s | 9.2% faster |
| | Write wall time | 105.96 s | 155.18 s | 46.5% slower |
| | Pairwise input files | 13,600 | 2,400 | 82.4% fewer |

Peak GPU memory remained broadly comparable to main. The partial-fit end-to-end improvement and lower file count are useful results, but the write path itself did not become faster and the full-fit workload regressed slightly.

[Compare the final PR run with the September 4 main nightly](http://rratzel-ws1:5050/compare?dir_a=login-eos-nightly%3A%2Flustre%2Ffsw%2Fcoreai_dlalgo_ci%2Fcurator_ci%2Fresults%2Fmain&dir_b=login-eos-nightly%3A%2Flustre%2Ffsw%2Fcoreai_dlalgo_ci%2Fcurator_ci%2Fresults%2Fmain-mirror&run_a=nightly-2026_09_04__06_23_39_UTC&run_b=pr-2361-2026_09_04__18_07_49_UTC-b83e7277&entry=semdedup_identification_xenna_fit_data_fraction)

## Decision

Closing this prototype without merging. The reader-only improvement remains on main. The writer work can be revisited when cuDF provides a native bounded persistent partitioned writer, including correct rollover for nested/list columns, or when a larger-scale benchmark demonstrates enough benefit to justify a custom implementation.

Relevant cuDF issues: #23502, [cudf#23378](https://github.com/NVIDIA/cudf/issues/23378), and [cudf#23751](https://github.com/NVIDIA/cudf/issues/23751).