### PR TITLE
fix(docs): read semantic output with Arrow dtypes

### DIFF
--- a/tutorials/text/deduplication/semantic/semantic_step_by_step.ipynb
+++ b/tutorials/text/deduplication/semantic/semantic_step_by_step.ipynb
@@ -966,7 +966,10 @@
    "source": [
     "deduplicated_path = os.path.join(output_path, \"deduplicated\")\n",
     "\n",
-    "pd.read_parquet(os.path.join(deduplicated_path, os.listdir(deduplicated_path)[0])).head()"
+    "pd.read_parquet(\n",
+    "    os.path.join(deduplicated_path, os.listdir(deduplicated_path)[0]),\n",
+    "    dtype_backend=\"pyarrow\",\n",
+    ").head()"
    ]
   },
   {


### PR DESCRIPTION
## Summary

- read the final semantic-deduplication output with the pandas PyArrow dtype backend
- keep the workaround scoped to the tutorial inspection cell
- leave Curator's Parquet writer behavior unchanged

## Context

The workflow already reads Parquet with dtype_backend="pyarrow". The failure occurs only when the final tutorial cell reads output with pandas' default NumPy-backed path and encounters metadata for a nested Arrow list column. Using the PyArrow dtype backend in that inspection cell preserves the nested Arrow dtype and avoids the pandas metadata error.

## Validation

- repository pre-commit hooks passed
- notebook JSON validation passed
- revised read succeeded against the tutorial's generated Parquet output using the project image (pandas 3.0.3)
- semantic step-by-step tutorial completed end to end on a reduced 400-row dataset