### PR TITLE
[Do Not Merge] Banded minhash

### DIFF
--- a/benchmarking/4xGB200-64CPU.yaml
+++ b/benchmarking/4xGB200-64CPU.yaml
@@ -50,10 +50,16 @@ entries:
   - name: fuzzy_dedup_identification_raw_bands_per_iteration_20
     timeout_s: 2400
 
-  - name: fuzzy_dedup_identification_banded_bands_per_iteration_4
+  - name: fuzzy_dedup_identification_banded_bands_per_iteration_5
     timeout_s: 2400
 
-  - name: fuzzy_dedup_identification_raw_bands_per_iteration_4
+  - name: fuzzy_dedup_identification_raw_bands_per_iteration_5
+    timeout_s: 2400
+
+  - name: fuzzy_dedup_identification_banded_bands_per_iteration_1
+    timeout_s: 2400
+
+  - name: fuzzy_dedup_identification_raw_bands_per_iteration_1
     timeout_s: 2400
 
   - name: minhash_file_group_task_ray_actors

--- a/benchmarking/4xGB200-64CPU.yaml
+++ b/benchmarking/4xGB200-64CPU.yaml
@@ -60,7 +60,7 @@ entries:
     timeout_s: 2700
 
   - name: fuzzy_dedup_identification_raw_bands_per_iteration_1
-    timeout_s: 2700
+    timeout_s: 7200
 
   - name: minhash_file_group_task_ray_actors
     timeout_s: 1024

--- a/benchmarking/4xGB200-64CPU.yaml
+++ b/benchmarking/4xGB200-64CPU.yaml
@@ -45,22 +45,22 @@ entries:
     timeout_s: 2400
 
   - name: fuzzy_dedup_identification_banded_bands_per_iteration_20
-    timeout_s: 2400
+    timeout_s: 2700
 
   - name: fuzzy_dedup_identification_raw_bands_per_iteration_20
-    timeout_s: 2400
+    timeout_s: 2700
 
   - name: fuzzy_dedup_identification_banded_bands_per_iteration_5
-    timeout_s: 2400
+    timeout_s: 2700
 
   - name: fuzzy_dedup_identification_raw_bands_per_iteration_5
-    timeout_s: 2400
+    timeout_s: 2700
 
   - name: fuzzy_dedup_identification_banded_bands_per_iteration_1
-    timeout_s: 2400
+    timeout_s: 2700
 
   - name: fuzzy_dedup_identification_raw_bands_per_iteration_1
-    timeout_s: 2400
+    timeout_s: 2700
 
   - name: minhash_file_group_task_ray_actors
     timeout_s: 1024

--- a/benchmarking/4xGB200-64CPU.yaml
+++ b/benchmarking/4xGB200-64CPU.yaml
@@ -44,7 +44,16 @@ entries:
   - name: exact_dedup_identification
     timeout_s: 2400
 
-  - name: fuzzy_dedup_identification
+  - name: fuzzy_dedup_identification_banded_bands_per_iteration_20
+    timeout_s: 2400
+
+  - name: fuzzy_dedup_identification_raw_bands_per_iteration_20
+    timeout_s: 2400
+
+  - name: fuzzy_dedup_identification_banded_bands_per_iteration_4
+    timeout_s: 2400
+
+  - name: fuzzy_dedup_identification_raw_bands_per_iteration_4
     timeout_s: 2400
 
   - name: minhash_file_group_task_ray_actors

--- a/benchmarking/benchmarks.yaml
+++ b/benchmarking/benchmarks.yaml
@@ -341,6 +341,7 @@ entries:
       --output-path={session_entry_dir}/scratch/output
       --input-filetype=jsonl
       --bands-per-iteration=20
+      --minhash-output-format=banded
       --text-field=text
       --input-blocksize=1.5GiB
     timeout_s: 1200

--- a/benchmarking/benchmarks.yaml
+++ b/benchmarking/benchmarks.yaml
@@ -331,7 +331,7 @@ entries:
       - metric: num_duplicates
         exact_value: 64292856
 
-  - name: fuzzy_dedup_identification
+  - name: fuzzy_dedup_identification_banded_bands_per_iteration_20
     enabled: true
     script: fuzzy_dedup_identification_benchmark.py
     args: >-
@@ -342,6 +342,90 @@ entries:
       --input-filetype=jsonl
       --bands-per-iteration=20
       --minhash-output-format=banded
+      --text-field=text
+      --input-blocksize=1.5GiB
+    timeout_s: 1200
+    sink_data:
+      - name: slack
+        additional_metrics:
+          - num_duplicates
+          - minhash_percent_time
+          - lsh_percent_time
+          - connected_components_percent_time
+        ping_on_failure:
+          - UBDSVEQPL  # Ayush Dattagupta
+
+    requirements:
+      - metric: num_duplicates
+        exact_value: 59226133
+
+  - name: fuzzy_dedup_identification_raw_bands_per_iteration_20
+    enabled: true
+    script: fuzzy_dedup_identification_benchmark.py
+    args: >-
+      --benchmark-results-path={session_entry_dir}
+      --input-path={dataset:commoncrawl,jsonl}
+      --cache-path={session_entry_dir}/scratch/cache
+      --output-path={session_entry_dir}/scratch/output
+      --input-filetype=jsonl
+      --bands-per-iteration=20
+      --minhash-output-format=raw
+      --text-field=text
+      --input-blocksize=1.5GiB
+    timeout_s: 1200
+    sink_data:
+      - name: slack
+        additional_metrics:
+          - num_duplicates
+          - minhash_percent_time
+          - lsh_percent_time
+          - connected_components_percent_time
+        ping_on_failure:
+          - UBDSVEQPL  # Ayush Dattagupta
+
+    requirements:
+      - metric: num_duplicates
+        exact_value: 59226133
+
+  - name: fuzzy_dedup_identification_banded_bands_per_iteration_4
+    enabled: true
+    script: fuzzy_dedup_identification_benchmark.py
+    args: >-
+      --benchmark-results-path={session_entry_dir}
+      --input-path={dataset:commoncrawl,jsonl}
+      --cache-path={session_entry_dir}/scratch/cache
+      --output-path={session_entry_dir}/scratch/output
+      --input-filetype=jsonl
+      --bands-per-iteration=4
+      --minhash-output-format=banded
+      --text-field=text
+      --input-blocksize=1.5GiB
+    timeout_s: 1200
+    sink_data:
+      - name: slack
+        additional_metrics:
+          - num_duplicates
+          - minhash_percent_time
+          - lsh_percent_time
+          - connected_components_percent_time
+        ping_on_failure:
+          - UBDSVEQPL  # Ayush Dattagupta
+
+    requirements:
+      - metric: num_duplicates
+        exact_value: 59226133
+
+  - name: fuzzy_dedup_identification_raw_bands_per_iteration_4
+    enabled: true
+    script: fuzzy_dedup_identification_benchmark.py
+    args: >-
+      --benchmark-results-path={session_entry_dir}
+      --input-path={dataset:commoncrawl,jsonl}
+      --cache-path={session_entry_dir}/scratch/cache
+      --output-path={session_entry_dir}/scratch/output
+      --input-filetype=jsonl
+      --bands-per-iteration=4
+      --minhash-output-format=raw
       --text-field=text
       --input-blocksize=1.5GiB
     timeout_s: 1200

--- a/benchmarking/benchmarks.yaml
+++ b/benchmarking/benchmarks.yaml
@@ -336,13 +336,13 @@ entries:
     script: fuzzy_dedup_identification_benchmark.py
     args: >-
       --benchmark-results-path={session_entry_dir}
-      --input-path={dataset:commoncrawl,jsonl}
+      --input-path={dataset:rpv2-2023-14-en,parquet}
       --cache-path={session_entry_dir}/scratch/cache
       --output-path={session_entry_dir}/scratch/output
-      --input-filetype=jsonl
+      --input-filetype=parquet
       --bands-per-iteration=20
       --minhash-output-format=banded
-      --text-field=text
+      --text-field=raw_content
       --input-blocksize=1.5GiB
     timeout_s: 1200
     sink_data:
@@ -364,13 +364,13 @@ entries:
     script: fuzzy_dedup_identification_benchmark.py
     args: >-
       --benchmark-results-path={session_entry_dir}
-      --input-path={dataset:commoncrawl,jsonl}
+      --input-path={dataset:rpv2-2023-14-en,parquet}
       --cache-path={session_entry_dir}/scratch/cache
       --output-path={session_entry_dir}/scratch/output
-      --input-filetype=jsonl
+      --input-filetype=parquet
       --bands-per-iteration=20
       --minhash-output-format=raw
-      --text-field=text
+      --text-field=raw_content
       --input-blocksize=1.5GiB
     timeout_s: 1200
     sink_data:
@@ -387,18 +387,18 @@ entries:
       - metric: num_duplicates
         exact_value: 59226133
 
-  - name: fuzzy_dedup_identification_banded_bands_per_iteration_4
+  - name: fuzzy_dedup_identification_banded_bands_per_iteration_5
     enabled: true
     script: fuzzy_dedup_identification_benchmark.py
     args: >-
       --benchmark-results-path={session_entry_dir}
-      --input-path={dataset:commoncrawl,jsonl}
+      --input-path={dataset:rpv2-2023-14-en,parquet}
       --cache-path={session_entry_dir}/scratch/cache
       --output-path={session_entry_dir}/scratch/output
-      --input-filetype=jsonl
-      --bands-per-iteration=4
+      --input-filetype=parquet
+      --bands-per-iteration=5
       --minhash-output-format=banded
-      --text-field=text
+      --text-field=raw_content
       --input-blocksize=1.5GiB
     timeout_s: 1200
     sink_data:
@@ -415,18 +415,74 @@ entries:
       - metric: num_duplicates
         exact_value: 59226133
 
-  - name: fuzzy_dedup_identification_raw_bands_per_iteration_4
+  - name: fuzzy_dedup_identification_raw_bands_per_iteration_5
     enabled: true
     script: fuzzy_dedup_identification_benchmark.py
     args: >-
       --benchmark-results-path={session_entry_dir}
-      --input-path={dataset:commoncrawl,jsonl}
+      --input-path={dataset:rpv2-2023-14-en,parquet}
       --cache-path={session_entry_dir}/scratch/cache
       --output-path={session_entry_dir}/scratch/output
-      --input-filetype=jsonl
-      --bands-per-iteration=4
+      --input-filetype=parquet
+      --bands-per-iteration=5
       --minhash-output-format=raw
-      --text-field=text
+      --text-field=raw_content
+      --input-blocksize=1.5GiB
+    timeout_s: 1200
+    sink_data:
+      - name: slack
+        additional_metrics:
+          - num_duplicates
+          - minhash_percent_time
+          - lsh_percent_time
+          - connected_components_percent_time
+        ping_on_failure:
+          - UBDSVEQPL  # Ayush Dattagupta
+
+    requirements:
+      - metric: num_duplicates
+        exact_value: 59226133
+
+  - name: fuzzy_dedup_identification_banded_bands_per_iteration_1
+    enabled: true
+    script: fuzzy_dedup_identification_benchmark.py
+    args: >-
+      --benchmark-results-path={session_entry_dir}
+      --input-path={dataset:rpv2-2023-14-en,parquet}
+      --cache-path={session_entry_dir}/scratch/cache
+      --output-path={session_entry_dir}/scratch/output
+      --input-filetype=parquet
+      --bands-per-iteration=1
+      --minhash-output-format=banded
+      --text-field=raw_content
+      --input-blocksize=1.5GiB
+    timeout_s: 1200
+    sink_data:
+      - name: slack
+        additional_metrics:
+          - num_duplicates
+          - minhash_percent_time
+          - lsh_percent_time
+          - connected_components_percent_time
+        ping_on_failure:
+          - UBDSVEQPL  # Ayush Dattagupta
+
+    requirements:
+      - metric: num_duplicates
+        exact_value: 59226133
+
+  - name: fuzzy_dedup_identification_raw_bands_per_iteration_1
+    enabled: true
+    script: fuzzy_dedup_identification_benchmark.py
+    args: >-
+      --benchmark-results-path={session_entry_dir}
+      --input-path={dataset:rpv2-2023-14-en,parquet}
+      --cache-path={session_entry_dir}/scratch/cache
+      --output-path={session_entry_dir}/scratch/output
+      --input-filetype=parquet
+      --bands-per-iteration=1
+      --minhash-output-format=raw
+      --text-field=raw_content
       --input-blocksize=1.5GiB
     timeout_s: 1200
     sink_data:

--- a/benchmarking/benchmarks.yaml
+++ b/benchmarking/benchmarks.yaml
@@ -357,7 +357,7 @@ entries:
 
     requirements:
       - metric: num_duplicates
-        exact_value: 59226133
+        exact_value: 204527662
 
   - name: fuzzy_dedup_identification_raw_bands_per_iteration_20
     enabled: true
@@ -385,7 +385,7 @@ entries:
 
     requirements:
       - metric: num_duplicates
-        exact_value: 59226133
+        exact_value: 204527662
 
   - name: fuzzy_dedup_identification_banded_bands_per_iteration_5
     enabled: true
@@ -413,7 +413,7 @@ entries:
 
     requirements:
       - metric: num_duplicates
-        exact_value: 59226133
+        exact_value: 204527662
 
   - name: fuzzy_dedup_identification_raw_bands_per_iteration_5
     enabled: true
@@ -441,7 +441,7 @@ entries:
 
     requirements:
       - metric: num_duplicates
-        exact_value: 59226133
+        exact_value: 204527662
 
   - name: fuzzy_dedup_identification_banded_bands_per_iteration_1
     enabled: true
@@ -469,7 +469,7 @@ entries:
 
     requirements:
       - metric: num_duplicates
-        exact_value: 59226133
+        exact_value: 204527662
 
   - name: fuzzy_dedup_identification_raw_bands_per_iteration_1
     enabled: true
@@ -497,7 +497,7 @@ entries:
 
     requirements:
       - metric: num_duplicates
-        exact_value: 59226133
+        exact_value: 204527662
 
   - name: minhash_file_group_task_ray_actors
     enabled: true

--- a/benchmarking/scripts/fuzzy_dedup_identification_benchmark.py
+++ b/benchmarking/scripts/fuzzy_dedup_identification_benchmark.py
@@ -36,6 +36,7 @@ def run_duplicate_identification_benchmark(  # noqa: PLR0913
     output_path: str,
     input_filetype: str = "jsonl",
     bands_per_iteration: int = 20,  # Number of bands to shuffle concurrently during LSH. Higher values have higher memory pressure but can reduce runtime
+    minhash_output_format: Literal["raw", "banded"] = "banded",
     text_field: str = "text",
     input_blocksize: str = "1.5GiB",
     lsh_num_output_partitions: int | None = None,
@@ -61,6 +62,7 @@ def run_duplicate_identification_benchmark(  # noqa: PLR0913
         output_path=output_path,
         input_filetype=input_filetype,
         bands_per_iteration=bands_per_iteration,
+        minhash_output_format=minhash_output_format,
         text_field=text_field,
         input_blocksize=input_blocksize,
         lsh_num_output_partitions=lsh_num_output_partitions,
@@ -121,6 +123,12 @@ def main() -> int:
     parser.add_argument("--input-filetype", default="jsonl", choices=["jsonl", "parquet"], help="Input filetype")
     parser.add_argument(
         "--bands-per-iteration", type=int, default=20, help="Bands per iteration (for LSH deduplication)"
+    )
+    parser.add_argument(
+        "--minhash-output-format",
+        choices=["raw", "banded"],
+        default="banded",
+        help="MinHash cache layout; banded enables per-iteration Parquet column projection during LSH",
     )
     parser.add_argument("--text-field", default="text", help="Text field to use for duplicate identification")
     parser.add_argument(

--- a/nemo_curator/stages/deduplication/fuzzy/banding.py
+++ b/nemo_curator/stages/deduplication/fuzzy/banding.py
@@ -1,0 +1,76 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import cudf
+
+from nemo_curator.stages.deduplication.fuzzy.utils import CURATOR_LSH_BUCKET_FIELD
+
+CURATOR_MINHASH_BAND_FIELD_PREFIX = "_minhash_band_"
+
+
+def get_band_columns(
+    band_range: tuple[int, int],
+    band_field_prefix: str = CURATOR_MINHASH_BAND_FIELD_PREFIX,
+) -> list[str]:
+    """Return the top-level Parquet columns for a half-open band range."""
+    return [f"{band_field_prefix}{band_number}" for band_number in range(*band_range)]
+
+
+def minhash_to_band_columns(
+    minhashes: cudf.Series,
+    num_bands: int,
+    minhashes_per_band: int,
+    band_range: tuple[int, int] | None = None,
+    band_field_prefix: str = CURATOR_MINHASH_BAND_FIELD_PREFIX,
+) -> cudf.DataFrame:
+    """Hash MinHash signature slices into one top-level column per LSH band."""
+    if num_bands < 1:
+        msg = f"num_bands must be at least 1, got {num_bands}"
+        raise ValueError(msg)
+    if minhashes_per_band < 1:
+        msg = f"minhashes_per_band must be at least 1, got {minhashes_per_band}"
+        raise ValueError(msg)
+
+    band_range = band_range or (0, num_bands)
+    if band_range[0] < 0 or band_range[1] > num_bands or band_range[0] >= band_range[1]:
+        msg = f"Invalid band range: {band_range}, must be in range [0, {num_bands}]"
+        raise ValueError(msg)
+
+    band_df = cudf.DataFrame(index=minhashes.index)
+    for band_number in range(*band_range):
+        indices = list(
+            range(
+                band_number * minhashes_per_band,
+                (band_number + 1) * minhashes_per_band,
+            )
+        )
+        row_indices = cudf.Series([indices]).repeat(len(minhashes))
+        column = f"{band_field_prefix}{band_number}"
+        band_df[column] = f"b{band_number}_" + minhashes.list.take(row_indices).hash_values(method="md5")
+
+    return band_df
+
+
+def melt_band_columns(
+    band_df: cudf.DataFrame,
+    id_field: str,
+    band_columns: list[str],
+) -> cudf.DataFrame:
+    """Convert projected wide band columns into the rows consumed by the LSH shuffle."""
+    melted_df = band_df.melt(
+        id_vars=[id_field],
+        value_name=CURATOR_LSH_BUCKET_FIELD,
+        value_vars=band_columns,
+    )
+    return melted_df[[id_field, CURATOR_LSH_BUCKET_FIELD]]

--- a/nemo_curator/stages/deduplication/fuzzy/lsh/lsh.py
+++ b/nemo_curator/stages/deduplication/fuzzy/lsh/lsh.py
@@ -18,14 +18,22 @@ from collections.abc import Iterator
 from typing import TYPE_CHECKING, Any, Literal
 
 import cudf
+import pyarrow.parquet as pq
 from loguru import logger
 
+from nemo_curator.stages.deduplication.fuzzy.banding import (
+    CURATOR_MINHASH_BAND_FIELD_PREFIX,
+    get_band_columns,
+    melt_band_columns,
+    minhash_to_band_columns,
+)
 from nemo_curator.stages.deduplication.fuzzy.utils import CURATOR_DEFAULT_MINHASH_FIELD, CURATOR_LSH_BUCKET_FIELD
 from nemo_curator.stages.deduplication.id_generator import CURATOR_DEDUP_ID_STR
 from nemo_curator.stages.deduplication.shuffle_utils.rapidsmpf_shuffler import (
     BulkRapidsMPFShuffler,
     pylibcudf_to_cudf_dataframe,
 )
+from nemo_curator.utils.file_utils import get_fs
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
@@ -48,7 +56,12 @@ class LSHActor(BulkRapidsMPFShuffler):
     id_field
         Name of the ID field in input data.
     minhash_field
-        Name of the minhash field in input data.
+        Name of the minhash field in raw input data.
+    input_format
+        Whether input contains raw signatures, precomputed band columns, or should be
+        detected automatically from the Parquet schema.
+    band_field_prefix
+        Prefix used for precomputed band columns.
     output_path
         Path to write output files.
     rmm_pool_size
@@ -106,6 +119,8 @@ class LSHActor(BulkRapidsMPFShuffler):
         spill_memory_limit: int | Literal["auto"] | None = "auto",
         rmm_async: bool = True,
         *,
+        input_format: Literal["auto", "raw", "banded"] = "auto",
+        band_field_prefix: str = CURATOR_MINHASH_BAND_FIELD_PREFIX,
         enable_statistics: bool = False,
         read_kwargs: dict[str, Any] | None = None,
         write_kwargs: dict[str, Any] | None = None,
@@ -126,71 +141,100 @@ class LSHActor(BulkRapidsMPFShuffler):
         self.minhash_field = minhash_field
         self.read_kwargs = read_kwargs if read_kwargs is not None else {}
         self.write_kwargs = write_kwargs if write_kwargs is not None else {}
+        if input_format not in ("auto", "raw", "banded"):
+            msg = f"input_format must be 'auto', 'raw', or 'banded', got {input_format!r}"
+            raise ValueError(msg)
+        self.input_format = input_format
+        self.band_field_prefix = band_field_prefix
 
-    @staticmethod
-    def _generate_band_ranges(num_bands: int, minhashes_per_band: int) -> list[list[int]]:
-        """
-        Generates a list of indices for the minhash ranges given num_bands &
-        minhashes_per_band.
-        eg: num_bands=3, minhashes_per_band=2
-        [[0, 1], [2, 3], [4, 5]]
-        """
-        return [list(range(band * minhashes_per_band, (band + 1) * minhashes_per_band)) for band in range(num_bands)]
+    def _resolve_input_format(self, filepaths: list[str]) -> Literal["raw", "banded"]:
+        if self.input_format != "auto":
+            return self.input_format
 
-    def read_minhash(self, filepaths: list[str]) -> cudf.DataFrame:
-        """
-        Read minhash data from parquet files.
+        input_fs = get_fs(filepaths[0], self.read_kwargs.get("storage_options"))
+        schema = pq.read_schema(filepaths[0], filesystem=input_fs)
+        schema_columns = set(schema.names)
+        band_columns = get_band_columns(
+            (0, self.num_bands),
+            band_field_prefix=self.band_field_prefix,
+        )
+        has_raw_minhashes = self.minhash_field in schema_columns
+        has_all_bands = set(band_columns).issubset(schema_columns)
 
-        Parameters
-        ----------
-        filepaths
-            List of paths to minhash files.
+        if has_raw_minhashes and has_all_bands:
+            msg = (
+                "Could not infer the MinHash input format because both the raw "
+                f"{self.minhash_field!r} column and all band columns are present. "
+                "Set input_format explicitly."
+            )
+            raise ValueError(msg)
+        if has_raw_minhashes:
+            return "raw"
+        if has_all_bands:
+            return "banded"
 
-        Returns
-        -------
-            DataFrame containing minhash data from all input files.
-        """
+        msg = (
+            "Could not infer the MinHash input format. Expected either the raw "
+            f"{self.minhash_field!r} column or band columns {band_columns}."
+        )
+        raise ValueError(msg)
+
+    def read_minhash(
+        self,
+        filepaths: list[str],
+        band_range: tuple[int, int] | None = None,
+    ) -> cudf.DataFrame:
+        """Read only the raw signature or band columns needed by this iteration."""
         if self.read_kwargs.get("columns", None) is not None:
             err_msg = "Columns cannot be set in read_kwargs for LSHActor"
             raise ValueError(err_msg)
-        return cudf.read_parquet(filepaths, columns=[self.id_field, self.minhash_field], **self.read_kwargs)
 
-    def minhash_to_bands(self, minhash_df: cudf.DataFrame, band_range: tuple[int, int]) -> cudf.DataFrame:
-        """
-        Process a single minhash DataFrame to extract LSH band data.
+        band_range = band_range or (0, self.num_bands)
+        input_format = self._resolve_input_format(filepaths)
+        if input_format == "raw":
+            columns = [self.id_field, self.minhash_field]
+        else:
+            columns = [
+                self.id_field,
+                *get_band_columns(
+                    band_range,
+                    band_field_prefix=self.band_field_prefix,
+                ),
+            ]
+        return cudf.read_parquet(filepaths, columns=columns, **self.read_kwargs)
 
-        Parameters
-        ----------
-        minhash_df
-            DataFrame containing minhash data.
-        band_range
-            Tuple of (start_band, end_band) to process.
-
-        Returns
-        -------
-            DataFrame with document IDs and their corresponding bucket IDs.
-        """
+    def minhash_to_bands(
+        self,
+        minhash_df: cudf.DataFrame,
+        band_range: tuple[int, int],
+    ) -> cudf.DataFrame | None:
+        """Convert raw or pre-banded MinHash input into rows for the LSH shuffle."""
         if minhash_df is None or len(minhash_df) == 0:
             return None
 
-        # Get the band ranges for the specified band range
-        band_ranges = self._generate_band_ranges(num_bands=self.num_bands, minhashes_per_band=self.minhashes_per_band)[
-            band_range[0] : band_range[1]
-        ]
-
-        id_df = minhash_df[[self.id_field]]
-
-        for i, h in enumerate(band_ranges):
-            indices = cudf.Series([h]).repeat(len(id_df))
-            id_df[f"_bucket_{i}"] = f"b{i}_" + minhash_df[self.minhash_field].list.take(indices).hash_values(
-                method="md5"
+        band_columns = get_band_columns(
+            band_range,
+            band_field_prefix=self.band_field_prefix,
+        )
+        if self.minhash_field in minhash_df.columns:
+            computed_bands = minhash_to_band_columns(
+                minhash_df[self.minhash_field],
+                num_bands=self.num_bands,
+                minhashes_per_band=self.minhashes_per_band,
+                band_range=band_range,
+                band_field_prefix=self.band_field_prefix,
             )
+            band_df = minhash_df[[self.id_field]].copy()
+            for column in band_columns:
+                band_df[column] = computed_bands[column]
+        else:
+            band_df = minhash_df
 
-        value_vars = [f"_bucket_{i}" for i in range(len(band_ranges))]
-        melted_df = id_df.melt(id_vars=[self.id_field], value_name=CURATOR_LSH_BUCKET_FIELD, value_vars=value_vars)
-
-        # Keep only the columns we need
-        return melted_df[[self.id_field, CURATOR_LSH_BUCKET_FIELD]]
+        return melt_band_columns(
+            band_df,
+            id_field=self.id_field,
+            band_columns=band_columns,
+        )
 
     def read_and_insert(self, filepaths: list[str], band_range: tuple[int, int]) -> None:
         """
@@ -220,7 +264,7 @@ class LSHActor(BulkRapidsMPFShuffler):
             raise ValueError(msg)
 
         # Process files in batches
-        minhash_df = self.read_minhash(filepaths)
+        minhash_df = self.read_minhash(filepaths, band_range)
         # Skip processing if the batch is empty
         if minhash_df is None or len(minhash_df) == 0:
             logger.info("Skipping empty batch")

--- a/nemo_curator/stages/deduplication/fuzzy/lsh/stage.py
+++ b/nemo_curator/stages/deduplication/fuzzy/lsh/stage.py
@@ -18,6 +18,7 @@ from typing import Any, Literal
 
 from nemo_curator.backends.utils import RayStageSpecKeys
 from nemo_curator.stages.base import ProcessingStage
+from nemo_curator.stages.deduplication.fuzzy.banding import CURATOR_MINHASH_BAND_FIELD_PREFIX
 from nemo_curator.stages.deduplication.fuzzy.lsh.lsh import LSHActor
 from nemo_curator.stages.deduplication.fuzzy.utils import CURATOR_DEFAULT_MINHASH_FIELD
 from nemo_curator.stages.deduplication.id_generator import CURATOR_DEDUP_ID_STR
@@ -42,7 +43,12 @@ class LSHStage(ProcessingStage[FileGroupTask, FileGroupTask]):
     id_field
         Name of the ID field in input data.
     minhash_field
-        Name of the minhash field in input data.
+        Name of the minhash field in raw input data.
+    input_format
+        Whether input contains raw signatures, precomputed band columns, or should be
+        detected automatically from the Parquet schema.
+    band_field_prefix
+        Prefix used for precomputed band columns.
     output_path
         Base path to write output files.
     read_kwargs
@@ -92,9 +98,14 @@ class LSHStage(ProcessingStage[FileGroupTask, FileGroupTask]):
     bands_per_iteration: int = 5  # number of bands to process in each iteration
     total_nparts: int | None = None
     use_async_memory: bool = True
+    input_format: Literal["auto", "raw", "banded"] = "auto"
+    band_field_prefix: str = CURATOR_MINHASH_BAND_FIELD_PREFIX
 
     def __post_init__(self):
         super().__init__()
+        if self.input_format not in ("auto", "raw", "banded"):
+            msg = "input_format must be 'auto', 'raw', or 'banded'"
+            raise ValueError(msg)
 
         self.read_kwargs = self.read_kwargs if self.read_kwargs is not None else {}
         self.write_kwargs = self.write_kwargs if self.write_kwargs is not None else {}
@@ -102,6 +113,8 @@ class LSHStage(ProcessingStage[FileGroupTask, FileGroupTask]):
 
         self.actor_kwargs = {
             "num_bands": self.num_bands,
+            "input_format": self.input_format,
+            "band_field_prefix": self.band_field_prefix,
             "minhashes_per_band": self.minhashes_per_band,
             "id_field": self.id_field,
             "minhash_field": self.minhash_field,

--- a/nemo_curator/stages/deduplication/fuzzy/minhash.py
+++ b/nemo_curator/stages/deduplication/fuzzy/minhash.py
@@ -24,6 +24,11 @@ import rmm
 from loguru import logger
 
 from nemo_curator.stages.base import ProcessingStage, StageInputSpecs
+from nemo_curator.stages.deduplication.fuzzy.banding import (
+    CURATOR_MINHASH_BAND_FIELD_PREFIX,
+    get_band_columns,
+    minhash_to_band_columns,
+)
 from nemo_curator.stages.deduplication.fuzzy.utils import CURATOR_DEFAULT_MINHASH_FIELD
 from nemo_curator.stages.deduplication.id_generator import CURATOR_DEDUP_ID_STR, get_id_generator_actor
 from nemo_curator.stages.deduplication.io_utils import DeduplicationIO
@@ -217,6 +222,14 @@ class MinHashStage(ProcessingStage[FileGroupTask | DocumentBatch, FileGroupTask]
     normalize_text : bool, default=False
         Whether to normalize text before computing minhashes
         Current normalization is limited to lowercase and trim whitespace
+    output_format : Literal["raw", "banded"], default="raw"
+        Whether to write the raw list-valued MinHash signature or one top-level
+        column containing the final bucket hash for each LSH band.
+    num_bands : int | None, default=None
+        Number of LSH bands to generate when ``output_format="banded"``. The
+        number of hashes must be evenly divisible by this value.
+    band_field_prefix : str, default="_minhash_band_"
+        Prefix used for banded output columns.
     read_format : Literal["jsonl", "parquet"] | None, default=None
         Format of input files. Only applies to FileGroupTask inputs; ignored for DocumentBatch
         inputs (which are already in memory). May be None when only DocumentBatch inputs are used.
@@ -251,6 +264,9 @@ class MinHashStage(ProcessingStage[FileGroupTask | DocumentBatch, FileGroupTask]
         read_kwargs: dict[str, Any] | None = None,
         write_kwargs: dict[str, Any] | None = None,
         pool: bool = True,
+        output_format: Literal["raw", "banded"] = "raw",
+        num_bands: int | None = None,
+        band_field_prefix: str = CURATOR_MINHASH_BAND_FIELD_PREFIX,
     ):
         # Set ProcessingStage attributes
         self.name = self.__class__.__name__
@@ -260,6 +276,20 @@ class MinHashStage(ProcessingStage[FileGroupTask | DocumentBatch, FileGroupTask]
         self.minhash_field = minhash_field
         self.char_ngrams = char_ngrams
         self.num_hashes = num_hashes
+        if output_format not in ("raw", "banded"):
+            msg = f"output_format must be 'raw' or 'banded', got {output_format!r}"
+            raise ValueError(msg)
+        if output_format == "banded":
+            if num_bands is None or num_bands < 1:
+                msg = "num_bands must be at least 1 when output_format='banded'"
+                raise ValueError(msg)
+            if num_hashes % num_bands != 0:
+                msg = f"num_hashes ({num_hashes}) must be evenly divisible by num_bands ({num_bands})"
+                raise ValueError(msg)
+        self.output_format = output_format
+        self.num_bands = num_bands
+        self.minhashes_per_band = num_hashes // num_bands if output_format == "banded" else None
+        self.band_field_prefix = band_field_prefix
         self.seed = seed
         self.use_64bit_hash = use_64bit_hash
         self.normalize_text = normalize_text
@@ -353,8 +383,23 @@ class MinHashStage(ProcessingStage[FileGroupTask | DocumentBatch, FileGroupTask]
                 text_for_minhash = normalize_text(text_for_minhash)
 
         with self._time_metric("minhash_compute_time"):
-            result_df[self.minhash_field] = self.minhash_processor.compute_minhashes(text_for_minhash)
+            minhashes = self.minhash_processor.compute_minhashes(text_for_minhash)
 
+        if self.output_format == "raw":
+            result_df[self.minhash_field] = minhashes
+        else:
+            with self._time_metric("minhash_banding_time"):
+                band_df = minhash_to_band_columns(
+                    minhashes,
+                    num_bands=self.num_bands,
+                    minhashes_per_band=self.minhashes_per_band,
+                    band_field_prefix=self.band_field_prefix,
+                )
+                for column in band_df.columns:
+                    result_df[column] = band_df[column]
+
+            del band_df
+        del minhashes
         # Write output file
         with self._time_metric("minhash_write_time"):
             self.write_parquet(df=result_df, filepath=output_file, **self.write_kwargs)
@@ -367,7 +412,20 @@ class MinHashStage(ProcessingStage[FileGroupTask | DocumentBatch, FileGroupTask]
                 **task._metadata,
                 "minhash_field": self.minhash_field,
                 "num_hashes": self.num_hashes,
+                "minhash_output_format": self.output_format,
                 "storage_options": self.write_kwargs.get("storage_options"),
+                **(
+                    {
+                        "num_bands": self.num_bands,
+                        "minhashes_per_band": self.minhashes_per_band,
+                        "band_columns": get_band_columns(
+                            (0, self.num_bands),
+                            band_field_prefix=self.band_field_prefix,
+                        ),
+                    }
+                    if self.output_format == "banded"
+                    else {}
+                ),
             },
             _stage_perf=task._stage_perf,
         )

--- a/nemo_curator/stages/deduplication/fuzzy/workflow.py
+++ b/nemo_curator/stages/deduplication/fuzzy/workflow.py
@@ -86,6 +86,7 @@ class FuzzyDeduplicationWorkflow(WorkflowBase):
         lsh_spill_memory_limit: int | Literal["auto"] | None = "auto",
         env_vars: dict[str, Any] | None = None,
         use_async_memory: bool = True,
+        minhash_output_format: Literal["raw", "banded"] = "banded",
     ):
         """
         Configuration for MinHash based fuzzy duplicates detection.
@@ -136,6 +137,9 @@ class FuzzyDeduplicationWorkflow(WorkflowBase):
             Whether to use a 32bit or 64bit hash function for minhashing.
         normalize_text: bool
             Whether to normalize text before computing minhashes.
+        minhash_output_format: Literal["raw", "banded"]
+            Format used for the cached MinHash intermediate. Banded output allows
+            LSH iterations to read only the bands they process.
         bands_per_iteration: int
             Number of bands/buckets to shuffle concurrently.
             Larger values process larger batches by processing multiple bands
@@ -175,6 +179,7 @@ class FuzzyDeduplicationWorkflow(WorkflowBase):
         self.seed = seed
         self.char_ngrams = char_ngrams
         self.num_bands = num_bands
+        self.minhash_output_format = minhash_output_format
         self.minhashes_per_band = minhashes_per_band
         self.use_64_bit_hash = use_64_bit_hash
         self.normalize_text = normalize_text
@@ -201,6 +206,9 @@ class FuzzyDeduplicationWorkflow(WorkflowBase):
         if self.perform_removal:
             msg = "Removal is not implemented yet"
             raise NotImplementedError(msg)
+        if self.minhash_output_format not in ("raw", "banded"):
+            msg = "minhash_output_format must be 'raw' or 'banded'"
+            raise ValueError(msg)
         if self.bands_per_iteration < 1 or self.bands_per_iteration > self.num_bands:
             msg = "bands_per_iteration must be between [1, num_bands]"
             raise ValueError(msg)
@@ -225,6 +233,8 @@ class FuzzyDeduplicationWorkflow(WorkflowBase):
                 seed=self.seed,
                 use_64bit_hash=self.use_64_bit_hash,
                 normalize_text=self.normalize_text,
+                output_format=self.minhash_output_format,
+                num_bands=self.num_bands,
                 read_format=self.input_filetype,
                 read_kwargs=self.read_kwargs,
                 write_kwargs=self.cache_kwargs,
@@ -251,6 +261,7 @@ class FuzzyDeduplicationWorkflow(WorkflowBase):
                 LSHStage(
                     num_bands=self.num_bands,
                     minhashes_per_band=self.minhashes_per_band,
+                    input_format=self.minhash_output_format,
                     output_path=self.cache_path,
                     # Reading minhashes from cache_path
                     read_kwargs=self.cache_kwargs,

--- a/tests/stages/deduplication/fuzzy/test_banding.py
+++ b/tests/stages/deduplication/fuzzy/test_banding.py
@@ -1,0 +1,69 @@
+# modality: text
+
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from contextlib import suppress
+
+import pytest
+
+with suppress(ImportError):
+    import cudf
+
+    from nemo_curator.stages.deduplication.fuzzy.banding import (
+        get_band_columns,
+        melt_band_columns,
+        minhash_to_band_columns,
+    )
+
+
+@pytest.mark.gpu
+def test_selected_band_hashes_use_absolute_band_numbers() -> None:
+    minhashes = cudf.Series(
+        [
+            [1, 2, 3, 4, 5, 6],
+            [1, 2, 7, 8, 5, 6],
+        ]
+    )
+
+    all_bands = minhash_to_band_columns(minhashes, num_bands=3, minhashes_per_band=2)
+    selected_bands = minhash_to_band_columns(
+        minhashes,
+        num_bands=3,
+        minhashes_per_band=2,
+        band_range=(1, 3),
+    )
+
+    assert list(selected_bands.columns) == ["_minhash_band_1", "_minhash_band_2"]
+    assert selected_bands.to_pandas().equals(all_bands[list(selected_bands.columns)].to_pandas())
+    assert selected_bands["_minhash_band_1"].str.startswith("b1_").all()
+    assert selected_bands["_minhash_band_2"].str.startswith("b2_").all()
+
+
+@pytest.mark.gpu
+def test_melt_preserves_absolute_band_identity() -> None:
+    minhashes = cudf.Series([[1, 2, 3, 4]])
+    band_df = minhash_to_band_columns(minhashes, num_bands=2, minhashes_per_band=2)
+    band_df.insert(0, "document_id", [7])
+
+    result = melt_band_columns(
+        band_df,
+        id_field="document_id",
+        band_columns=get_band_columns((0, 2)),
+    )
+
+    assert list(result.columns) == ["document_id", "_bucket_id"]
+    assert result["document_id"].to_pandas().tolist() == [7, 7]
+    assert result["_bucket_id"].str.startswith("b0_").to_pandas().tolist() == [True, False]
+    assert result["_bucket_id"].str.startswith("b1_").to_pandas().tolist() == [False, True]

--- a/tests/stages/deduplication/fuzzy/test_fuzzy_workflow.py
+++ b/tests/stages/deduplication/fuzzy/test_fuzzy_workflow.py
@@ -304,7 +304,35 @@ class TestFuzzyDuplicates:
         assert lsh_stage.use_async_memory is False
         assert lsh_stage.actor_kwargs["rmm_async"] is False
 
+    @pytest.mark.parametrize("minhash_output_format", ["raw", "banded"])
+    def test_minhash_output_format_is_forwarded(
+        self,
+        tmp_path: Path,
+        minhash_output_format: str,
+    ) -> None:
+        workflow = FuzzyDeduplicationWorkflow(
+            input_path="/dummy",
+            cache_path=str(tmp_path / minhash_output_format / "cache"),
+            output_path=str(tmp_path / minhash_output_format / "output"),
+            minhash_output_format=minhash_output_format,
+        )
+
+        minhash_stage = workflow._create_minhash_pipeline(generate_input_filegroups=False).stages[0]
+        lsh_stage = workflow._create_lsh_pipeline().stages[1]
+
+        assert minhash_stage.output_format == minhash_output_format
+        assert minhash_stage.num_bands == workflow.num_bands
+        assert lsh_stage.input_format == minhash_output_format
+        assert lsh_stage.actor_kwargs["input_format"] == minhash_output_format
+
     def test_bad_inputs(self, tmp_path: Path) -> None:
+        with pytest.raises(ValueError, match="minhash_output_format must be"):
+            FuzzyDeduplicationWorkflow(
+                input_path="/dummy",
+                cache_path=str(tmp_path),
+                output_path=str(tmp_path),
+                minhash_output_format="invalid",
+            )
         with pytest.raises(ValueError, match="bands_per_iteration must be between"):
             # bands_per_iteration must be between 1 and num_bands
             FuzzyDeduplicationWorkflow(

--- a/tests/stages/deduplication/fuzzy/test_lsh_stage.py
+++ b/tests/stages/deduplication/fuzzy/test_lsh_stage.py
@@ -17,6 +17,7 @@
 import os
 from contextlib import suppress
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 
@@ -28,6 +29,8 @@ with suppress(ImportError):
 with suppress(ImportError):
     from nemo_curator.backends.ray_actor_pool import RayActorPoolExecutor
     from nemo_curator.pipeline import Pipeline
+    from nemo_curator.stages.deduplication.fuzzy.banding import minhash_to_band_columns
+    from nemo_curator.stages.deduplication.fuzzy.lsh.lsh import LSHActor
     from nemo_curator.stages.deduplication.fuzzy.lsh.stage import LSHStage
     from nemo_curator.stages.deduplication.id_generator import CURATOR_DEDUP_ID_STR
 
@@ -69,10 +72,12 @@ class TestLSHStage:
         )
 
     @pytest.mark.parametrize(
-        ("bands_per_iteration", "total_nparts"),
+        ("bands_per_iteration", "total_nparts", "minhash_layout"),
         [
-            (2, 4),
-            (3, None),
+            (2, 4, "raw"),
+            (3, None, "raw"),
+            (1, 4, "banded"),
+            (2, None, "banded"),
         ],
     )
     def test_lsh(
@@ -81,7 +86,22 @@ class TestLSHStage:
         tmp_path: Path,
         bands_per_iteration: int,
         total_nparts: int | None,
+        minhash_layout: str,
     ) -> None:
+        if minhash_layout == "banded":
+            raw_df = cudf.read_parquet(minhash_data.data)
+            band_df = raw_df[[CURATOR_DEDUP_ID_STR]].copy()
+            computed_bands = minhash_to_band_columns(
+                raw_df["_minhash_signature"],
+                num_bands=3,
+                minhashes_per_band=2,
+            )
+            for column in computed_bands.columns:
+                band_df[column] = computed_bands[column]
+            banded_file = os.path.join(tmp_path, "banded_minhash_data.parquet")
+            band_df.to_parquet(banded_file)
+            minhash_data.data = [banded_file]
+
         # Create LSHStage
         lsh_stage = LSHStage(
             output_path=str(tmp_path / "lsh_output"),
@@ -362,6 +382,41 @@ class TestLSHStage:
         expected_pairs = {(1, 2), (1, 3)}
         assert found_pairs == expected_pairs, f"Expected pairs {expected_pairs} not found in {found_pairs}"
 
+    def test_banded_read_projects_only_the_active_columns(
+        self,
+        minhash_data: FileGroupTask,
+        tmp_path: Path,
+    ) -> None:
+        raw_df = cudf.read_parquet(minhash_data.data)
+        band_df = raw_df[[CURATOR_DEDUP_ID_STR]].copy()
+        computed_bands = minhash_to_band_columns(
+            raw_df["_minhash_signature"],
+            num_bands=3,
+            minhashes_per_band=2,
+        )
+        for column in computed_bands.columns:
+            band_df[column] = computed_bands[column]
+        band_df["_unused"] = "not needed"
+        banded_file = os.path.join(tmp_path, "projected_banded_minhashes.parquet")
+        band_df.to_parquet(banded_file)
+
+        actor = object.__new__(LSHActor)
+        actor.num_bands = 3
+        actor.id_field = CURATOR_DEDUP_ID_STR
+        actor.minhash_field = "_minhash_signature"
+        actor.input_format = "banded"
+        actor.band_field_prefix = "_minhash_band_"
+        actor.read_kwargs = {}
+
+        with patch.object(cudf, "read_parquet", wraps=cudf.read_parquet) as read_parquet:
+            result = actor.read_minhash([banded_file], band_range=(1, 2))
+
+        read_parquet.assert_called_once_with(
+            [banded_file],
+            columns=[CURATOR_DEDUP_ID_STR, "_minhash_band_1"],
+        )
+        assert list(result.columns) == [CURATOR_DEDUP_ID_STR, "_minhash_band_1"]
+
     def test_actor_not_initialized(
         self,
         minhash_data: FileGroupTask,
@@ -426,4 +481,10 @@ class TestLSHStage:
                 num_bands=5,
                 minhashes_per_band=2,
                 bands_per_iteration=-1,  # Invalid: negative
+            )
+        with pytest.raises(ValueError, match="input_format must be"):
+            LSHStage(
+                num_bands=5,
+                minhashes_per_band=2,
+                input_format="invalid",
             )

--- a/tests/stages/deduplication/fuzzy/test_minhash_stage.py
+++ b/tests/stages/deduplication/fuzzy/test_minhash_stage.py
@@ -512,6 +512,55 @@ class TestMinHashStage:
             }
         )
 
+    @pytest.mark.usefixtures("shared_ray_client")
+    def test_banded_output(self, batch_dataframe: pd.DataFrame, tmp_path: Path) -> None:
+        task = DocumentBatch(dataset_name="banded", data=batch_dataframe, _metadata={})
+        stage = MinHashStage(
+            output_path=str(tmp_path / "banded"),
+            text_field="text",
+            char_ngrams=3,
+            num_hashes=6,
+            output_format="banded",
+            num_bands=3,
+            pool=False,
+        )
+
+        stage.setup()
+        output_task = stage.process(task)
+        stage.teardown()
+
+        result_df = cudf.read_parquet(output_task.data[0])
+        band_columns = [f"_minhash_band_{band_number}" for band_number in range(3)]
+        assert list(result_df.columns) == [CURATOR_DEDUP_ID_STR, *band_columns]
+        assert output_task._metadata["minhash_output_format"] == "banded"
+        assert output_task._metadata["num_bands"] == 3
+        assert output_task._metadata["minhashes_per_band"] == 2
+        assert output_task._metadata["band_columns"] == band_columns
+        assert stage._custom_metrics["minhash_banding_time"] > 0
+        for column in band_columns:
+            assert result_df[column].str.startswith(column.replace("_minhash_band_", "b") + "_").all()
+            assert result_df[column].iloc[3] == result_df[column].iloc[4]
+
+    @pytest.mark.parametrize(
+        ("kwargs", "error"),
+        [
+            ({"output_format": "invalid"}, "output_format must be"),
+            ({"output_format": "banded"}, "num_bands must be"),
+            (
+                {"output_format": "banded", "num_bands": 4, "num_hashes": 6},
+                "must be evenly divisible",
+            ),
+        ],
+    )
+    def test_banded_output_validation(
+        self,
+        tmp_path: Path,
+        kwargs: dict[str, object],
+        error: str,
+    ) -> None:
+        with pytest.raises(ValueError, match=error):
+            MinHashStage(output_path=str(tmp_path / "invalid_bands"), pool=False, **kwargs)
+
     def test_inputs_declares_type_specific_requirements(self, tmp_path: Path) -> None:
         """MinHash declares separate input specs for file and in-memory paths."""
         stage = MinHashStage(output_path=str(tmp_path / "inputs"), text_field="text", pool=False)


### PR DESCRIPTION
## Description

Fuzzy deduplication currently writes each document's raw MinHash signature to the cache. During LSH, every band iteration reads that complete signature column and then extracts only the bands needed for that iteration. When `bands_per_iteration` is small, the same raw MinHash data is read repeatedly—for example, 20 times when processing one of 20 bands per iteration—creating avoidable Parquet I/O.

This PR adds a banded MinHash cache layout so LSH can project only the columns needed by the current iteration.

### Changes

- Adds shared banding utilities used by both MinHash and LSH.
- Extends `MinHashStage` with two output layouts:
  - `banded`: hashes the raw signature into bands and writes each band as a separate top-level Parquet column.
  - `raw`: preserves the existing raw MinHash signature output for users who need those values.
- Extends LSH to consume either layout:
  - raw input follows the existing read-and-band path;
  - banded input reads only the ID column and the band columns required for the current iteration, then melts only those columns.
- Uses absolute band numbers in bucket IDs so IDs remain stable across multiple iterations.
- Exposes the layout through `FuzzyDeduplicationWorkflow` and the fuzzy deduplication benchmark.
- Keeps standalone `MinHashStage` backward-compatible by defaulting to raw output; the high-level fuzzy workflow defaults to banded output.
- Requires no adapter or executor changes.

## Usage

The optimized layout is the default for the high-level workflow:

```python
workflow = FuzzyDeduplicationWorkflow(
    input_path=input_path,
    cache_path=cache_path,
    output_path=output_path,
    bands_per_iteration=1,
    minhash_output_format="banded",
)
```

Users who need to preserve raw MinHash signatures can opt into the previous layout:

```python
workflow = FuzzyDeduplicationWorkflow(
    input_path=input_path,
    cache_path=cache_path,
    output_path=output_path,
    minhash_output_format="raw",
)
```

The fuzzy benchmark accepts the same choice through `--minhash-output-format {raw,banded}`.

## Benchmark results

[Benchmark run](http://rratzel-ws1:5050/run-viewer?dir=oci-hsg%3A%2Flustre%2Ffsw%2Fportfolios%2Fcoreai%2Fprojects%2Fcoreai_dlalgo_llm%2Fcurator_ci%2Fresults%2Fmain-mirror&run=adhoc-adattagupta-banded-minhash-2026_09_11__15_08_31_UTC) on the RPV2 2023-14 English dataset using 4 GB200 GPUs and 64 CPUs:

| Bands per iteration | Raw LSH time | Banded LSH time | LSH reduction | Raw workflow time | Banded workflow time | Workflow reduction |
| ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| 1 | 3031.2 s | 436.6 s | 85.6% | 4065.1 s | 1343.7 s | 67.0% |
| 5 | 678.3 s | 193.5 s | 71.5% | 1600.2 s | 1085.1 s | 32.2% |
| 20 | 211.0 s | 140.1 s | 33.6% | 1157.3 s | 1033.0 s | 10.7% |

All six runs completed successfully and produced the same 204,527,662 duplicate count. As expected, the benefit grows as `bands_per_iteration` decreases because column projection avoids rereading unused bands on each LSH pass.

## Validation

- Unit coverage for shared banding and absolute band numbering.
- MinHash coverage for raw/banded schemas, metadata, and validation.
- LSH coverage for both layouts and per-iteration Parquet column projection.
- Workflow propagation and end-to-end banded workflow coverage.
- Ruff, formatting, and pre-commit checks.

## Checklist

- [ ] I am familiar with the [Contributing Guide](https://github.com/NVIDIA-NeMo/Curator/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
