### PR TITLE
perf(semdedup): default pairwise precision to fp16

### DIFF
--- a/benchmarking/benchmarks.yaml
+++ b/benchmarking/benchmarks.yaml
@@ -615,8 +615,8 @@ entries:
       --eps=0.01
       --which-to-keep=hard
       --pairwise-batch-size=1024
-      --kmeans-embedding-output-dtype=float32
-      --pairwise-compute-dtype=float32
+      --kmeans-embedding-output-dtype=float16
+      --pairwise-compute-dtype=float16
       --dataset-size-ratio=0.20
       --fit-data-fraction=1.0
     timeout_s: 1200
@@ -670,8 +670,8 @@ entries:
       --eps=0.01
       --which-to-keep=hard
       --pairwise-batch-size=1024
-      --kmeans-embedding-output-dtype=float32
-      --pairwise-compute-dtype=float32
+      --kmeans-embedding-output-dtype=float16
+      --pairwise-compute-dtype=float16
       --fit-data-fraction=0.20
     timeout_s: 1800
     sink_data:

--- a/benchmarking/scripts/semdedup_identification_benchmark.py
+++ b/benchmarking/scripts/semdedup_identification_benchmark.py
@@ -47,8 +47,8 @@ def run_semdedup_identification_benchmark(  # noqa: PLR0913
     which_to_keep: str = "hard",
     pairwise_batch_size: int = 1024,
     fit_data_fraction: float | None = None,
-    pairwise_compute_dtype: str = "float32",
-    kmeans_embedding_output_dtype: str = "float32",
+    pairwise_compute_dtype: str = "float16",
+    kmeans_embedding_output_dtype: str = "float16",
     **kwargs,  # noqa: ARG001
 ) -> dict[str, Any]:
     """Run the semantic duplicate identification benchmark and collect comprehensive metrics.

--- a/benchmarking/scripts/semdedup_identification_benchmark.py
+++ b/benchmarking/scripts/semdedup_identification_benchmark.py
@@ -243,13 +243,13 @@ def main() -> int:
     parser.add_argument(
         "--kmeans-embedding-output-dtype",
         choices=["float16", "float32"],
-        default="float32",
+        default="float16",
         help="Precision used to store KMeans embedding output",
     )
     parser.add_argument(
         "--pairwise-compute-dtype",
         choices=["auto", "float16", "float32"],
-        default="float32",
+        default="float16",
         help="Multiplication precision used by Pairwise",
     )
     parser.add_argument(

--- a/fern/versions/main/pages/curate-text/process-data/deduplication/semdedup.mdx
+++ b/fern/versions/main/pages/curate-text/process-data/deduplication/semdedup.mdx
@@ -153,8 +153,8 @@ Compare semantic deduplication with other methods:
 | `kmeans_fit_data_fraction` | float \| None | `None` | Fraction of generated Parquet embedding files used to fit K-means. `None` automatically selects complete embedding files within the live GPU-memory budget. |
 | `eps` | float | `0.01` | Threshold for deduplication (higher = more aggressive) |
 | `which_to_keep` | str | `"hard"` | Strategy for keeping duplicates ("hard", "easy", or "random") |
-| `kmeans_embedding_output_dtype` | str | `"float32"` | Precision used to store KMeans embeddings for Pairwise (`"float16"` or `"float32"`) |
-| `pairwise_compute_dtype` | str | `"float32"` | Pairwise multiplication precision: `"auto"`, `"float16"`, or `"float32"` |
+| `kmeans_embedding_output_dtype` | str | `"float16"` | Precision used to store KMeans embeddings for Pairwise (`"float16"` or `"float32"`) |
+| `pairwise_compute_dtype` | str | `"float16"` | Pairwise multiplication precision: `"auto"`, `"float16"`, or `"float32"` |
 | `pairwise_batch_size` | int | `1024` | Positive batch size for the bounded similarity workspace |
 | `distance_metric` | str | `"cosine"` | Distance metric for similarity ("cosine" or "l2") |
 | `perform_removal` | bool | `True` | Whether to perform duplicate removal |
@@ -195,11 +195,13 @@ Because they have unit length, `X @ X.T` is their cosine-similarity matrix:
 
 Only candidates to the left of the query's diagonal are eligible. Pairwise therefore selects `B -> A (0.96)`, `C -> B (0.28)`, `D -> A (0.00)`, and `E -> C (0.96)`. With `eps=0.1`, the duplicate threshold is `1 - eps = 0.9`, so the next stage removes query rows `B` and `E` while preserving `A`, `C`, and `D`. An earlier-ranked candidate remains eligible even if that candidate is itself later marked for removal.
 
-KMeans fit, prediction, and distance calculations remain FP32. By default, KMeans retains FP32 embeddings in its output. Set `kmeans_embedding_output_dtype="float16"` to cast normalized embeddings to FP16 and store their bit patterns in uint16 list leaves because cuDF does not support numeric FP16 columns. The uint16 representation does not guarantee half-sized Parquet files because Parquet stores uint16 values using an INT32 physical type.
+KMeans fit, prediction, and distance calculations remain FP32. By default, KMeans casts normalized embeddings to FP16 and stores their bit patterns in uint16 list leaves because cuDF does not support numeric FP16 columns. Set `kmeans_embedding_output_dtype="float32"` to retain FP32 embeddings. The uint16 representation does not guarantee half-sized Parquet files because Parquet stores uint16 values using an INT32 physical type.
 
 Pairwise infers storage precision from the embedding list leaves: uint16 leaves are decoded as FP16 bit patterns, FP32 leaves keep their precision, and legacy FP64 leaves are normalized to FP32. With `pairwise_compute_dtype="auto"`, FP16 embeddings use FP16 multiplication and FP32 embeddings use FP32. FP32 embeddings can instead use `"float16"` multiplication; upcasting stored FP16 embeddings is rejected because it cannot restore the discarded precision.
 
 FP16 scores remain FP16 through multiplication and reduction, then are promoted to FP32 because cuDF does not support an FP16 numeric output column. Pairwise records cumulative footer scan, read, rank, precision conversion, compute, and write time.
+
+Use FP32 storage and compute when exact or near-exact similarity thresholds make FP16 rounding material, or when the selected nearest-neighbor ID is part of the required output contract.
 
 ### Control K-means fitting memory
 

--- a/nemo_curator/config/text/semantic_deduplication_pipeline.yaml
+++ b/nemo_curator/config/text/semantic_deduplication_pipeline.yaml
@@ -64,8 +64,8 @@ workflow:
       _target_: nemo_curator.stages.deduplication.semantic.RankingStrategy
       metadata_cols: ["cosine_dist_to_cent"]
       ascending: True
-    kmeans_embedding_output_dtype: float32
-    pairwise_compute_dtype: float32
+    kmeans_embedding_output_dtype: float16
+    pairwise_compute_dtype: float16
     pairwise_batch_size: 1024
     # ID generator parameters
     # For large scale data removal we should set use_id_generator to True

--- a/nemo_curator/stages/deduplication/semantic/workflow.py
+++ b/nemo_curator/stages/deduplication/semantic/workflow.py
@@ -107,8 +107,8 @@ class SemanticDeduplicationWorkflow(WorkflowBase):
         # Execution parameters
         verbose: bool = True,
         # Pairwise precision (appended for positional compatibility)
-        pairwise_compute_dtype: PairwiseComputeDtype = "float32",
-        kmeans_embedding_output_dtype: KMeansEmbeddingOutputDtype = "float32",
+        pairwise_compute_dtype: PairwiseComputeDtype = "float16",
+        kmeans_embedding_output_dtype: KMeansEmbeddingOutputDtype = "float16",
     ):
         """
         Initialize the semantic deduplication workflow.

--- a/nemo_curator/stages/text/deduplication/semantic.py
+++ b/nemo_curator/stages/text/deduplication/semantic.py
@@ -121,8 +121,8 @@ class TextSemanticDeduplicationWorkflow:
     verbose: bool = True
     clear_output: bool = True
     # Pairwise precision (appended for positional compatibility)
-    pairwise_compute_dtype: PairwiseComputeDtype = "float32"
-    kmeans_embedding_output_dtype: KMeansEmbeddingOutputDtype = "float32"
+    pairwise_compute_dtype: PairwiseComputeDtype = "float16"
+    kmeans_embedding_output_dtype: KMeansEmbeddingOutputDtype = "float16"
     """
     Initialize the text semantic deduplication workflow.
 

--- a/tests/stages/deduplication/semantic/test_workflow.py
+++ b/tests/stages/deduplication/semantic/test_workflow.py
@@ -107,8 +107,6 @@ class TestSemanticDeduplicationWorkflow:
             which_to_keep=which_to_keep,
             eps=0.01,
             random_state=42,
-            kmeans_embedding_output_dtype="float32",
-            pairwise_compute_dtype="float32",
             verbose=False,
         )
 

--- a/tests/stages/text/deduplication/test_semantic.py
+++ b/tests/stages/text/deduplication/test_semantic.py
@@ -205,8 +205,6 @@ class TestTextSemanticDeduplicationWorkflow:
             n_clusters=3,  # Use fewer clusters to group similar documents
             eps=0.1,  # Set epsilon to identify duplicates
             which_to_keep="hard",  # Keep harder examples (less similar to others)
-            kmeans_embedding_output_dtype="float32",
-            pairwise_compute_dtype="float32",
             use_id_generator=use_id_generator,
             id_field="id" if not use_id_generator else "_curator_dedup_id",
             input_filetype="parquet",


### PR DESCRIPTION
## Description

Change the default SemDedup precision from FP32 to FP16 for both:
- KMeans embedding output storage
- Pairwise cosine-similarity computation

KMeans fitting, prediction, and centroid-distance calculations remain FP32. Users can explicitly select FP32 storage and compute if they want to.

## TLDR of findings

For the 65.8M-document / 329.8M-document workloads, respectively:

- KMeans write time improved by 1.10x / 1.21x (8.7% / 17.7% lower).
- Pairwise matrix-multiply time improved by 5.15x / 7.94x (80.6% / 87.4% lower).
- Overall workflow runtime improved by 1.08x / 1.71x (7.3% / 41.7% lower).
- At the default threshold of `0.99`, FP32 alone removes 475 IDs and FP16 alone removes 962 IDs. All 1,437 changed decisions have an absolute score movement at most `0.0005`.
- Across the complete corpus, the absolute score delta has mean `0.0001175`, p95 `0.0002335`, p99 `0.0002547`, and maximum `0.0005836`.
## Scale validation

This was evaluated on the `semdedup_identification_xenna_dataset_size_ratio` workload with:

- 65,844,782 documents
- 1,000 KMeans clusters
- 8 H100 GPUs
- `which_to_keep="hard"`
- default `eps=0.01`, corresponding to cosine similarity threshold `0.99`

### Controlled methodology

The three original end-to-end benchmark variants independently reran KMeans. Their clusters and within-cluster rankings therefore differed, so comparing only their duplicate counts does not isolate precision.

To make the comparison causal, the FP32 KMeans output was frozen and Pairwise was replayed in FP16 against those exact same clusters and rankings. The FP32 and FP16 Pairwise outputs were then joined across all 65,844,782 IDs; this analysis used no sampling. Every ID was present in both outputs and remained in the same numeric cluster.

### Duplicate-set agreement across thresholds

“Decision flips” count IDs whose final keep/remove outcome changes. Removal Jaccard is the intersection divided by the union of removed-ID sets.

| Cosine threshold | FP32 removes | FP16 removes | Decision flips | Corpus flip rate | Removal Jaccard |
| ---: | ---: | ---: | ---: | ---: | ---: |
| 0.9000 | 8,172,085 | 8,158,692 | 13,393 | 0.020340% | 99.8361% |
| 0.9500 | 4,186,169 | 4,189,465 | 3,304 | 0.005018% | 99.9211% |
| 0.9700 | 2,728,914 | 2,730,783 | 1,985 | 0.003015% | 99.9273% |
| 0.9800 | 1,970,010 | 1,952,235 | 17,775 | 0.026995% | 99.0977% |
| 0.9850 | 1,573,749 | 1,564,693 | 9,056 | 0.013754% | 99.4246% |
| **0.9900** | **1,154,802** | **1,155,289** | **1,437** | **0.002182%** | **99.8757%** |
| 0.9920 | 980,030 | 984,656 | 4,628 | 0.007029% | 99.5300% |
| 0.9950 | 715,662 | 726,559 | 10,897 | 0.016550% | 98.5002% |
| 0.9970 | 535,315 | 550,937 | 15,622 | 0.023725% | 97.1645% |
| 0.9990 | 335,145 | 359,529 | 24,384 | 0.037033% | 93.2178% |
| 0.9995 | 270,443 | 301,995 | 31,552 | 0.047919% | 89.5521% |
| 1.0000 | 71,521 | 224,049 | 152,528 | 0.231648% | 31.9220% |

At the default threshold of `0.99`, FP32 alone removes 475 IDs and FP16 alone removes 962 IDs. All 1,437 changed decisions have an absolute score movement at most `0.0005`.

Across the complete corpus, the absolute score delta has mean `0.0001175`, p95 `0.0002335`, p99 `0.0002547`, and maximum `0.0005836`.

### Nearest-neighbor identity

At threshold `0.99`, 153,133 of the 1,154,327 IDs removed by both modes select a different earlier-ranked nearest neighbor: 86.734% parent agreement.

This does not change the current removal output, which consumes the duplicate ID rather than its selected `max_id`. It does matter if nearest-neighbor identity is used as a stable explanation, representative mapping, or downstream component edge.

### Storage and performance observations

The latest EOS comparison uses the FP32 nightly `nightly-2026_09_10__06_35_45_UTC` at commit `fed018ee` and the FP16 PR run `praateekmahajan-pr-2388-2026_09_10__19_14_14_UTC-e959e761` at commit `e959e761`. Both ran with 1,000 clusters, a Pairwise batch size of 1,024, and 8 H100 GPUs.

| Workload | Metric | FP32 nightly | FP16 PR | Time reduction | Speedup |
| --- | --- | ---: | ---: | ---: | ---: |
| 65,844,782 documents | Workflow wall time | 178.04 s | 165.03 s | 7.3% | 1.08x |
| 65,844,782 documents | Pairwise wall time | 54.68 s | 44.81 s | 18.1% | 1.22x |
| 65,844,782 documents | Cumulative Pairwise compute time | 91.78 s | 17.81 s | 80.6% | 5.15x |
| 65,844,782 documents | KMeans write time | 21.91 s | 20.00 s | 8.7% | 1.10x |
| 329,774,475 documents | Workflow wall time | 761.09 s | 444.04 s | 41.7% | 1.71x |
| 329,774,475 documents | Pairwise wall time | 400.62 s | 111.95 s | 72.1% | 3.58x |
| 329,774,475 documents | Cumulative Pairwise compute time | 2,049.25 s | 258.00 s | 87.4% | 7.94x |
| 329,774,475 documents | Cumulative Pairwise read time | 497.42 s | 222.97 s | 55.2% | 2.23x |
| 329,774,475 documents | KMeans write time | 100.00 s | 82.31 s | 17.7% | 1.21x |

The two benchmark entries recorded `float32` storage/compute in nightly and `float16` storage/compute in the PR run. The runs used different EOS hosts and independently fit KMeans, so these are end-to-end operational observations rather than paired microbenchmarks. The controlled quality comparison above instead freezes the FP32 KMeans output.

The earlier storage experiment measured approximately 191 GiB of benchmark cache with FP32 KMeans output and 94 GiB with FP16 output.

FP16 storage does not introduce a second rounding step once Pairwise compute is FP16: FP32-storage/FP16-compute casts embeddings to FP16 before multiplication, while FP16 storage performs the same cast before serialization.
### Guardrails

- The scale results support FP16 defaults for the current removed-ID contract at the default `eps=0.01`.
- FP16 is not interchangeable with FP32 at exact or near-exact thresholds.
- Use explicit FP32 storage and compute when nearest-neighbor identity is contractual or when exact/near-exact thresholds are required.

## Usage

The new defaults require no configuration:

```python
workflow = SemanticDeduplicationWorkflow(...)
```

Retain the previous behavior explicitly when needed:

```python
workflow = SemanticDeduplicationWorkflow(
    ...,
    kmeans_embedding_output_dtype="float32",
    pairwise_compute_dtype="float32",
)
```

## Validation

- `uvx pre-commit run --files <changed files>`

All hooks passed. No Curator imports or compute tests were run on the SLURM login node.

## Checklist

- [ ] I am familiar with the [Contributing Guide](https://github.com/NVIDIA-NeMo/Curator/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.


Closes NMCUR-465