### PR TITLE
fix(benchmarking): relax dedup removal IO threshold

### DIFF
--- a/benchmarking/benchmarks.yaml
+++ b/benchmarking/benchmarks.yaml
@@ -751,7 +751,7 @@ entries:
       - metric: num_duplicates_removed
         exact_value: 59226133
       - metric: io_percentage
-        min_value: 90
+        min_value: 75
 
   - name: score_filter_raydata
     enabled: true


### PR DESCRIPTION
## Summary
- Relax the dedup_removal_xenna io_percentage requirement from 90 to 75.
- The latest standard nightly run only failed this requirement; the benchmark process exited successfully and reported io_percentage=78.41. This is likely because of an improvement to IO resulting in shorter IO time (cc @ayushdg)

## Testing
- python -m pytest --confcutdir=tests/benchmarking tests/benchmarking/runner/test_benchmark_configs.py

## Notes
- Applying docs-only so benchmark-only config CI can be skipped; this change updates a nightly benchmark requirement that is not exercised by normal CI.