### PR TITLE
Audio: handle no-space scripts in transcript guards

### DIFF
--- a/nemo_curator/stages/audio/text_filtering/__init__.py
+++ b/nemo_curator/stages/audio/text_filtering/__init__.py
@@ -15,12 +15,14 @@
 """Audio transcript filtering stages."""
 
 from .abbreviation_concat import AbbreviationConcatStage
+from .disfluency_wer_guard import DisfluencyWerGuardStage
 from .regex_substitution import RegexSubstitutionStage
 from .select_best_prediction import SelectBestPredictionStage
 from .whisper_hallucination import WhisperHallucinationStage
 
 __all__ = [
     "AbbreviationConcatStage",
+    "DisfluencyWerGuardStage",
     "RegexSubstitutionStage",
     "SelectBestPredictionStage",
     "WhisperHallucinationStage",

--- a/nemo_curator/stages/audio/text_filtering/disfluency_wer_guard.py
+++ b/nemo_curator/stages/audio/text_filtering/disfluency_wer_guard.py
@@ -1,0 +1,78 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Guard a disfluency-removal pass against excessive transcript changes."""
+
+from dataclasses import dataclass, field
+
+from nemo_curator.stages.audio.text_filtering.scriptio_continua import is_scriptio_continua
+from nemo_curator.stages.audio.text_filtering.text_metrics import (
+    character_error_rate_percent,
+    word_error_rate_percent,
+)
+from nemo_curator.stages.base import ProcessingStage
+from nemo_curator.stages.resources import Resources
+from nemo_curator.tasks import AudioTask
+
+
+@dataclass
+class DisfluencyWerGuardStage(ProcessingStage[AudioTask, AudioTask]):
+    """Restore the original prediction when disfluency removal diverges.
+
+    The stage compares ``ref_text_key`` with the disfluency-cleaned text at
+    ``hyp_text_key``. It uses character error rate (CER) for languages written
+    without word-separating spaces and word error rate (WER) otherwise. If the
+    selected error rate exceeds ``max_wer_pct``, the cleaned prediction is
+    replaced with the original prediction.
+
+    The selected rate is stored in the compatibility field ``wer_key`` even
+    when CER is used, matching the reference pipeline contract.
+    """
+
+    ref_text_key: str = "qwen3_prediction_s1"
+    hyp_text_key: str = "qwen3_prediction_s2"
+    wer_key: str = "disfluency_wer"
+    max_wer_pct: float = 50.0
+    skip_me_key: str = "_skipme"
+    language_key: str = "source_lang"
+    name: str = "DisfluencyWerGuard"
+    resources: Resources = field(default_factory=lambda: Resources(cpus=1.0))
+
+    def inputs(self) -> tuple[list[str], list[str]]:
+        return [], [self.ref_text_key, self.hyp_text_key]
+
+    def outputs(self) -> tuple[list[str], list[str]]:
+        return [], [self.hyp_text_key, self.wer_key]
+
+    def process(self, task: AudioTask) -> AudioTask:
+        if task.data.get(self.skip_me_key, ""):
+            task.data.setdefault(self.wer_key, -1.0)
+            return task
+
+        reference = task.data.get(self.ref_text_key, "")
+        hypothesis = task.data.get(self.hyp_text_key, "")
+        if not reference or not hypothesis:
+            task.data[self.wer_key] = -1.0
+            return task
+
+        metric_fn = (
+            character_error_rate_percent
+            if is_scriptio_continua(task.data.get(self.language_key))
+            else word_error_rate_percent
+        )
+        error_rate = metric_fn(str(reference), str(hypothesis))
+        task.data[self.wer_key] = error_rate
+        if error_rate > self.max_wer_pct:
+            task.data[self.hyp_text_key] = reference
+        return task

--- a/nemo_curator/stages/audio/text_filtering/scriptio_continua.py
+++ b/nemo_curator/stages/audio/text_filtering/scriptio_continua.py
@@ -1,0 +1,54 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Language helpers for text written without word-separating spaces."""
+
+SCRIPTIO_CONTINUA_LANGUAGE_CODES: frozenset[str] = frozenset(
+    {
+        "ja",
+        "zh",
+        "zh-cn",
+        "zh-tw",
+        "zh-hans",
+        "zh-hant",
+        "yue",
+        "th",
+        "lo",
+        "km",
+        "my",
+        "bo",
+        "dz",
+    }
+)
+
+_SCRIPTIO_CONTINUA_LANGUAGE_NAMES: frozenset[str] = frozenset(
+    {
+        "chinese",
+        "japanese",
+        "thai",
+    }
+)
+
+
+def is_scriptio_continua(language: object | None) -> bool:
+    """Return whether ``language`` normally omits spaces between words.
+
+    ISO codes, the Chinese locale tags used by the reference pipeline, and
+    full English language names are accepted case-insensitively. Underscores
+    in locale tags are normalized to hyphens.
+    """
+    if language is None:
+        return False
+    normalized = str(language).strip().lower().replace("_", "-")
+    return normalized in SCRIPTIO_CONTINUA_LANGUAGE_CODES or normalized in _SCRIPTIO_CONTINUA_LANGUAGE_NAMES

--- a/nemo_curator/stages/audio/text_filtering/select_best_prediction.py
+++ b/nemo_curator/stages/audio/text_filtering/select_best_prediction.py
@@ -16,6 +16,11 @@ import re
 from dataclasses import dataclass, field
 from typing import Any
 
+from nemo_curator.stages.audio.text_filtering.scriptio_continua import is_scriptio_continua
+from nemo_curator.stages.audio.text_filtering.text_metrics import (
+    character_error_rate_percent,
+    word_error_rate_percent,
+)
 from nemo_curator.stages.base import ProcessingStage
 from nemo_curator.stages.resources import Resources
 from nemo_curator.tasks import AudioTask
@@ -31,30 +36,8 @@ def _set_note(data: dict[str, Any], stage: str, value: str, notes_key: str) -> N
     notes[stage] = value
 
 
-def _normalized_words(text: str) -> list[str]:
-    return _PUNCTUATION.sub("", text).lower().split()
-
-
-def _word_error_rate_percent(reference: str, hypothesis: str) -> float:
-    """Return word-level Levenshtein distance as a percentage."""
-    ref = _normalized_words(reference)
-    hyp = _normalized_words(hypothesis)
-    if not ref:
-        return 0.0 if not hyp else 100.0
-
-    previous = list(range(len(hyp) + 1))
-    for ref_index, ref_word in enumerate(ref, start=1):
-        current = [ref_index]
-        for hyp_index, hyp_word in enumerate(hyp, start=1):
-            current.append(
-                min(
-                    previous[hyp_index] + 1,
-                    current[hyp_index - 1] + 1,
-                    previous[hyp_index - 1] + (ref_word != hyp_word),
-                )
-            )
-        previous = current
-    return round(previous[-1] / len(ref) * 100.0, 2)
+def _normalize_for_error_rate(text: str) -> str:
+    return _PUNCTUATION.sub("", text).lower()
 
 
 @dataclass
@@ -67,6 +50,9 @@ class SelectBestPredictionStage(ProcessingStage[AudioTask, AudioTask]):
     authoritative for datasets whose model output is not trusted. Otherwise,
     the stage handles unsupported languages, recovered fallback predictions,
     reference recovery, cross-model agreement, and the normal primary result.
+    Cross-model agreement uses character error rate (CER) for languages written
+    without word-separating spaces and word error rate (WER) otherwise. The
+    selected metric is recorded in ``metric_key``.
     ``asr_text_key`` is a compatibility alias that overrides
     ``fallback_text_key`` when supplied.
     """
@@ -79,8 +65,10 @@ class SelectBestPredictionStage(ProcessingStage[AudioTask, AudioTask]):
     notes_key: str = "additional_notes"
     skip_me_key: str = "_skipme"
     duration_key: str = "duration"
+    language_key: str = "source_lang"
     min_agreement_pct: float = 80.0
     agreement_wer_key: str = "primary_fallback_agreement_wer"
+    metric_key: str = "primary_fallback_agreement_metric"
     primary_source_label: str = "primary"
     fallback_source_label: str = "fallback"
     reference_text_key: str | None = None
@@ -101,10 +89,18 @@ class SelectBestPredictionStage(ProcessingStage[AudioTask, AudioTask]):
         return [], keys
 
     def outputs(self) -> tuple[list[str], list[str]]:
-        return [], [self.output_key, self.source_key, self.skip_me_key, self.agreement_wer_key, self.notes_key]
+        return [], [
+            self.output_key,
+            self.source_key,
+            self.skip_me_key,
+            self.agreement_wer_key,
+            self.metric_key,
+            self.notes_key,
+        ]
 
     def process(self, task: AudioTask) -> AudioTask:  # noqa: C901, PLR0911, PLR0912, PLR0915
         task.data.pop(self.agreement_wer_key, None)
+        task.data.pop(self.metric_key, None)
 
         if (
             self.use_ground_truth_for_short_audio
@@ -198,16 +194,22 @@ class SelectBestPredictionStage(ProcessingStage[AudioTask, AudioTask]):
                 return task
 
         if skip_reason.startswith("Hallucination") and primary and fallback:
-            wer = _word_error_rate_percent(primary, fallback)
-            task.data[self.agreement_wer_key] = wer
-            if wer <= 100.0 - self.min_agreement_pct:
+            normalized_primary = _normalize_for_error_rate(primary)
+            normalized_fallback = _normalize_for_error_rate(fallback)
+            use_cer = is_scriptio_continua(task.data.get(self.language_key))
+            metric_name = "cer" if use_cer else "wer"
+            metric_fn = character_error_rate_percent if use_cer else word_error_rate_percent
+            error_rate = metric_fn(normalized_primary, normalized_fallback)
+            task.data[self.agreement_wer_key] = error_rate
+            task.data[self.metric_key] = metric_name
+            if error_rate <= 100.0 - self.min_agreement_pct:
                 task.data[self.output_key] = primary
                 task.data[self.source_key] = self.primary_source_label
                 task.data[self.skip_me_key] = ""
                 _set_note(
                     task.data,
                     self.name,
-                    f"recovered:cross_model_agreement (wer={wer:.1f}%)",
+                    f"recovered:cross_model_agreement ({metric_name}={error_rate:.1f}%)",
                     self.notes_key,
                 )
                 return task

--- a/nemo_curator/stages/audio/text_filtering/text_metrics.py
+++ b/nemo_curator/stages/audio/text_filtering/text_metrics.py
@@ -1,0 +1,53 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Dependency-free text error-rate helpers for lightweight filtering stages."""
+
+from collections.abc import Sequence
+from typing import TypeVar
+
+_Token = TypeVar("_Token")
+
+
+def _levenshtein_distance(reference: Sequence[_Token], hypothesis: Sequence[_Token]) -> int:
+    """Return the Levenshtein edit distance between two token sequences."""
+    previous = list(range(len(hypothesis) + 1))
+    for ref_index, ref_token in enumerate(reference, start=1):
+        current = [ref_index]
+        for hyp_index, hyp_token in enumerate(hypothesis, start=1):
+            current.append(
+                min(
+                    previous[hyp_index] + 1,
+                    current[hyp_index - 1] + 1,
+                    previous[hyp_index - 1] + (ref_token != hyp_token),
+                )
+            )
+        previous = current
+    return previous[-1]
+
+
+def _error_rate_percent(reference: Sequence[_Token], hypothesis: Sequence[_Token]) -> float:
+    if not reference:
+        return 0.0 if not hypothesis else 100.0
+    return round(_levenshtein_distance(reference, hypothesis) / len(reference) * 100.0, 2)
+
+
+def word_error_rate_percent(reference: str, hypothesis: str) -> float:
+    """Return whitespace-token word error rate as a percentage."""
+    return _error_rate_percent(reference.split(), hypothesis.split())
+
+
+def character_error_rate_percent(reference: str, hypothesis: str) -> float:
+    """Return Unicode code-point character error rate as a percentage."""
+    return _error_rate_percent(reference, hypothesis)

--- a/nemo_curator/stages/audio/text_filtering/whisper_hallucination.py
+++ b/nemo_curator/stages/audio/text_filtering/whisper_hallucination.py
@@ -24,6 +24,7 @@ from typing import Any
 
 from loguru import logger
 
+from nemo_curator.stages.audio.text_filtering.scriptio_continua import is_scriptio_continua
 from nemo_curator.stages.base import ProcessingStage
 from nemo_curator.stages.resources import Resources
 from nemo_curator.tasks import AudioTask
@@ -62,6 +63,11 @@ class WhisperHallucinationStage(ProcessingStage[AudioTask, AudioTask]):
     - **High char rate**: characters per second exceed ``max_char_rate``, an
       impossible speaking rate, which catches dense text confabulated over a
       very short clip.
+
+    Repeated-word and long-word checks are disabled for languages written
+    without word-separating spaces because whitespace tokenization treats an
+    entire utterance as one word. Phrase and character-rate checks remain
+    active for those languages.
 
     When flagged, ``skip_me_key`` is set to ``"Hallucination:{name}"`` so the
     originating instance stays identifiable. An existing non-hallucination flag
@@ -180,6 +186,9 @@ class WhisperHallucinationStage(ProcessingStage[AudioTask, AudioTask]):
         lang = str(task.data.get(self.language_key, "")).lower().strip()
         return lang in AGGLUTINATIVE_COMPOUNDING_LANGS
 
+    def _is_scriptio_continua(self, task: AudioTask) -> bool:
+        return is_scriptio_continua(task.data.get(self.language_key))
+
     def process(self, task: AudioTask) -> AudioTask:
         current_flag = str(task.data.get(self.skip_me_key, ""))
         if not self.overwrite and current_flag:
@@ -194,8 +203,13 @@ class WhisperHallucinationStage(ProcessingStage[AudioTask, AudioTask]):
 
         is_agglutinative = self._is_agglutinative(task)
         long_word_thresh = self.agglutinative_long_word_threshold if is_agglutinative else self.long_word_threshold
-        repeated = self._repeated_ngrams(words)
-        long_w = self._long_word(words, threshold=long_word_thresh, skip_relative=is_agglutinative)
+        word_checks_apply = not self._is_scriptio_continua(task)
+        repeated = self._repeated_ngrams(words) if word_checks_apply else False
+        long_w = (
+            self._long_word(words, threshold=long_word_thresh, skip_relative=is_agglutinative)
+            if word_checks_apply
+            else False
+        )
         phrase = self._frequent_single_word(text)
         high_rate = self._high_char_rate(words, duration)
 

--- a/tests/stages/audio/text_filtering/test_disfluency_wer_guard.py
+++ b/tests/stages/audio/text_filtering/test_disfluency_wer_guard.py
@@ -1,0 +1,115 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# ruff: noqa: INP001
+
+import pytest
+
+from nemo_curator.stages.audio.text_filtering import DisfluencyWerGuardStage
+from nemo_curator.tasks import AudioTask
+
+_REF_KEY = "qwen3_prediction_s1"
+_HYP_KEY = "qwen3_prediction_s2"
+_RATE_KEY = "disfluency_wer"
+
+
+def _task(reference: str, hypothesis: str, language: str | None = None) -> AudioTask:
+    data = {_REF_KEY: reference, _HYP_KEY: hypothesis, "_skipme": ""}
+    if language is not None:
+        data["source_lang"] = language
+    return AudioTask(data=data)
+
+
+@pytest.mark.parametrize("language", ["ja", "zh", "th", "zh_CN", "Japanese"])
+def test_no_space_languages_use_cer_and_keep_near_match(language: str) -> None:
+    task = _task("这是一个测试句子用来检查协议", "这是一个测试句子用来检查协义", language)
+
+    DisfluencyWerGuardStage(max_wer_pct=20.0).process(task)
+
+    assert 0.0 < task.data[_RATE_KEY] < 20.0
+    assert task.data[_HYP_KEY] == "这是一个测试句子用来检查协义"
+
+
+def test_no_space_genuine_disagreement_restores_original() -> None:
+    task = _task("あなたのおすすめの映画は何ですか", "今日はとても良い天気ですね", "ja")
+
+    DisfluencyWerGuardStage(max_wer_pct=20.0).process(task)
+
+    assert task.data[_RATE_KEY] > 20.0
+    assert task.data[_HYP_KEY] == task.data[_REF_KEY]
+
+
+def test_space_separated_language_keeps_wer_behavior() -> None:
+    task = _task("one two three four", "one two three", "en")
+
+    DisfluencyWerGuardStage(max_wer_pct=20.0).process(task)
+
+    assert task.data[_RATE_KEY] == 25.0
+    assert task.data[_HYP_KEY] == task.data[_REF_KEY]
+
+
+def test_missing_language_defaults_to_wer() -> None:
+    task = _task("hello world", "hello")
+
+    DisfluencyWerGuardStage(max_wer_pct=75.0).process(task)
+
+    assert task.data[_RATE_KEY] == 50.0
+    assert task.data[_HYP_KEY] == "hello"
+
+
+def test_custom_language_and_text_keys_are_supported() -> None:
+    task = AudioTask(data={"before": "日本語の文字列", "after": "日本語の文宇列", "lang": "Japanese"})
+    stage = DisfluencyWerGuardStage(
+        ref_text_key="before",
+        hyp_text_key="after",
+        language_key="lang",
+        wer_key="error_rate",
+        max_wer_pct=20.0,
+    )
+
+    stage.process(task)
+
+    assert 0.0 < task.data["error_rate"] < 20.0
+    assert task.data["after"] == "日本語の文宇列"
+
+
+@pytest.mark.parametrize(
+    "data",
+    [
+        {_REF_KEY: "", _HYP_KEY: "text"},
+        {_REF_KEY: "text", _HYP_KEY: ""},
+        {_REF_KEY: "before", _HYP_KEY: "after", "_skipme": "other filter"},
+    ],
+)
+def test_unscorable_or_previously_skipped_rows_record_sentinel(data: dict[str, str]) -> None:
+    task = AudioTask(data=data)
+
+    DisfluencyWerGuardStage().process(task)
+
+    assert task.data[_RATE_KEY] == -1.0
+
+
+def test_existing_sentinel_is_not_overwritten_on_skipped_row() -> None:
+    task = AudioTask(data={_REF_KEY: "before", _HYP_KEY: "after", "_skipme": "other filter", _RATE_KEY: 12.5})
+
+    DisfluencyWerGuardStage().process(task)
+
+    assert task.data[_RATE_KEY] == 12.5
+
+
+def test_declares_reference_compatible_io_contract() -> None:
+    stage = DisfluencyWerGuardStage()
+
+    assert stage.inputs() == ([], [_REF_KEY, _HYP_KEY])
+    assert stage.outputs() == ([], [_HYP_KEY, _RATE_KEY])

--- a/tests/stages/audio/text_filtering/test_scriptio_continua.py
+++ b/tests/stages/audio/text_filtering/test_scriptio_continua.py
@@ -1,0 +1,66 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# ruff: noqa: INP001
+
+from collections.abc import Callable
+
+import pytest
+
+from nemo_curator.stages.audio.text_filtering.scriptio_continua import is_scriptio_continua
+from nemo_curator.stages.audio.text_filtering.text_metrics import (
+    character_error_rate_percent,
+    word_error_rate_percent,
+)
+
+
+@pytest.mark.parametrize(
+    "language",
+    ["ja", "zh", "zh-CN", "zh_tw", "zh-Hans", "zh-hant", "yue", "th", "lo", "km", "my", "bo", "dz"],
+)
+def test_reference_no_space_codes_are_recognized(language: str) -> None:
+    assert is_scriptio_continua(language)
+
+
+@pytest.mark.parametrize("language", ["Japanese", "CHINESE", "Thai"])
+def test_full_language_names_are_recognized(language: str) -> None:
+    assert is_scriptio_continua(language)
+
+
+@pytest.mark.parametrize("language", [None, "", "en", "ko", "vi", "ja-JP", "Cantonese", "Lao", "Khmer", "unknown"])
+def test_other_or_missing_languages_are_not_recognized(language: str | None) -> None:
+    assert not is_scriptio_continua(language)
+
+
+def test_word_and_character_metrics_diverge_for_unspaced_near_match() -> None:
+    reference = "这是一个测试句子用来检查协议"
+    hypothesis = "这是一个测试句子用来检查协义"
+
+    assert word_error_rate_percent(reference, hypothesis) == 100.0
+    assert character_error_rate_percent(reference, hypothesis) == 7.14
+
+
+@pytest.mark.parametrize(
+    ("metric", "reference", "hypothesis", "expected"),
+    [
+        (word_error_rate_percent, "", "", 0.0),
+        (word_error_rate_percent, "", "text", 100.0),
+        (character_error_rate_percent, "", "", 0.0),
+        (character_error_rate_percent, "", "字", 100.0),
+    ],
+)
+def test_empty_reference_metric_contract(
+    metric: Callable[[str, str], float], reference: str, hypothesis: str, expected: float
+) -> None:
+    assert metric(reference, hypothesis) == expected

--- a/tests/stages/audio/text_filtering/test_select_best_prediction.py
+++ b/tests/stages/audio/text_filtering/test_select_best_prediction.py
@@ -16,8 +16,13 @@
 
 from copy import deepcopy
 
+import pytest
+
 from nemo_curator.stages.audio.text_filtering import SelectBestPredictionStage
 from nemo_curator.tasks import AudioTask
+
+_JA_PRIMARY = "なんかおばあちゃんのレシピみたいなあのどんな思い出とか食べ物とかでどんな思い出とかあったりしますか"
+_JA_FALLBACK = "なんかばあちゃんのレシピみたいなあのどんな思い出とか食べ物とかでどんな思い出とかあったりしますか。"
 
 
 def test_uses_recovery_prediction_after_hallucination_recheck() -> None:
@@ -269,6 +274,7 @@ def test_cross_model_agreement_recovers_primary() -> None:
     assert task.data["best_prediction_source"] == "primary"
     assert task.data["_skipme"] == ""
     assert task.data["primary_fallback_agreement_wer"] == 0.0
+    assert task.data["primary_fallback_agreement_metric"] == "wer"
 
 
 def test_cross_model_agreement_uses_reference_wer_rounding() -> None:
@@ -284,6 +290,7 @@ def test_cross_model_agreement_uses_reference_wer_rounding() -> None:
     stage.process(task)
 
     assert task.data["primary_fallback_agreement_wer"] == 33.33
+    assert task.data["primary_fallback_agreement_metric"] == "wer"
     assert task.data["best_prediction"] == "one two three"
     assert task.data["_skipme"] == ""
 
@@ -303,6 +310,107 @@ def test_cross_model_disagreement_preserves_hallucination_skip() -> None:
     assert task.data["best_prediction_source"] == "primary"
     assert task.data["_skipme"] == "Hallucination"
     assert task.data["primary_fallback_agreement_wer"] > 20.0
+    assert task.data["primary_fallback_agreement_metric"] == "wer"
+
+
+def test_near_identical_japanese_predictions_are_recovered_with_cer() -> None:
+    task = AudioTask(
+        data={
+            "primary_model_prediction": _JA_PRIMARY,
+            "fallback_model_prediction": _JA_FALLBACK,
+            "_skipme": "Hallucination:WhisperHallucination",
+            "source_lang": "ja",
+        }
+    )
+
+    SelectBestPredictionStage().process(task)
+
+    assert task.data["best_prediction"] == _JA_PRIMARY
+    assert task.data["_skipme"] == ""
+    assert task.data["primary_fallback_agreement_metric"] == "cer"
+    assert task.data["primary_fallback_agreement_wer"] < 20.0
+
+
+@pytest.mark.parametrize("language", ["ja", "zh", "th", "zh-TW", "yue"])
+def test_no_space_languages_use_cer(language: str) -> None:
+    task = AudioTask(
+        data={
+            "primary_model_prediction": "这是一个测试句子用来检查协议",
+            "fallback_model_prediction": "这是一个测试句子用来检查协义",
+            "_skipme": "Hallucination:WhisperHallucination",
+            "source_lang": language,
+        }
+    )
+
+    SelectBestPredictionStage().process(task)
+
+    assert task.data["primary_fallback_agreement_metric"] == "cer"
+    assert task.data["_skipme"] == ""
+
+
+@pytest.mark.parametrize("language", ["en", "de", "es", "ko", "vi"])
+def test_space_separated_languages_use_wer(language: str) -> None:
+    task = AudioTask(
+        data={
+            "primary_model_prediction": "the cat sat on the mat",
+            "fallback_model_prediction": "the cat sat on the mat",
+            "_skipme": "Hallucination:WhisperHallucination",
+            "source_lang": language,
+        }
+    )
+
+    SelectBestPredictionStage().process(task)
+
+    assert task.data["primary_fallback_agreement_metric"] == "wer"
+    assert task.data["_skipme"] == ""
+
+
+def test_japanese_genuine_disagreement_remains_flagged() -> None:
+    task = AudioTask(
+        data={
+            "primary_model_prediction": "あなたのおすすめの映画は何ですか",
+            "fallback_model_prediction": "今日はとても良い天気ですね",
+            "_skipme": "Hallucination:WhisperHallucination",
+            "source_lang": "ja",
+        }
+    )
+
+    SelectBestPredictionStage().process(task)
+
+    assert task.data["_skipme"].startswith("Hallucination")
+    assert task.data["primary_fallback_agreement_metric"] == "cer"
+    assert task.data["primary_fallback_agreement_wer"] > 20.0
+
+
+def test_missing_language_defaults_to_wer() -> None:
+    task = AudioTask(
+        data={
+            "primary_model_prediction": "hello world",
+            "fallback_model_prediction": "hello world",
+            "_skipme": "Hallucination:WhisperHallucination",
+        }
+    )
+
+    SelectBestPredictionStage().process(task)
+
+    assert task.data["primary_fallback_agreement_metric"] == "wer"
+    assert task.data["_skipme"] == ""
+
+
+def test_custom_language_and_metric_keys_are_supported() -> None:
+    task = AudioTask(
+        data={
+            "primary_model_prediction": "日本語の文字列",
+            "fallback_model_prediction": "日本語の文宇列",
+            "_skipme": "Hallucination",
+            "lang": "Japanese",
+        }
+    )
+
+    SelectBestPredictionStage(language_key="lang", metric_key="agreement_metric").process(task)
+
+    assert task.data["agreement_metric"] == "cer"
+    assert "primary_fallback_agreement_metric" not in task.data
 
 
 def test_scans_all_recovery_notes_like_reference() -> None:
@@ -339,6 +447,7 @@ def test_rerunning_cross_model_agreement_scans_the_prior_recovery_note() -> None
     assert task.data["best_prediction_source"] == "fallback"
     assert task.data["_skipme"] == ""
     assert "primary_fallback_agreement_wer" not in task.data
+    assert "primary_fallback_agreement_metric" not in task.data
     assert task.data["additional_notes"]["SelectBestPrediction"] == "used fallback"
 
 
@@ -352,6 +461,7 @@ def test_declares_every_mutated_output_key() -> None:
             "best_prediction_source",
             "_skipme",
             "primary_fallback_agreement_wer",
+            "primary_fallback_agreement_metric",
             "additional_notes",
         ],
     )

--- a/tests/stages/audio/text_filtering/test_whisper_hallucination.py
+++ b/tests/stages/audio/text_filtering/test_whisper_hallucination.py
@@ -28,6 +28,7 @@ _TEXT_KEY = "pred_text"
 _SKIP_KEY = "_skipme"
 _REPO_ROOT = Path(__file__).resolve().parents[4]
 _EXAMPLE_DIR = _REPO_ROOT / "tutorials" / "audio" / "whisper_hallucination"
+_JA_LONG = "なんかおばあちゃんのレシピみたいなあのどんな思い出とか食べ物とかでどんな思い出とかあったりしますか"
 
 
 def _make_stage(tmp_path: Path, phrases: list[str], **kwargs) -> WhisperHallucinationStage:
@@ -155,6 +156,56 @@ def test_agglutinative_language_skips_relative_long_word_check(tmp_path: Path) -
     stage = _make_stage(tmp_path, [])
     result = stage.process(AudioTask(data={_TEXT_KEY: "a természetvédelmi cat", _SKIP_KEY: "", "language": "hu"}))
     assert result.data[_SKIP_KEY] == ""
+
+
+def test_long_japanese_utterance_does_not_trigger_word_checks(tmp_path: Path) -> None:
+    stage = _make_stage(tmp_path, [])
+    result = stage.process(AudioTask(data={_TEXT_KEY: _JA_LONG, _SKIP_KEY: "", "language": "ja"}))
+
+    assert result.data[_SKIP_KEY] == ""
+    assert result.data["additional_notes"]["WhisperHallucination"] == "passed"
+
+
+@pytest.mark.parametrize("language", ["ja", "zh", "th", "zh-CN", "yue", "Japanese"])
+def test_no_space_languages_skip_word_checks(tmp_path: Path, language: str) -> None:
+    stage = _make_stage(tmp_path, [])
+    result = stage.process(AudioTask(data={_TEXT_KEY: "字" * 60, _SKIP_KEY: "", "language": language}))
+
+    assert result.data[_SKIP_KEY] == ""
+
+
+def test_no_space_language_skips_repeated_word_check(tmp_path: Path) -> None:
+    stage = _make_stage(tmp_path, [])
+    result = stage.process(
+        AudioTask(data={_TEXT_KEY: "字 字 字 字 字 字", _SKIP_KEY: "", "language": "ja", "duration": 20.0})
+    )
+
+    assert result.data[_SKIP_KEY] == ""
+
+
+def test_identical_long_text_still_uses_word_checks_for_english(tmp_path: Path) -> None:
+    stage = _make_stage(tmp_path, [])
+    result = stage.process(AudioTask(data={_TEXT_KEY: _JA_LONG, _SKIP_KEY: "", "language": "en"}))
+
+    assert result.data[_SKIP_KEY] == "Hallucination:WhisperHallucination"
+    assert "long_word" in result.data["additional_notes"]["WhisperHallucination"]
+
+
+def test_no_space_language_still_triggers_phrase_match(tmp_path: Path) -> None:
+    phrase = "ご視聴ありがとうございました"
+    stage = _make_stage(tmp_path, [phrase])
+    result = stage.process(AudioTask(data={_TEXT_KEY: phrase, _SKIP_KEY: "", "language": "ja"}))
+
+    assert result.data[_SKIP_KEY] == "Hallucination:WhisperHallucination"
+    assert result.data["additional_notes"]["WhisperHallucination"] == "hallucination (phrase_match)"
+
+
+def test_no_space_language_still_triggers_high_character_rate(tmp_path: Path) -> None:
+    stage = _make_stage(tmp_path, [], max_char_rate=40.0)
+    result = stage.process(AudioTask(data={_TEXT_KEY: "字" * 100, _SKIP_KEY: "", "language": "ja", "duration": 1.0}))
+
+    assert result.data[_SKIP_KEY] == "Hallucination:WhisperHallucination"
+    assert result.data["additional_notes"]["WhisperHallucination"] == "hallucination (high_char_rate)"
 
 
 def test_missing_duration_disables_character_rate_check(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- add `DisfluencyWerGuardStage`, using CER for scriptio-continua languages and WER otherwise
- skip whitespace-dependent repeated-word and long-word hallucination checks for no-space scripts while retaining phrase and character-rate checks
- use CER for primary/recovery agreement on no-space scripts and record the selected metric
- add dependency-free shared error-rate and scriptio-continua helpers

This is a current-`main`-native port of the three no-space-script behaviors from `nithinraok/Curator@1e2d639946f28dfd289a0a9456480385d4480c28` (feature commit `c9b4fb4e532d56978ead910675a2ef86aa62016b`). A direct cherry-pick is not viable because current `main` already contains newer implementations of `WhisperHallucinationStage` and `SelectBestPredictionStage`.

## Behavior

`SCRIPTIO_CONTINUA_LANGUAGE_CODES` covers Japanese, Chinese locale variants, Cantonese, Thai, Lao, Khmer, Burmese, Tibetan, and Dzongkha, matching the reference contract. Missing or space-separated languages retain the existing WER/word-heuristic behavior.

The selector keeps main's generic field naming (`primary_fallback_agreement_*`) while exposing configurable keys for pipelines that use the reference's `omni_asr_agreement_*` names.

## Validation

- `ruff format --check`: passed
- `ruff check`: passed
- focused unit suite: `127 passed`
- local target-versus-reference parity:
  - target: `2baa97e7903c9bbab0b126bf9ca99cb1d3453004`
  - reference: `1e2d639946f28dfd289a0a9456480385d4480c28`
  - 40 frozen cases: 11 guard, 11 hallucination, 13 selector, 5 composed stage-flow cases
  - Chinese, Japanese, Thai, locale/name aliases, missing-language fallbacks, English/German/Korean controls, near matches, genuine disagreements, phrase matches, high character rate, and both word heuristics
  - 40/40 independent behavioral oracle checks passed on each arm
  - zero missing rows and zero output mismatches
  - target/reference outputs were byte-identical on two isolated executions: SHA-256 `22d3baa54b38baa11270ea20111c042f5f488dbf3dc9ddde542e446b1c8aa686`

The parity run intentionally starts at these deterministic text-filtering stages. No ASR model run is needed: the changed contracts consume already-produced transcript/language/duration fields and do not modify Qwen inference.

## Related work

Draft PR #1881 contains an older WER-only baseline. This PR applies only the requested no-space behavior to current `main` and supplies the missing guard without bringing over the unrelated legacy Qwen pipeline stack.
