### PR TITLE
fix(metrics): warn when the packaged Xenna Grafana dashboard is missing (#2189)

### DIFF
--- a/nemo_curator/metrics/utils.py
+++ b/nemo_curator/metrics/utils.py
@@ -263,8 +263,15 @@ def write_grafana_configs(grafana_web_port: int, prometheus_web_port: int, metri
     xenna_dashboard_src = os.path.join(os.path.dirname(__file__), "xenna_grafana_dashboard.json")
     xenna_dashboard_src = os.path.abspath(xenna_dashboard_src)
     xenna_dashboard_dst = os.path.join(dashboards_path, "xenna_grafana_dashboard.json")
-    if os.path.isfile(xenna_dashboard_src) and not os.path.isfile(xenna_dashboard_dst):
-        shutil.copy(xenna_dashboard_src, xenna_dashboard_dst)
+    if not os.path.isfile(xenna_dashboard_dst):
+        if os.path.isfile(xenna_dashboard_src):
+            shutil.copy(xenna_dashboard_src, xenna_dashboard_dst)
+        else:
+            logger.warning(
+                f"Xenna Grafana dashboard not found at {xenna_dashboard_src}; "
+                "the Xenna dashboard will not be provisioned. This usually means the "
+                "packaged data file is missing from the installed nemo_curator distribution."
+            )
 
     # Generate Ray's default Grafana dashboards
     _write_ray_default_dashboards(dashboards_path)

--- a/tests/metrics/test_metrics_utils.py
+++ b/tests/metrics/test_metrics_utils.py
@@ -16,6 +16,7 @@ import os
 import pathlib
 from unittest.mock import patch
 
+import pytest
 import yaml
 
 from nemo_curator.metrics.constants import (
@@ -33,6 +34,7 @@ from nemo_curator.metrics.utils import (
     is_grafana_running,
     is_prometheus_running,
     remove_ray_prometheus_metrics_service_discovery,
+    write_grafana_configs,
 )
 
 
@@ -251,3 +253,48 @@ class TestRemoveRayPrometheusMetricsServiceDiscovery:
             f.write(PROMETHEUS_YAML_TEMPLATE)
 
         remove_ray_prometheus_metrics_service_discovery("/ray/cluster1", str(tmp_path))
+
+
+class TestWriteGrafanaConfigs:
+    @pytest.mark.parametrize(
+        ("src_present", "dst_present", "expect_copy", "expect_warning"),
+        [
+            (True, False, True, False),  # packaged json present -> copied
+            (True, True, False, False),  # already provisioned -> no-op
+            (False, False, False, True),  # missing from package -> warn
+            (False, True, False, False),  # missing but provisioned -> silent
+        ],
+    )
+    def test_xenna_dashboard_provisioning(  # noqa: PLR0913
+        self,
+        tmp_path: pathlib.Path,
+        caplog: pytest.LogCaptureFixture,
+        src_present: bool,
+        dst_present: bool,
+        expect_copy: bool,
+        expect_warning: bool,
+    ) -> None:
+        """A missing packaged dashboard must warn, unless it is already provisioned."""
+        pkg_dir = tmp_path / "pkg"
+        pkg_dir.mkdir()
+        if src_present:
+            (pkg_dir / "xenna_grafana_dashboard.json").write_text('{"title": "xenna"}')
+        metrics_dir = tmp_path / "metrics"
+        dst = metrics_dir / "grafana" / "dashboards" / "xenna_grafana_dashboard.json"
+        if dst_present:
+            dst.parent.mkdir(parents=True)
+            dst.write_text('{"title": "stale"}')
+
+        with (
+            patch("nemo_curator.metrics.utils.__file__", str(pkg_dir / "utils.py")),
+            patch("nemo_curator.metrics.utils._write_ray_default_dashboards"),
+        ):
+            ini_path = write_grafana_configs(3000, 9090, metrics_dir=str(metrics_dir))
+
+        assert os.path.isfile(ini_path)  # other config still written
+        assert dst.is_file() == (expect_copy or dst_present)
+        if dst_present:
+            assert dst.read_text() == '{"title": "stale"}'  # never overwritten
+        elif expect_copy:
+            assert dst.read_text() == '{"title": "xenna"}'  # content transferred
+        assert ("will not be provisioned" in caplog.text) == expect_warning


### PR DESCRIPTION
## Description

`write_grafana_configs()` folded the packaged-file check into the copy condition:

```python
if os.path.isfile(xenna_dashboard_src) and not os.path.isfile(xenna_dashboard_dst):
    shutil.copy(xenna_dashboard_src, xenna_dashboard_dst)
```

so "the packaged dashboard is missing" and "it is already provisioned" took the same silent
branch. When the JSON was absent from the install the function returned normally, having written
only the Ray dashboards, with no log at any level. The reporter had to list `site-packages` to
work out why the Xenna dashboard never appeared in Grafana.

This guards on the destination first and warns only when the packaged source is genuinely
absent, so an already-provisioned dashboard stays quiet and is never overwritten.

Packaging itself is untouched: the missing-from-the-wheel half of the report was already fixed
by ad587436 (#1911), which added `recursive-include nemo_curator ... *.json` to `MANIFEST.in`.
What was left is the silent skip, which is what the issue's "Suggested fix" asks for.

closes #2189

## Usage

No API change. When the packaged dashboard is missing, `write_grafana_configs()` now logs it
instead of returning quietly:

```python
from nemo_curator.metrics.utils import write_grafana_configs

write_grafana_configs(3000, 9090)
# WARNING | Xenna Grafana dashboard not found at /.../nemo_curator/metrics/xenna_grafana_dashboard.json;
#           the Xenna dashboard will not be provisioned. This usually means the packaged data file is
#           missing from the installed nemo_curator distribution.
```

## Tests

Added a parametrized test in `tests/metrics/test_metrics_utils.py` covering the four
(source present, destination present) states for `write_grafana_configs`; only the
"source missing, destination missing" case fails on `main` today, with the reported symptom
(no warning logged). All four pass with this fix, and the rest of `tests/metrics/` (28 tests)
is unaffected.

- `pytest tests/metrics/test_metrics_utils.py -k WriteGrafanaConfigs` — 4 passed
- `pytest tests/metrics/` — 28 passed
- `ruff check` / `ruff format --check` on both changed files — clean

## Checklist
- [x] I am familiar with the [Contributing Guide](https://github.com/NVIDIA-NeMo/Curator/blob/main/CONTRIBUTING.md).
- [x] New or Existing tests cover these changes.
- [x] The documentation is up to date with these changes.
