### PR TITLE
docs: document optional OpenCV installation

### DIFF
--- a/fern/versions/main/pages/curate-text/load-data/nemotron-parse-pdf.mdx
+++ b/fern/versions/main/pages/curate-text/load-data/nemotron-parse-pdf.mdx
@@ -30,6 +30,7 @@ Choose your PDF source and confirm the prerequisites:
 - **GPU**: Required. Nemotron-Parse runs on GPU via vLLM (recommended) or Hugging Face Transformers.
 - **vLLM**: Strongly recommended for throughput. Falls back to HF Transformers if `backend="hf"` is set.
 - **`pypdfium2`**: Required Python dependency for PDF rendering. Installed automatically with the `interleaved_cpu` or `interleaved_cuda12` extras (e.g., `uv sync --extra interleaved_cuda12`).
+- **OpenCV**: Required for PDF rendering plus the postprocessing color conversion and resizing paths. Install the optional extra with `uv pip install "nemo-curator[cv2]"` (or add `--extra cv2` to a source checkout).
 - **Manifest**: A JSONL file listing the PDFs to process. Each line should specify the PDF location relative to the source directory you choose.
 
 ### Choosing a PDF Source

--- a/fern/versions/main/pages/curate-text/process-data/interleaved/filters.mdx
+++ b/fern/versions/main/pages/curate-text/process-data/interleaved/filters.mdx
@@ -33,6 +33,14 @@ Blur → QR-code → Image-to-Text Ratio → CLIP Score
 
 The CLIP filter dominates cost. Putting it last means it only runs against samples that survived all other checks.
 
+<Note>
+The blur and QR-code filters, as well as the image-byte decoder used by
+interleaved image processing, require the optional `cv2` extra. Install it
+with `uv pip install "nemo-curator[cv2]"`. If it is missing, Curator raises an
+`ImportError` with the same installation hint. Interleaved readers and writers
+that only move bytes between WebDataset and Parquet do not require OpenCV.
+</Note>
+
 ## `InterleavedBlurFilterStage`
 
 Computes the [Laplacian variance](https://docs.opencv.org/4.x/d2/d2c/tutorial_py_canny.html) of each image (via OpenCV) and drops images below `score_threshold`. Lower variance means a flatter, blurrier image.

--- a/fern/versions/main/pages/curate-video/process-data/filtering.mdx
+++ b/fern/versions/main/pages/curate-video/process-data/filtering.mdx
@@ -12,6 +12,20 @@ modality: "video-only"
 
 Apply motion-based filtering to clips and aesthetic filtering to frames to prune low-quality assets during curation.
 
+<Note>
+Motion filtering uses OpenCV for flow-field resizing. Install the optional
+dependency before enabling it:
+
+```bash
+uv pip install "nemo-curator[cv2]"
+```
+
+The `video_cpu` or `video_cuda12` extra is also required for motion-vector
+decoding; it provides PyAV and its FFmpeg libraries. Stages that invoke the
+`ffmpeg` executable still need the FFmpeg setup required by your video
+pipeline. Installing `cv2` does not provide that executable or its codecs.
+</Note>
+
 ## How it Works
 
 Filtering runs in two passes that balance speed and quality:
@@ -21,7 +35,7 @@ Filtering runs in two passes that balance speed and quality:
 
 ## Before You Start
 
-Motion decoding and aesthetic scoring operate on clip buffers. You must run [clipping](/curate-video/process-data/clipping) and [encoding](/curate-video/process-data/transcoding) first so each clip has a valid `buffer` (bytes). 
+Motion decoding and aesthetic scoring operate on clip buffers. You must run [clipping](/curate-video/process-data/clipping) and [encoding](/curate-video/process-data/transcoding) first so each clip has a valid `buffer` (bytes).
 
 ---
 

--- a/fern/versions/main/pages/get-started/installation.mdx
+++ b/fern/versions/main/pages/get-started/installation.mdx
@@ -264,10 +264,11 @@ OpenCV-gated features. The extra does not install or configure the `ffmpeg`
 command-line tool. Video and audio workflows that call FFmpeg still require
 the FFmpeg setup described above.
 
-If an OpenCV-gated feature is called without the extra, Curator raises an
-`ImportError` that identifies the missing `opencv-python-headless` dependency
-and suggests installing `nemo_curator[cv2]`. To verify the active environment,
-run:
+Most OpenCV-gated features raise an `ImportError` that identifies the missing
+`opencv-python-headless` dependency and suggests installing
+`nemo_curator[cv2]`. Nemotron-Parse PDF processing instead logs a warning and
+skips the affected PDF when OpenCV is unavailable. To verify the active
+environment, run:
 
 ```bash
 python -c "import cv2; print(cv2.__version__)"

--- a/fern/versions/main/pages/get-started/installation.mdx
+++ b/fern/versions/main/pages/get-started/installation.mdx
@@ -216,6 +216,7 @@ NeMo Curator provides several installation extras to install only the components
 | **image_cuda12** | `uv pip install nemo-curator[image_cuda12]` | GPU-accelerated image processing with NVIDIA DALI |
 | **video_cpu** | `uv pip install nemo-curator[video_cpu]` | CPU-only video processing |
 | **video_cuda12** | `uv pip install --no-build-isolation nemo-curator[video_cuda12]` | GPU-accelerated video processing with CUDA libraries. Requires FFmpeg and additional build dependencies when using `uv`. |
+| **cv2** | `uv pip install nemo-curator[cv2]` | Optional OpenCV-based image and video operations |
 | **inference_server** | `uv pip install nemo-curator[inference_server]` | Ray Serve + vLLM for serving LLMs alongside curation pipelines |
 | **sdg_cpu** | `uv pip install nemo-curator[sdg_cpu]` | CPU-only synthetic data generation with Data Designer |
 | **sdg_cuda12** | `uv pip install nemo-curator[sdg_cuda12]` | GPU-accelerated synthetic data generation with local inference server support |
@@ -232,6 +233,45 @@ python -m pip install \
 
 All remaining dependencies, including Dynamo, NIXL, and RAPIDS packages, are
 resolved from public PyPI.
+
+### Optional OpenCV Support
+
+The base NeMo Curator installation does not install OpenCV. The `cv2` extra
+installs `opencv-python-headless` for features that decode or transform images
+with OpenCV. Install it in the same environment as Curator when you use one of
+these features:
+
+- interleaved image decoding, `InterleavedBlurFilterStage`, or
+  `InterleavedQRCodeFilterStage`;
+- Nemotron-Parse PDF postprocessing; or
+- video target-resolution frame resizing or motion-vector filtering.
+
+For a PyPI installation, run:
+
+```bash
+uv pip install "nemo-curator[cv2]"
+```
+
+For a source checkout, run:
+
+```bash
+uv sync --extra cv2
+```
+
+The `cv2` extra is intentionally separate from the `all` extra. This keeps
+OpenCV's bundled media dependencies out of installations that do not use
+OpenCV-gated features. The extra does not install or configure the `ffmpeg`
+command-line tool. Video and audio workflows that call FFmpeg still require
+the FFmpeg setup described above.
+
+If an OpenCV-gated feature is called without the extra, Curator raises an
+`ImportError` that identifies the missing `opencv-python-headless` dependency
+and suggests installing `nemo_curator[cv2]`. To verify the active environment,
+run:
+
+```bash
+python -c "import cv2; print(cv2.__version__)"
+```
 
 For `text_cuda12`, download Curator's override file and use uv's pip-compatible
 installer with the CUDA 12.9 wheel source:

--- a/fern/versions/main/pages/get-started/video.mdx
+++ b/fern/versions/main/pages/get-started/video.mdx
@@ -60,6 +60,16 @@ To use NeMo Curator's video curation capabilities, ensure your system meets thes
   - GPU encoder: `h264_nvenc` (recommended for performance; requires an NVENC-equipped GPU — note that A100 and H100 do **not** include NVENC)
   - CPU encoder: `libvpx-vp9` (for non-NVENC GPUs; produces VP9 in `.mp4`)
 
+Some video operations, including target-resolution frame resizing and motion
+filtering, use OpenCV. The base installation does not include it; add
+`uv pip install "nemo-curator[cv2]"` before using those operations. Motion-vector
+decoding also requires the `video_cpu` or `video_cuda12` extra, which provides
+PyAV and its FFmpeg libraries. Stages that invoke the `ffmpeg` executable still
+require the FFmpeg setup above; installing `cv2` does not install that
+executable or its codecs. If you use a container image, verify the active image
+with `python -c "import cv2; print(cv2.__version__)"` and install the extra in
+the container when needed.
+
 <Tip>
 If `uv` is not installed, refer to the [Installation Guide](/get-started/installation) for setup instructions, or install it quickly with:
 


### PR DESCRIPTION
## Description

Documents when OpenCV is optional, how to install the `opencv` extra, and which text, PDF, and video workflows require it.

Linear: https://linear.app/nvidia/issue/NMCUR-412/docs-document-the-optional-opencv-installation-path

## Validation

- `pre-commit run --files <changed Fern pages>`
- `make docs-check`
- `git diff --check`

## Checklist

- [x] I am familiar with the Contributing Guide.
- [x] Documentation validation covers these docs-only changes.
- [x] The documentation is up to date with these changes.