### PR TITLE
[benchmarking] Add environment config for benchmark subprocesses

### DIFF
--- a/.github/workflows/config/.secrets.baseline
+++ b/.github/workflows/config/.secrets.baseline
@@ -435,6 +435,15 @@
         "line_number": 55
       }
     ],
+    "tests/benchmarking/runner/test_process.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/benchmarking/runner/test_process.py",
+        "hashed_secret": "dff6d4ff5dc357cf451d1855ab9cbda562645c9f",
+        "is_verified": false,
+        "line_number": 33
+      }
+    ],
     "tests/models/client/test_openai_client.py": [
       {
         "type": "Secret Keyword",
@@ -534,5 +543,5 @@
       }
     ]
   },
-  "generated_at": "2026-09-09T19:37:37Z"
+  "generated_at": "2026-09-11T14:18:56Z"
 }

--- a/benchmarking/4xGB200-64CPU.yaml
+++ b/benchmarking/4xGB200-64CPU.yaml
@@ -43,9 +43,15 @@ entries:
 
   - name: exact_dedup_identification
     timeout_s: 2400
+    environment:
+      UCX_TLS: all
+      CONTAINER_ENVS: UCX_TLS
 
   - name: fuzzy_dedup_identification
     timeout_s: 2400
+    environment:
+      UCX_TLS: all
+      CONTAINER_ENVS: UCX_TLS
 
   - name: minhash_file_group_task_ray_actors
     timeout_s: 1024

--- a/benchmarking/README.md
+++ b/benchmarking/README.md
@@ -246,6 +246,12 @@ ray:
   num_gpus: 8
   enable_object_spilling: false
 
+# Optional: Global environment variables inherited by benchmark subprocesses.
+# Per-entry environment sections add variables and override matching names.
+environment:
+  NCCL_DEBUG: WARN
+  HF_HOME: "{model_weights_path}/hf_cache"
+
 # Optional: Define datasets for template substitution
 datasets:
   - name: common_crawl
@@ -276,6 +282,12 @@ entries:
       num_gpus: 1
       enable_object_spilling: false
 
+    # Optional: Add or override environment variables for this entry subprocess.
+    # This entry inherits NCCL_DEBUG from the top-level environment and overrides HF_HOME.
+    environment:
+      HF_HOME: "{session_entry_dir}/scratch/hf_cache"
+      UCX_TLS: all
+
     # Optional: Requirements for the benchmark to pass
     requirements:
       - metric: throughput_docs_per_sec
@@ -284,6 +296,14 @@ entries:
     # Optional: Override global delete_scratch setting
     delete_scratch: false
 ```
+
+Environment variables configured in YAML are merged into the current process
+environment before each benchmark subprocess starts. Top-level `environment`
+values apply to every entry. Entry-level `environment` values are merged on top
+of the top-level values and override individual variables with the same name.
+The full subprocess environment is written to the entry's `logs/stdouterr.log`
+before the command output starts; obvious secret-bearing variable names such as
+tokens, passwords, credentials, and API keys are redacted in that debug dump.
 
 ### Passing Configuration Files
 

--- a/benchmarking/README.md
+++ b/benchmarking/README.md
@@ -301,9 +301,11 @@ Environment variables configured in YAML are merged into the current process
 environment before each benchmark subprocess starts. Top-level `environment`
 values apply to every entry. Entry-level `environment` values are merged on top
 of the top-level values and override individual variables with the same name.
-The full subprocess environment is written to the entry's `logs/stdouterr.log`
-before the command output starts; obvious secret-bearing variable names such as
-tokens, passwords, credentials, and API keys are redacted in that debug dump.
+The full list of subprocess environment variable names is written to the
+entry's `logs/stdouterr.log` before the command output starts. Values inherited
+from the parent process are redacted by default. Values configured in YAML are
+shown only when their variable names do not look secret-bearing; tokens,
+passwords, credentials, keys, webhooks, and similar values are redacted.
 
 ### Passing Configuration Files
 

--- a/benchmarking/benchmarks.yaml
+++ b/benchmarking/benchmarks.yaml
@@ -312,6 +312,9 @@ entries:
   - name: exact_dedup_identification
     enabled: true
     script: exact_dedup_identification_benchmark.py
+    environment:
+      UCX_TLS: all
+      CONTAINER_ENVS: UCX_TLS
     args: >-
       --benchmark-results-path={session_entry_dir}
       --input-path={dataset:rpv2-2023-14-en,parquet}
@@ -334,6 +337,9 @@ entries:
   - name: fuzzy_dedup_identification
     enabled: true
     script: fuzzy_dedup_identification_benchmark.py
+    environment:
+      UCX_TLS: all
+      CONTAINER_ENVS: UCX_TLS
     args: >-
       --benchmark-results-path={session_entry_dir}
       --input-path={dataset:commoncrawl,jsonl}

--- a/benchmarking/benchmarks.yaml
+++ b/benchmarking/benchmarks.yaml
@@ -175,7 +175,7 @@ sinks:
     thread_replies_for_failures_or_warnings_only: true
     channel_id: ${SLACK_CHANNEL_ID}
     default_metrics: ["exec_time_s"]
-    ping_users_on_failure: true
+    ping_users_on_failure: false
 #  - name: gdrive
 #    enabled: false
 #    drive_folder_id: ${GDRIVE_FOLDER_ID}

--- a/benchmarking/benchmarks.yaml
+++ b/benchmarking/benchmarks.yaml
@@ -312,9 +312,6 @@ entries:
   - name: exact_dedup_identification
     enabled: true
     script: exact_dedup_identification_benchmark.py
-    environment:
-      UCX_TLS: all
-      CONTAINER_ENVS: UCX_TLS
     args: >-
       --benchmark-results-path={session_entry_dir}
       --input-path={dataset:rpv2-2023-14-en,parquet}
@@ -337,9 +334,6 @@ entries:
   - name: fuzzy_dedup_identification
     enabled: true
     script: fuzzy_dedup_identification_benchmark.py
-    environment:
-      UCX_TLS: all
-      CONTAINER_ENVS: UCX_TLS
     args: >-
       --benchmark-results-path={session_entry_dir}
       --input-path={dataset:commoncrawl,jsonl}

--- a/benchmarking/benchmarks.yaml
+++ b/benchmarking/benchmarks.yaml
@@ -196,6 +196,13 @@ ray:
   num_gpus: 8
   enable_object_spilling: false
 
+# Global environment variables inherited by all benchmark subprocesses.
+# Keep Ray Data scheduler diagnostics enabled for benchmark runs so entry logs
+# include scheduler events that help explain stalls, resource bottlenecks, and
+# autoscaling behavior during post-run analysis.
+environment:
+  NEMO_CURATOR_RAY_DATA_DIAGNOSTICS: "1"
+
 entries:
   - name: domain_classification_raydata
     enabled: true

--- a/benchmarking/benchmarks.yaml
+++ b/benchmarking/benchmarks.yaml
@@ -167,7 +167,7 @@ sinks:
 #    tracking_uri: ${MLFLOW_TRACKING_URI}
 #    experiment: ray-curator-common-crawl
   - name: slack
-    enabled: true
+    enabled: false
     live_updates: true
     thread_replies_for_failures_or_warnings_only: true
     channel_id: ${SLACK_CHANNEL_ID}

--- a/benchmarking/benchmarks.yaml
+++ b/benchmarking/benchmarks.yaml
@@ -167,6 +167,9 @@ sinks:
 #    tracking_uri: ${MLFLOW_TRACKING_URI}
 #    experiment: ray-curator-common-crawl
   - name: slack
+    # Disabled by default so local/open-source runs do not require Slack
+    # credentials or post notifications. Managed orchestration can re-enable
+    # this sink with an override config while reusing the settings below.
     enabled: false
     live_updates: true
     thread_replies_for_failures_or_warnings_only: true
@@ -195,13 +198,6 @@ ray:
   num_cpus: 128
   num_gpus: 8
   enable_object_spilling: false
-
-# Global environment variables inherited by all benchmark subprocesses.
-# Keep Ray Data scheduler diagnostics enabled for benchmark runs so entry logs
-# include scheduler events that help explain stalls, resource bottlenecks, and
-# autoscaling behavior during post-run analysis.
-environment:
-  NEMO_CURATOR_RAY_DATA_DIAGNOSTICS: "1"
 
 entries:
   - name: domain_classification_raydata

--- a/benchmarking/run.py
+++ b/benchmarking/run.py
@@ -43,6 +43,7 @@ sys.path.insert(0, _this_script_dir)
 from runner.datasets import DatasetResolver
 from runner.entry import Entry
 from runner.env_capture import dump_env
+from runner.environment import merge_subprocess_environment
 from runner.gpu_stats_recorder import GPUStatsRecorder
 from runner.path_resolver import PathResolver
 from runner.process import run_command_with_timeout
@@ -164,7 +165,7 @@ def build_subprocess_environment(
         resolved_value = entry.substitute_reserved_placeholders(value, session_entry_path, dataset_resolver)
         resolved_value = entry.substitute_container_or_host_paths(resolved_value, path_resolver)
         entry_environment[name] = resolved_value
-    return {**os.environ, **entry_environment}, set(entry_environment)
+    return merge_subprocess_environment(entry_environment), set(entry_environment)
 
 
 def run_data_setup_entry(

--- a/benchmarking/run.py
+++ b/benchmarking/run.py
@@ -26,9 +26,6 @@ from contextlib import nullcontext
 from pathlib import Path
 from typing import Any
 
-# Benchmark runs always retain Ray Data scheduler diagnostics for post-run analysis.
-os.environ.setdefault("NEMO_CURATOR_RAY_DATA_DIAGNOSTICS", "1")
-
 from loguru import logger
 
 from nemo_curator.pipeline.workflow import WorkflowRunResult

--- a/benchmarking/run.py
+++ b/benchmarking/run.py
@@ -155,6 +155,21 @@ def check_requirements_update_results(result_data: dict[str, Any], requirements:
     return meets_requirements
 
 
+def build_subprocess_environment(
+    entry: Entry,
+    session_entry_path: Path,
+    path_resolver: PathResolver,
+    dataset_resolver: DatasetResolver,
+) -> dict[str, str]:
+    """Return the full environment for an entry subprocess."""
+    entry_environment = {}
+    for name, value in entry.environment.items():
+        resolved_value = entry.substitute_reserved_placeholders(value, session_entry_path, dataset_resolver)
+        resolved_value = entry.substitute_container_or_host_paths(resolved_value, path_resolver)
+        entry_environment[name] = resolved_value
+    return {**os.environ, **entry_environment}
+
+
 def run_data_setup_entry(
     setup_entry: Entry,
     path_resolver: PathResolver,
@@ -184,6 +199,7 @@ def run_data_setup_entry(
             command=cmd,
             timeout=setup_entry.timeout_s,
             stdouterr_path=stdouterr_path,
+            env=build_subprocess_environment(setup_entry, setup_path, path_resolver, dataset_resolver),
             run_id=f"data_setup-{setup_entry.name}-{int(started_exec)}",
             fancy=os.environ.get("CURATOR_BENCHMARKING_DEBUG", "0") == "0",
         )
@@ -319,6 +335,7 @@ def run_entry(  # noqa: PLR0913
                 command=cmd,
                 timeout=entry.timeout_s,
                 stdouterr_path=stdouterr_path,
+                env=build_subprocess_environment(entry, session_entry_path, path_resolver, dataset_resolver),
                 run_id=run_id,
                 fancy=os.environ.get("CURATOR_BENCHMARKING_DEBUG", "0") == "0",
             )

--- a/benchmarking/run.py
+++ b/benchmarking/run.py
@@ -160,14 +160,14 @@ def build_subprocess_environment(
     session_entry_path: Path,
     path_resolver: PathResolver,
     dataset_resolver: DatasetResolver,
-) -> dict[str, str]:
-    """Return the full environment for an entry subprocess."""
+) -> tuple[dict[str, str], set[str]]:
+    """Return the full subprocess environment and the configured names safe to consider for value logging."""
     entry_environment = {}
     for name, value in entry.environment.items():
         resolved_value = entry.substitute_reserved_placeholders(value, session_entry_path, dataset_resolver)
         resolved_value = entry.substitute_container_or_host_paths(resolved_value, path_resolver)
         entry_environment[name] = resolved_value
-    return {**os.environ, **entry_environment}
+    return {**os.environ, **entry_environment}, set(entry_environment)
 
 
 def run_data_setup_entry(
@@ -195,11 +195,15 @@ def run_data_setup_entry(
         "logs_dir": logs_path,
     }
     try:
+        subprocess_env, configured_env_names = build_subprocess_environment(
+            setup_entry, setup_path, path_resolver, dataset_resolver
+        )
         run_data = run_command_with_timeout(
             command=cmd,
             timeout=setup_entry.timeout_s,
             stdouterr_path=stdouterr_path,
-            env=build_subprocess_environment(setup_entry, setup_path, path_resolver, dataset_resolver),
+            env=subprocess_env,
+            env_value_allowlist=configured_env_names,
             run_id=f"data_setup-{setup_entry.name}-{int(started_exec)}",
             fancy=os.environ.get("CURATOR_BENCHMARKING_DEBUG", "0") == "0",
         )
@@ -330,12 +334,16 @@ def run_entry(  # noqa: PLR0913
             else nullcontext()
         )
         started_exec = time.time()
+        subprocess_env, configured_env_names = build_subprocess_environment(
+            entry, session_entry_path, path_resolver, dataset_resolver
+        )
         with gpu_stats_recorder_ctx:
             run_data = run_command_with_timeout(
                 command=cmd,
                 timeout=entry.timeout_s,
                 stdouterr_path=stdouterr_path,
-                env=build_subprocess_environment(entry, session_entry_path, path_resolver, dataset_resolver),
+                env=subprocess_env,
+                env_value_allowlist=configured_env_names,
                 run_id=run_id,
                 fancy=os.environ.get("CURATOR_BENCHMARKING_DEBUG", "0") == "0",
             )

--- a/benchmarking/runner/entry.py
+++ b/benchmarking/runner/entry.py
@@ -31,6 +31,29 @@ _curator_repo_path = Path(__file__).parent.parent.parent
 _entry_script_base_path = _curator_repo_path / "benchmarking/scripts"
 
 
+def normalize_environment(environment: dict[str, Any] | None, context: str) -> dict[str, str]:
+    """Validate an environment config block and return values suitable for subprocess."""
+    if environment is None:
+        return {}
+    if not isinstance(environment, dict):
+        msg = f"Invalid environment for {context}: expected dict, got {type(environment).__name__}"
+        raise TypeError(msg)
+
+    normalized = {}
+    for key, value in environment.items():
+        if not isinstance(key, str) or not key:
+            msg = f"Invalid environment variable name for {context}: {key!r}; must be a non-empty string."
+            raise ValueError(msg)
+        if not isinstance(value, str):
+            msg = (
+                f"Invalid environment variable value for {context}.{key}: "
+                f"{value!r}; must be a string. Quote YAML values that should be strings."
+            )
+            raise TypeError(msg)
+        normalized[key] = value
+    return normalized
+
+
 @dataclass
 class Entry:
     name: str
@@ -49,9 +72,14 @@ class Entry:
     delete_scratch: bool | None = None
     # If set, overrides the session-level gpu_mem_use_warning_threshold for this entry
     gpu_mem_use_warning_threshold: float | None = None
+    # Environment variables to add to this benchmark subprocess. Session-level
+    # values are applied before entry-level values, so entries override by name.
+    environment: dict[str, str] = field(default_factory=dict)
 
     def __post_init__(self) -> None:  # noqa: C901, PLR0912
         """Post-initialization checks and updates for dataclass."""
+        self.environment = normalize_environment(self.environment, f"entry '{self.name}'")
+
         # Process object_store_size by converting values representing fractions of system memory to bytes.
         if isinstance(self.object_store_size, float):
             self.object_store_size = int(get_total_memory_bytes() * self.object_store_size)

--- a/benchmarking/runner/entry.py
+++ b/benchmarking/runner/entry.py
@@ -44,12 +44,21 @@ def normalize_environment(environment: dict[str, Any] | None, context: str) -> d
         if not isinstance(key, str) or not key:
             msg = f"Invalid environment variable name for {context}: {key!r}; must be a non-empty string."
             raise ValueError(msg)
+        if "=" in key:
+            msg = f"Invalid environment variable name for {context}: {key!r}; cannot contain '='."
+            raise ValueError(msg)
+        if "\0" in key:
+            msg = f"Invalid environment variable name for {context}: {key!r}; cannot contain NUL."
+            raise ValueError(msg)
         if not isinstance(value, str):
             msg = (
                 f"Invalid environment variable value for {context}.{key}: "
                 f"{value!r}; must be a string. Quote YAML values that should be strings."
             )
             raise TypeError(msg)
+        if "\0" in value:
+            msg = f"Invalid environment variable value for {context}.{key}: cannot contain NUL."
+            raise ValueError(msg)
         normalized[key] = value
     return normalized
 

--- a/benchmarking/runner/environment.py
+++ b/benchmarking/runner/environment.py
@@ -1,0 +1,32 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import os
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+DEFAULT_SUBPROCESS_ENVIRONMENT = {
+    # Enable Ray Data scheduler diagnostics for all benchmark subprocesses by
+    # default so entry logs include scheduler events useful for post-run analysis.
+    "NEMO_CURATOR_RAY_DATA_DIAGNOSTICS": "1",
+}
+
+
+def merge_subprocess_environment(configured_environment: Mapping[str, str]) -> dict[str, str]:
+    """Return subprocess env with benchmark defaults, parent env, then config overrides."""
+    return {**DEFAULT_SUBPROCESS_ENVIRONMENT, **os.environ, **configured_environment}

--- a/benchmarking/runner/process.py
+++ b/benchmarking/runner/process.py
@@ -37,7 +37,10 @@ from rich.text import Text
 _control_chars = {c: None for c in range(sys.maxunicode) if unicodedata.category(chr(c)) == "Cc"}
 
 _SENSITIVE_ENV_NAME_PATTERN = re.compile(
-    r"(^|[_-])(TOKEN|PASSWORD|PASSWD|SECRET|CREDENTIAL|PRIVATE_KEY|ACCESS_KEY|API_KEY)([_-]|$)"
+    r"(^|[_-])"
+    r"(AUTH|AUTHORIZATION|BEARER|COOKIE|CREDENTIAL|CREDENTIALS|KEY|PASSWORD|PASSWD|PAT|PRIVATE_KEY|"
+    r"SECRET|SESSION|TOKEN|WEBHOOK)"
+    r"([_-]|$)"
 )
 
 
@@ -48,15 +51,22 @@ def _get_subprocess_env(env: dict[str, str] | None) -> dict[str, str]:
     return dict(env)
 
 
-def _redact_environment_value(name: str, value: str) -> str:
-    if _SENSITIVE_ENV_NAME_PATTERN.search(name.upper()):
+def _redact_environment_value(name: str, value: str, env_value_allowlist: set[str]) -> str:
+    if name not in env_value_allowlist or _SENSITIVE_ENV_NAME_PATTERN.search(name.upper()):
         return "<redacted>"
     return value
 
 
-def _write_subprocess_environment(outfile: TextIO, env: dict[str, str]) -> None:
+def _write_subprocess_environment(
+    outfile: TextIO,
+    env: dict[str, str],
+    env_value_allowlist: set[str] | None = None,
+) -> None:
+    env_value_allowlist = env_value_allowlist or set()
     outfile.write("--- Subprocess environment ---\n")
-    outfile.writelines(f"{name}={_redact_environment_value(name, env[name])}\n" for name in sorted(env))
+    outfile.writelines(
+        f"{name}={_redact_environment_value(name, env[name], env_value_allowlist)}\n" for name in sorted(env)
+    )
     outfile.write("--- End subprocess environment ---\n")
     outfile.flush()
 
@@ -66,6 +76,7 @@ def run_command_with_timeout(  # noqa: PLR0913
     timeout: int,
     stdouterr_path: Path = Path("stdouterr.log"),
     env: dict[str, str] | None = None,
+    env_value_allowlist: set[str] | None = None,
     run_id: str | None = None,
     fancy: bool = True,
     collapse_on_success: bool = True,
@@ -80,6 +91,7 @@ def run_command_with_timeout(  # noqa: PLR0913
         timeout: Timeout (in seconds) to terminate the command.
         stdouterr_path: Path to the file for writing combined stdout and stderr.
         env: Optional dictionary of environment variables.
+        env_value_allowlist: Environment variable names whose values may be written to the log if not secret-like.
         run_id: Optional run ID to identify the run.
         fancy: If True, displays subprocess output in a live, scrolling window.
         collapse_on_success: If True and command succeeds, collapses live window output (only for fancy=True and interactive mode).
@@ -95,21 +107,28 @@ def run_command_with_timeout(  # noqa: PLR0913
             timeout=timeout,
             stdouterr_path=stdouterr_path,
             env=env,
+            env_value_allowlist=env_value_allowlist,
             window_height=6,
             collapse_on_success=collapse_on_success,
             run_id=run_id,
         )
     else:
         return display_simple_subprocess(
-            cmd_list, timeout=timeout, stdouterr_path=stdouterr_path, env=env, run_id=run_id
+            cmd_list,
+            timeout=timeout,
+            stdouterr_path=stdouterr_path,
+            env=env,
+            env_value_allowlist=env_value_allowlist,
+            run_id=run_id,
         )
 
 
-def display_simple_subprocess(
+def display_simple_subprocess(  # noqa: PLR0913
     cmd_list: list[str],
     timeout: int,
     stdouterr_path: Path = Path("stdouterr.log"),
     env: dict[str, str] | None = None,
+    env_value_allowlist: set[str] | None = None,
     run_id: str | None = None,
 ) -> dict[str, Any]:
     """Run a shell command with an optional timeout, streaming both stdout and stderr to a log file.
@@ -124,6 +143,7 @@ def display_simple_subprocess(
         timeout: Maximum allowed time in seconds before the process is terminated.
         stdouterr_path: Destination file to save all subprocess output.
         env: Optional dictionary of environment variables to use.
+        env_value_allowlist: Environment variable names whose values may be written to the log if not secret-like.
         run_id: Optional run ID to identify the run.
 
     Returns:
@@ -137,7 +157,7 @@ def display_simple_subprocess(
 
     with open(stdouterr_path, "a") as outfile:
         start_time = time.time()
-        _write_subprocess_environment(outfile, subprocess_env)
+        _write_subprocess_environment(outfile, subprocess_env, env_value_allowlist)
         logger.info(
             f"\tRunning command (output to stdout/err): {' '.join(cmd_list) if isinstance(cmd_list, list) else cmd_list}"
         )
@@ -209,6 +229,7 @@ def display_scrolling_subprocess(  # noqa: PLR0913,PLR0915
     timeout: int,
     stdouterr_path: Path = Path("stdouterr.log"),
     env: dict[str, str] | None = None,
+    env_value_allowlist: set[str] | None = None,
     window_height: int = 6,
     run_id: str | None = None,
     collapse_on_success: bool = True,
@@ -226,6 +247,7 @@ def display_scrolling_subprocess(  # noqa: PLR0913,PLR0915
         timeout (int): Timeout in seconds.
         stdouterr_path (Path): Log file path to write stdout/stderr.
         env (dict[str, str] | None): Environment variables for the subprocess.
+        env_value_allowlist (set[str] | None): Environment variable names whose values may be written to the log if not secret-like.
         window_height (int): Number of output lines to display in the live panel.
         run_id (str | None): Optional run ID to identify the run.
         collapse_on_success (bool): If True, collapse panel after successful completion.
@@ -249,7 +271,7 @@ def display_scrolling_subprocess(  # noqa: PLR0913,PLR0915
     ):
         start_time = time.time()
         final_panel = None
-        _write_subprocess_environment(outfile, subprocess_env)
+        _write_subprocess_environment(outfile, subprocess_env, env_value_allowlist)
         logger.info(
             f"\tRunning command in subprocess (output to scrolling window): {' '.join(cmd_list) if isinstance(cmd_list, list) else cmd_list}"
         )

--- a/benchmarking/runner/process.py
+++ b/benchmarking/runner/process.py
@@ -14,6 +14,8 @@
 
 from __future__ import annotations
 
+import os
+import re
 import shlex
 import subprocess
 import sys
@@ -23,7 +25,7 @@ import traceback
 import unicodedata
 from collections import deque
 from pathlib import Path
-from typing import Any
+from typing import Any, TextIO
 
 from loguru import logger
 from rich.live import Live
@@ -33,6 +35,30 @@ from rich.text import Text
 # Create a translation table that maps all control characters to None for deletion in order to safely print subprocess output to the scrolling live window.
 # This includes characters in the Unicode category 'Cc' (Control).
 _control_chars = {c: None for c in range(sys.maxunicode) if unicodedata.category(chr(c)) == "Cc"}
+
+_SENSITIVE_ENV_NAME_PATTERN = re.compile(
+    r"(^|[_-])(TOKEN|PASSWORD|PASSWD|SECRET|CREDENTIAL|PRIVATE_KEY|ACCESS_KEY|API_KEY)([_-]|$)"
+)
+
+
+def _get_subprocess_env(env: dict[str, str] | None) -> dict[str, str]:
+    """Return the exact environment mapping passed to subprocess.Popen."""
+    if env is None:
+        return dict(os.environ)
+    return dict(env)
+
+
+def _redact_environment_value(name: str, value: str) -> str:
+    if _SENSITIVE_ENV_NAME_PATTERN.search(name.upper()):
+        return "<redacted>"
+    return value
+
+
+def _write_subprocess_environment(outfile: TextIO, env: dict[str, str]) -> None:
+    outfile.write("--- Subprocess environment ---\n")
+    outfile.writelines(f"{name}={_redact_environment_value(name, env[name])}\n" for name in sorted(env))
+    outfile.write("--- End subprocess environment ---\n")
+    outfile.flush()
 
 
 def run_command_with_timeout(  # noqa: PLR0913
@@ -107,9 +133,11 @@ def display_simple_subprocess(
     timed_out = False
     msg = ""
     run_id_msg = f" for run ID: {run_id}" if run_id else ""
+    subprocess_env = _get_subprocess_env(env)
 
     with open(stdouterr_path, "a") as outfile:
         start_time = time.time()
+        _write_subprocess_environment(outfile, subprocess_env)
         logger.info(
             f"\tRunning command (output to stdout/err): {' '.join(cmd_list) if isinstance(cmd_list, list) else cmd_list}"
         )
@@ -118,7 +146,7 @@ def display_simple_subprocess(
                 cmd_list,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.STDOUT,
-                env=env,
+                env=subprocess_env,
                 text=True,
                 bufsize=1,
                 universal_newlines=True,
@@ -213,6 +241,7 @@ def display_scrolling_subprocess(  # noqa: PLR0913,PLR0915
     timed_out = False
     msg = ""
     run_id_msg = f" for run ID: {run_id}" if run_id else ""
+    subprocess_env = _get_subprocess_env(env)
 
     with (
         Live(auto_refresh=False, vertical_overflow="visible") as live,
@@ -220,6 +249,7 @@ def display_scrolling_subprocess(  # noqa: PLR0913,PLR0915
     ):
         start_time = time.time()
         final_panel = None
+        _write_subprocess_environment(outfile, subprocess_env)
         logger.info(
             f"\tRunning command in subprocess (output to scrolling window): {' '.join(cmd_list) if isinstance(cmd_list, list) else cmd_list}"
         )
@@ -228,7 +258,7 @@ def display_scrolling_subprocess(  # noqa: PLR0913,PLR0915
                 cmd_list,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.STDOUT,
-                env=env,
+                env=subprocess_env,
                 text=True,
                 bufsize=1,
                 universal_newlines=True,

--- a/benchmarking/runner/session.py
+++ b/benchmarking/runner/session.py
@@ -28,7 +28,7 @@ from loguru import logger
 if TYPE_CHECKING:
     from runner.sinks.sink import Sink
 from runner.datasets import DatasetResolver
-from runner.entry import Entry
+from runner.entry import Entry, normalize_environment
 from runner.path_resolver import PathResolver
 from runner.utils import assert_valid_config_dict, get_total_memory_bytes
 
@@ -91,6 +91,9 @@ class Session:
     run_reason: str | None = None
     # Global ray settings inherited by all entries; per-entry ray sections override these values.
     ray: dict = field(default_factory=dict)
+    # Global environment variables inherited by all benchmark subprocesses; per-entry
+    # environment sections override individual variables by name.
+    environment: dict[str, str] = field(default_factory=dict)
     path_resolver: PathResolver = None
     dataset_resolver: DatasetResolver = None
 
@@ -111,6 +114,8 @@ class Session:
         # Process object_store_size by converting values representing fractions of system memory to bytes.
         if isinstance(self.object_store_size, float):
             self.object_store_size = int(get_total_memory_bytes() * self.object_store_size)
+
+        self.environment = normalize_environment(self.environment, "session")
 
         # Validate the session-level warning threshold range, if set.
         if self.gpu_mem_use_warning_threshold is not None and not (0 <= self.gpu_mem_use_warning_threshold <= 1):
@@ -169,6 +174,11 @@ class Session:
         # Apply global ray defaults to each entry, with per-entry ray values taking precedence.
         for entry in self.entries:
             entry.ray = {**self.ray, **entry.ray}
+
+        # Apply global environment defaults to each subprocess entry, with per-entry
+        # values taking precedence per variable name.
+        for entry in [*self.entries, *self.data_setups]:
+            entry.environment = {**self.environment, **entry.environment}
 
     @classmethod
     def from_dict(

--- a/tests/benchmarking/runner/test_benchmark_configs.py
+++ b/tests/benchmarking/runner/test_benchmark_configs.py
@@ -38,7 +38,6 @@ def test_benchmarks_yaml_is_complete_default_8xh100_config() -> None:
     entries = _entries(config)
 
     assert config["ray"] == {"num_cpus": 128, "num_gpus": 8, "enable_object_spilling": False}
-    assert config["environment"] == {"NEMO_CURATOR_RAY_DATA_DIAGNOSTICS": "1"}
     assert next(sink for sink in config["sinks"] if sink["name"] == "slack")["enabled"] is False
     assert config["object_store_size"] == 536870912000
     assert config["max_timeout_s"] == 14340

--- a/tests/benchmarking/runner/test_benchmark_configs.py
+++ b/tests/benchmarking/runner/test_benchmark_configs.py
@@ -46,6 +46,8 @@ def test_benchmarks_yaml_is_complete_default_8xh100_config() -> None:
         assert "--gpu-stage-num-workers" not in entries[entry_name]["args"]
     replica_8_arg = '--autoscaling-config=\'{"min_replicas": 8, "max_replicas": 8}\''
     assert replica_8_arg in entries["ndd_dynamo"]["args"]
+    for entry_name in ("exact_dedup_identification", "fuzzy_dedup_identification"):
+        assert "environment" not in entries[entry_name]
 
 
 def test_4xgb200_64cpu_override_updates_resources_and_caps_timeouts() -> None:
@@ -69,6 +71,9 @@ def test_4xgb200_64cpu_override_updates_resources_and_caps_timeouts() -> None:
         replica_4_arg = '--autoscaling-config=\'{"min_replicas": 4, "max_replicas": 4}\''
         assert replica_4_arg in entries[entry_name]["args"]
         assert entries[entry_name]["ray"]["num_cpus"] == 16
+
+    for entry_name in ("exact_dedup_identification", "fuzzy_dedup_identification"):
+        assert entries[entry_name]["environment"] == {"UCX_TLS": "all", "CONTAINER_ENVS": "UCX_TLS"}
 
 
 def test_4xgb200_64cpu_override_sets_known_video_performance_baselines() -> None:

--- a/tests/benchmarking/runner/test_benchmark_configs.py
+++ b/tests/benchmarking/runner/test_benchmark_configs.py
@@ -45,6 +45,11 @@ def test_benchmarks_yaml_is_complete_default_8xh100_config() -> None:
         assert "--gpu-stage-num-workers" not in entries[entry_name]["args"]
     replica_8_arg = '--autoscaling-config=\'{"min_replicas": 8, "max_replicas": 8}\''
     assert replica_8_arg in entries["ndd_dynamo"]["args"]
+    for entry_name in ("exact_dedup_identification", "fuzzy_dedup_identification"):
+        assert entries[entry_name]["environment"] == {
+            "UCX_TLS": "all",
+            "CONTAINER_ENVS": "UCX_TLS",
+        }
 
 
 def test_4xgb200_64cpu_override_updates_resources_and_caps_timeouts() -> None:

--- a/tests/benchmarking/runner/test_benchmark_configs.py
+++ b/tests/benchmarking/runner/test_benchmark_configs.py
@@ -38,7 +38,9 @@ def test_benchmarks_yaml_is_complete_default_8xh100_config() -> None:
     entries = _entries(config)
 
     assert config["ray"] == {"num_cpus": 128, "num_gpus": 8, "enable_object_spilling": False}
-    assert next(sink for sink in config["sinks"] if sink["name"] == "slack")["enabled"] is False
+    slack_sink = next(sink for sink in config["sinks"] if sink["name"] == "slack")
+    assert slack_sink["enabled"] is False
+    assert slack_sink["ping_users_on_failure"] is False
     assert config["object_store_size"] == 536870912000
     assert config["max_timeout_s"] == 14340
     assert "audio_tagging_tts_xenna_repeat" not in entries

--- a/tests/benchmarking/runner/test_benchmark_configs.py
+++ b/tests/benchmarking/runner/test_benchmark_configs.py
@@ -45,11 +45,6 @@ def test_benchmarks_yaml_is_complete_default_8xh100_config() -> None:
         assert "--gpu-stage-num-workers" not in entries[entry_name]["args"]
     replica_8_arg = '--autoscaling-config=\'{"min_replicas": 8, "max_replicas": 8}\''
     assert replica_8_arg in entries["ndd_dynamo"]["args"]
-    for entry_name in ("exact_dedup_identification", "fuzzy_dedup_identification"):
-        assert entries[entry_name]["environment"] == {
-            "UCX_TLS": "all",
-            "CONTAINER_ENVS": "UCX_TLS",
-        }
 
 
 def test_4xgb200_64cpu_override_updates_resources_and_caps_timeouts() -> None:

--- a/tests/benchmarking/runner/test_benchmark_configs.py
+++ b/tests/benchmarking/runner/test_benchmark_configs.py
@@ -39,6 +39,7 @@ def test_benchmarks_yaml_is_complete_default_8xh100_config() -> None:
 
     assert config["ray"] == {"num_cpus": 128, "num_gpus": 8, "enable_object_spilling": False}
     assert config["environment"] == {"NEMO_CURATOR_RAY_DATA_DIAGNOSTICS": "1"}
+    assert next(sink for sink in config["sinks"] if sink["name"] == "slack")["enabled"] is False
     assert config["object_store_size"] == 536870912000
     assert config["max_timeout_s"] == 14340
     assert "audio_tagging_tts_xenna_repeat" not in entries

--- a/tests/benchmarking/runner/test_benchmark_configs.py
+++ b/tests/benchmarking/runner/test_benchmark_configs.py
@@ -38,6 +38,7 @@ def test_benchmarks_yaml_is_complete_default_8xh100_config() -> None:
     entries = _entries(config)
 
     assert config["ray"] == {"num_cpus": 128, "num_gpus": 8, "enable_object_spilling": False}
+    assert config["environment"] == {"NEMO_CURATOR_RAY_DATA_DIAGNOSTICS": "1"}
     assert config["object_store_size"] == 536870912000
     assert config["max_timeout_s"] == 14340
     assert "audio_tagging_tts_xenna_repeat" not in entries

--- a/tests/benchmarking/runner/test_environment.py
+++ b/tests/benchmarking/runner/test_environment.py
@@ -1,0 +1,52 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from _pytest.monkeypatch import MonkeyPatch
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[3] / "benchmarking"))
+
+from runner.environment import DEFAULT_SUBPROCESS_ENVIRONMENT, merge_subprocess_environment
+
+
+def test_default_ray_data_diagnostics_enabled(monkeypatch: MonkeyPatch) -> None:
+    monkeypatch.delenv("NEMO_CURATOR_RAY_DATA_DIAGNOSTICS", raising=False)
+
+    env = merge_subprocess_environment({})
+
+    assert (
+        env["NEMO_CURATOR_RAY_DATA_DIAGNOSTICS"] == DEFAULT_SUBPROCESS_ENVIRONMENT["NEMO_CURATOR_RAY_DATA_DIAGNOSTICS"]
+    )
+
+
+def test_parent_environment_overrides_subprocess_defaults(monkeypatch: MonkeyPatch) -> None:
+    monkeypatch.setenv("NEMO_CURATOR_RAY_DATA_DIAGNOSTICS", "0")
+
+    env = merge_subprocess_environment({})
+
+    assert env["NEMO_CURATOR_RAY_DATA_DIAGNOSTICS"] == "0"
+
+
+def test_configured_environment_overrides_parent_environment(monkeypatch: MonkeyPatch) -> None:
+    monkeypatch.setenv("NEMO_CURATOR_RAY_DATA_DIAGNOSTICS", "0")
+
+    env = merge_subprocess_environment({"NEMO_CURATOR_RAY_DATA_DIAGNOSTICS": "1"})
+
+    assert env["NEMO_CURATOR_RAY_DATA_DIAGNOSTICS"] == "1"

--- a/tests/benchmarking/runner/test_process.py
+++ b/tests/benchmarking/runner/test_process.py
@@ -1,0 +1,50 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[3] / "benchmarking"))
+
+from runner.process import run_command_with_timeout
+
+
+def test_run_command_with_timeout_dumps_subprocess_environment(tmp_path: Path) -> None:
+    log_path = tmp_path / "stdouterr.log"
+    env = {
+        **os.environ,
+        "BENCHMARK_TEST_ENV": "present",
+        "SLACK_BOT_TOKEN": "secret-token",
+        "TOKENIZERS_PARALLELISM": "false",
+    }
+
+    result = run_command_with_timeout(
+        command=f"{sys.executable} -c 'print(\"done\")'",
+        timeout=10,
+        stdouterr_path=log_path,
+        env=env,
+        fancy=False,
+    )
+
+    log_text = log_path.read_text()
+    assert result == {"returncode": 0, "timed_out": False}
+    assert "--- Subprocess environment ---" in log_text
+    assert "BENCHMARK_TEST_ENV=present" in log_text
+    assert "SLACK_BOT_TOKEN=<redacted>" in log_text
+    assert "TOKENIZERS_PARALLELISM=false" in log_text
+    assert "secret-token" not in log_text
+    assert "done" in log_text

--- a/tests/benchmarking/runner/test_process.py
+++ b/tests/benchmarking/runner/test_process.py
@@ -28,7 +28,11 @@ def test_run_command_with_timeout_dumps_subprocess_environment(tmp_path: Path) -
     env = {
         **os.environ,
         "BENCHMARK_TEST_ENV": "present",
+        "INHERITED_TEST_ENV": "inherited-value",
         "SLACK_BOT_TOKEN": "secret-token",
+        "NVIDIA_API_KEY": "secret-key",
+        "GITHUB_PAT": "secret-pat",
+        "ALERT_WEBHOOK": "secret-webhook",
         "TOKENIZERS_PARALLELISM": "false",
     }
 
@@ -37,6 +41,14 @@ def test_run_command_with_timeout_dumps_subprocess_environment(tmp_path: Path) -
         timeout=10,
         stdouterr_path=log_path,
         env=env,
+        env_value_allowlist={
+            "ALERT_WEBHOOK",
+            "BENCHMARK_TEST_ENV",
+            "GITHUB_PAT",
+            "NVIDIA_API_KEY",
+            "SLACK_BOT_TOKEN",
+            "TOKENIZERS_PARALLELISM",
+        },
         fancy=False,
     )
 
@@ -44,7 +56,15 @@ def test_run_command_with_timeout_dumps_subprocess_environment(tmp_path: Path) -
     assert result == {"returncode": 0, "timed_out": False}
     assert "--- Subprocess environment ---" in log_text
     assert "BENCHMARK_TEST_ENV=present" in log_text
+    assert "INHERITED_TEST_ENV=<redacted>" in log_text
     assert "SLACK_BOT_TOKEN=<redacted>" in log_text
+    assert "NVIDIA_API_KEY=<redacted>" in log_text
+    assert "GITHUB_PAT=<redacted>" in log_text
+    assert "ALERT_WEBHOOK=<redacted>" in log_text
     assert "TOKENIZERS_PARALLELISM=false" in log_text
+    assert "inherited-value" not in log_text
     assert "secret-token" not in log_text
+    assert "secret-key" not in log_text
+    assert "secret-pat" not in log_text
+    assert "secret-webhook" not in log_text
     assert "done" in log_text

--- a/tests/benchmarking/runner/test_session.py
+++ b/tests/benchmarking/runner/test_session.py
@@ -88,6 +88,57 @@ def test_session_accepts_run_metadata() -> None:
     assert session.run_reason == "release candidate check"
 
 
+def test_session_merges_environment_defaults_per_variable() -> None:
+    session = Session.from_dict(
+        _config(
+            [
+                {"name": "entry_a", "script": "benchmark.py"},
+                {
+                    "name": "entry_b",
+                    "script": "benchmark.py",
+                    "environment": {"ENTRY_ONLY": "yes", "SHARED": "entry"},
+                },
+            ],
+            environment={"GLOBAL_ONLY": "yes", "SHARED": "session"},
+        )
+    )
+
+    assert session.entries[0].environment == {"GLOBAL_ONLY": "yes", "SHARED": "session"}
+    assert session.entries[1].environment == {
+        "GLOBAL_ONLY": "yes",
+        "ENTRY_ONLY": "yes",
+        "SHARED": "entry",
+    }
+
+
+def test_session_rejects_invalid_environment_value_type() -> None:
+    with pytest.raises(TypeError, match="environment variable value"):
+        Session.from_dict(
+            _config(
+                [{"name": "entry_a", "script": "benchmark.py", "environment": {"MY_VAR": 1}}],
+            )
+        )
+
+
+def test_session_rejects_invalid_environment_block_type() -> None:
+    with pytest.raises(TypeError, match="Invalid environment for session"):
+        Session.from_dict(
+            _config(
+                [{"name": "entry_a", "script": "benchmark.py"}],
+                environment=["MY_VAR=value"],
+            )
+        )
+
+
+def test_session_rejects_invalid_environment_variable_name() -> None:
+    with pytest.raises(ValueError, match="environment variable name"):
+        Session.from_dict(
+            _config(
+                [{"name": "entry_a", "script": "benchmark.py", "environment": {"": "value"}}],
+            )
+        )
+
+
 def test_session_rejects_viewer_url_and_viewer_url_template() -> None:
     with pytest.raises(ValueError, match="viewer_url and viewer_url_template are mutually exclusive"):
         Session.from_dict(

--- a/tests/benchmarking/runner/test_session.py
+++ b/tests/benchmarking/runner/test_session.py
@@ -130,11 +130,21 @@ def test_session_rejects_invalid_environment_block_type() -> None:
         )
 
 
-def test_session_rejects_invalid_environment_variable_name() -> None:
+@pytest.mark.parametrize("bad_name", ["", "BAD=NAME", "BAD\0NAME"])
+def test_session_rejects_invalid_environment_variable_name(bad_name: str) -> None:
     with pytest.raises(ValueError, match="environment variable name"):
         Session.from_dict(
             _config(
-                [{"name": "entry_a", "script": "benchmark.py", "environment": {"": "value"}}],
+                [{"name": "entry_a", "script": "benchmark.py", "environment": {bad_name: "value"}}],
+            )
+        )
+
+
+def test_session_rejects_environment_value_with_nul() -> None:
+    with pytest.raises(ValueError, match="environment variable value"):
+        Session.from_dict(
+            _config(
+                [{"name": "entry_a", "script": "benchmark.py", "environment": {"MY_VAR": "bad\0value"}}],
             )
         )
 


### PR DESCRIPTION
## Motivation

Some benchmark subprocesses need environment variables that should be declared with benchmark configuration rather than supplied out-of-band by every caller. This gives Curator benchmark configs and downstream override configs a consistent way to pass subprocess-specific environment values without changing benchmark scripts or orchestration code.

## Summary

- Add a top-level and per-entry `environment` YAML block for benchmark subprocess environment variables.
- Merge top-level environment values into each entry, with per-entry values overriding individual variables by name.
- Resolve the same reserved/path placeholders in configured environment values before launching subprocesses.
- Pass the resolved environment dictionary to `run_command_with_timeout()` for benchmark and data setup subprocesses.
- Keep `NEMO_CURATOR_RAY_DATA_DIAGNOSTICS=1` as a runner-level default subprocess environment value so custom configs retain Ray Data diagnostics while parent environment and YAML overrides still work.
- Disable the Slack sink by default in `benchmarks.yaml` while keeping all Slack config values in place for opt-in use.
- Dump subprocess environment variable names to each entry's `logs/stdouterr.log`.
- Redact inherited environment values by default, and only show YAML-configured values whose names do not look secret-bearing.
- Validate environment names and values early so invalid `=` and NUL-containing config values fail before subprocess launch.

## Validation

- Pre-commit hooks passed during commit.
- `python -m py_compile benchmarking/run.py benchmarking/runner/environment.py tests/benchmarking/runner/test_environment.py tests/benchmarking/runner/test_benchmark_configs.py`
- `python -c 'import os, sys; sys.path.insert(0, "benchmarking"); from runner.environment import merge_subprocess_environment; os.environ.pop("NEMO_CURATOR_RAY_DATA_DIAGNOSTICS", None); assert merge_subprocess_environment({})["NEMO_CURATOR_RAY_DATA_DIAGNOSTICS"] == "1"; os.environ["NEMO_CURATOR_RAY_DATA_DIAGNOSTICS"] = "0"; assert merge_subprocess_environment({})["NEMO_CURATOR_RAY_DATA_DIAGNOSTICS"] == "0"; assert merge_subprocess_environment({"NEMO_CURATOR_RAY_DATA_DIAGNOSTICS": "1"})["NEMO_CURATOR_RAY_DATA_DIAGNOSTICS"] == "1"; print("env default smoke ok")'`
- `python -c 'import sys; from pathlib import Path; sys.path.insert(0, "benchmarking"); from runner.utils import merge_config_files; cfg = merge_config_files([Path("benchmarking/benchmarks.yaml")]); slack = next(s for s in cfg["sinks"] if s["name"] == "slack"); assert slack["enabled"] is False; assert "environment" not in cfg; print("config smoke ok")'`
- `git diff --check`

Focused pytest targets could not be run in the local environment because `tests/conftest.py` imports `ray`, which is not installed there.
