### PR TITLE
docs: document Ray Actor Pool resource waits

### DIFF
--- a/fern/versions/main/pages/about/concepts/resource-allocation.mdx
+++ b/fern/versions/main/pages/about/concepts/resource-allocation.mdx
@@ -86,6 +86,14 @@ model_stage = ModelStage(model_path="path/to/model").with_(resources=Resources(g
 
 This is useful for inference stages where the model fits in a fraction of GPU memory, allowing you to increase parallelism without requiring more hardware. Note that `gpu_memory_gb` sets GPU memory for a single GPU.
 
+### Ray Actor Pool Sizing
+
+`RayActorPoolExecutor` sizes each stage from a CPU and GPU availability snapshot. It divides available CPUs by `stage.resources.cpus` and available GPUs by `stage.resources.gpus` (when a requirement is greater than zero), then uses the smaller limit. Automatic sizing is also bounded by the number of task batches. A positive `stage.num_workers()` requests that exact count when it fits; otherwise the executor caps the count to the available resource limit and logs a warning.
+
+Between stages, the executor keeps a high-water baseline: it retains the maximum CPU and GPU availability observed after subtracting `reserved_cpus` and `reserved_gpus`. It uses that baseline to determine the intended pool, then waits for the complete pool to fit the current snapshot. This accounts for temporary resource dips while Ray asynchronously cleans up actors from the preceding stage. A timeout raises an error; it does not create a smaller partial pool.
+
+For this wait behavior, `resource_wait_timeout_s` defaults to `5.0` seconds and must be non-negative. `resource_wait_interval_s` defaults to `0.2` seconds and must be positive. The executor polls both CPU and GPU availability at that interval. Set `ignore_head_node=True` to exclude the head node from the availability calculation; reservations and head-node exclusion apply to both baseline and polling snapshots.
+
 ## Best Practices
 
 - **Start with defaults.** Most stages have sensible default resource declarations. Override only when you observe resource contention or underutilization.

--- a/fern/versions/main/pages/reference/infrastructure/execution-backends.mdx
+++ b/fern/versions/main/pages/reference/infrastructure/execution-backends.mdx
@@ -67,19 +67,19 @@ executor = XennaExecutor(
         # Execution mode: 'streaming' (default) or 'batch'
         # Batch processes all data for a stage before moving to the next; streaming runs stages concurrently.
         "execution_mode": "streaming",
-        
+
         # Logging interval: seconds between status logs (default: 60)
         # Controls how frequently progress updates are printed
         "logging_interval": 60,
-        
+
         # Ignore failures: whether to continue on failures (default: False)
         # When True, the pipeline continues execution instead of failing fast when stages raise errors.
         "ignore_failures": False,
-        
+
         # CPU allocation percentage: ratio of CPU to allocate (0-1, default: 0.95)
         # Fraction of available CPU resources to use for pipeline execution
         "cpu_allocation_percentage": 0.95,
-        
+
         # Autoscale interval: seconds between auto-scaling checks (default: 180)
         # How often to run the stage auto-scaler.
         "autoscale_interval_s": 180,
@@ -134,8 +134,34 @@ results = pipeline.run(executor)
 | `ignore_head_node` | `bool` | `False` | Exclude head node from task scheduling |
 | `show_progress` | `bool` | `True` | Display tqdm progress bars during stage execution and shuffle inserts |
 | `progress_interval` | `float` | `10.0` | Minimum interval in seconds between progress bar updates |
+| `resource_wait_timeout_s` | `float` | `5.0` | Maximum time to wait for the intended actor pool between stages |
+| `resource_wait_interval_s` | `float` | `0.2` | Interval in seconds between resource availability checks |
 
 A positive stage `num_workers()` requests an exact actor count when resources fit. If fewer actors fit, this executor warns and caps the request to available CPU/GPU capacity. See [Stage Worker Sizing](/reference/infra/stage-worker-sizing#ray-actor-pool-resource-capping).
+
+#### Inter-stage Resource Waits
+
+Before the first stage, the executor records the CPU and GPU capacity currently available to the actor pool. Before every stage, it refreshes that snapshot as a high-water mark, retaining the maximum capacity observed so far. This avoids sizing a stage from a temporary dip while Ray finishes cleaning up actors from the previous stage.
+
+The intended actor count is calculated once from that high-water mark, the stage's CPU and GPU requirements, the number of tasks, and any `num_workers()` setting. The executor then polls current availability until the complete intended pool fits. Each poll checks both CPU and GPU capacity, logs current and required values, and sleeps for `resource_wait_interval_s`; the final sleep is shortened when it would pass the timeout.
+
+The defaults are a five-second timeout and a 0.2-second polling interval. Configure them through the executor's `config` dictionary:
+
+```python
+executor = RayActorPoolExecutor(
+    config={
+        "resource_wait_timeout_s": 30.0,
+        "resource_wait_interval_s": 0.5,
+        "reserved_cpus": 2.0,
+        "reserved_gpus": 1.0,
+    },
+    ignore_head_node=True,
+)
+```
+
+`resource_wait_timeout_s` must be non-negative, and `resource_wait_interval_s` must be greater than zero. Values are converted to floating-point numbers when execution starts. If the complete intended pool does not fit before the deadline, execution raises `TimeoutError` with the stage name and required versus available CPU and GPU values. The executor does not fall back to a smaller partial pool.
+
+The resource snapshot honors `reserved_cpus` and `reserved_gpus` by subtracting them from availability, never below zero. When `ignore_head_node=True`, the head node's total CPU and GPU capacity is also excluded from the snapshot. Ray's asynchronous actor termination can therefore make resources appear unavailable briefly between stages; the polling window is intended to cover that cleanup period.
 
 <Accordion title="Example: Fuzzy Deduplication">
 
@@ -207,7 +233,7 @@ For worker counts, resources, and backend-specific `with_()` overrides, see [Sta
 Ray-based executors provide enhanced scalability and performance for large-scale data processing tasks. These executors are beneficial for:
 
 - **Large-scale classification tasks**: Distributed inference across multi-GPU setups
-- **Deduplication workflows**: Parallel processing of document similarity computations  
+- **Deduplication workflows**: Parallel processing of document similarity computations
 - **Resource-intensive stages**: Automatic scaling based on computational demands
 
 ## Choosing a Backend

--- a/fern/versions/main/pages/reference/infrastructure/monitoring.mdx
+++ b/fern/versions/main/pages/reference/infrastructure/monitoring.mdx
@@ -102,3 +102,16 @@ To stop Prometheus and Grafana, use the PID files written to your metrics direct
 kill $(cat /shared/metrics/user_a/prometheus.pid)
 kill $(cat /shared/metrics/user_a/grafana.pid)
 ```
+
+## Troubleshoot Ray Actor Pool Resource Waits
+
+When `RayActorPoolExecutor` moves between stages, watch the executor logs for messages such as `Waiting for resources for <stage>` and `Timed out ... waiting for the intended <N>-actor pool`. These messages report the current and required CPU and GPU capacity. A successful wait is followed by a log that the actor pool is being created.
+
+The executor sizes the intended pool from a high-water resource baseline, then waits for that complete pool to become available. A temporary dip can occur while Ray asynchronously finishes terminating actors from the prior stage. If the wait reaches `resource_wait_timeout_s` (default `5.0` seconds), execution raises `TimeoutError`; it does not proceed with a smaller partial pool.
+
+Use the following checks when a wait times out:
+
+- Confirm that the cluster has enough CPU and GPU capacity for the stage's per-actor `Resources` multiplied by the intended actor count.
+- Check whether `reserved_cpus` or `reserved_gpus` leaves too little capacity after reservations.
+- If `ignore_head_node=True`, account for the head node's CPU and GPU capacity being excluded.
+- Increase `resource_wait_timeout_s` when actor termination or cluster scheduling needs more time. Increase `resource_wait_interval_s` to reduce polling frequency; it must remain greater than zero. A timeout of zero performs an immediate availability check.


### PR DESCRIPTION
## Description

Documents the Ray Actor Pool executor resource barrier between stages, including what it waits for, why the wait can occur, and how to monitor or troubleshoot it.

Linear: https://linear.app/nvidia/issue/NMCUR-454/docs-document-ray-actor-pool-inter-stage-resource-waits

## Validation

- `pre-commit run --files <changed Fern pages>`
- `make docs-check`
- `git diff --check`

## Checklist

- [x] I am familiar with the Contributing Guide.
- [x] Documentation validation covers these docs-only changes.
- [x] The documentation is up to date with these changes.